### PR TITLE
Add review file path to initial summary display

### DIFF
--- a/commands/review-code.md
+++ b/commands/review-code.md
@@ -151,6 +151,8 @@ Changes:
 - Files: $files_changed
 - Added: +$lines_added lines
 - Removed: -$lines_removed lines
+
+Review will be saved to: $review_file
 ```
 
 **For PR mode:**
@@ -171,6 +173,8 @@ Changes:
 - Files: $files_changed
 - Added: +$lines_added lines
 - Removed: -$lines_removed lines
+
+Review will be saved to: $review_file
 ```
 
 **For commit mode:**
@@ -190,6 +194,8 @@ Changes:
 - Files: $files_changed
 - Added: +$lines_added lines
 - Removed: -$lines_removed lines
+
+Review will be saved to: $review_file
 ```
 
 **For range mode:**
@@ -210,6 +216,8 @@ Changes:
 - Files: $files_changed
 - Added: +$lines_added lines
 - Removed: -$lines_removed lines
+
+Review will be saved to: $review_file
 ```
 
 **For local mode:**
@@ -230,6 +238,8 @@ Changes:
 - Files: $files_changed
 - Added: +$lines_added lines
 - Removed: -$lines_removed lines
+
+Review will be saved to: $review_file
 ```
 
 **Ask user to confirm:**


### PR DESCRIPTION
Display where the review notes will be saved in the initial review summary for all modes (branch, PR, commit, range, and local). This gives users visibility into the output location before confirming the review operation.