### PR TITLE
Capture all PR comment types with pagination support

### DIFF
--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -128,3 +128,97 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"|42" ]]
 }
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "pr-context.sh: validate_repo_spec accepts valid owner/repo" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec 'owner/repo'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: validate_repo_spec accepts owner with dots and dashes" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec 'my-org.name/my_repo-name'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: validate_repo_spec rejects empty string" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec ''"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid repo specification"* ]]
+}
+
+@test "pr-context.sh: validate_repo_spec rejects missing repo" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec 'owner/'"
+    [ "$status" -eq 1 ]
+}
+
+@test "pr-context.sh: validate_repo_spec rejects path traversal attempt" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec '../etc/passwd'"
+    [ "$status" -eq 1 ]
+}
+
+@test "pr-context.sh: validate_repo_spec rejects special characters" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_repo_spec 'owner/repo;rm -rf'"
+    [ "$status" -eq 1 ]
+}
+
+@test "pr-context.sh: validate_pr_number accepts numeric PR" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number '123'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: validate_pr_number accepts large PR number" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number '999999'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: validate_pr_number rejects empty string" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number ''"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid PR number"* ]]
+}
+
+@test "pr-context.sh: validate_pr_number rejects non-numeric" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number 'abc'"
+    [ "$status" -eq 1 ]
+}
+
+@test "pr-context.sh: validate_pr_number rejects mixed alphanumeric" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number '123abc'"
+    [ "$status" -eq 1 ]
+}
+
+@test "pr-context.sh: validate_pr_number rejects path traversal attempt" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && validate_pr_number '123/../456'"
+    [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# Fetch function input validation tests
+# =============================================================================
+
+@test "pr-context.sh: fetch_conversation_comments validates pr_number" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && fetch_conversation_comments 'invalid' 'owner/repo'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid PR number"* ]]
+}
+
+@test "pr-context.sh: fetch_conversation_comments validates repo_spec" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && fetch_conversation_comments '123' 'invalid'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid repo specification"* ]]
+}
+
+@test "pr-context.sh: fetch_inline_comments validates pr_number" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && fetch_inline_comments 'invalid' 'owner/repo'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid PR number"* ]]
+}
+
+@test "pr-context.sh: fetch_inline_comments validates repo_spec" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && fetch_inline_comments '123' 'invalid'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid repo specification"* ]]
+}

--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -80,8 +80,18 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "pr-context.sh: fetch_pr_comments uses array for command" {
-    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_pr_comments | grep -q 'gh_cmd=('"
+@test "pr-context.sh: fetch_reviews uses array for command" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_reviews | grep -q 'gh_cmd=('"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: fetch_conversation_comments uses paginated API" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_conversation_comments | grep -q 'gh api --paginate'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: fetch_inline_comments uses paginated API" {
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_inline_comments | grep -q 'gh api --paginate'"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -90,8 +90,20 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "pr-context.sh: fetch_conversation_comments uses jq slurp for pagination" {
+    # jq -s is required to combine multiple pages into a single array
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_conversation_comments | grep -q 'jq -s'"
+    [ "$status" -eq 0 ]
+}
+
 @test "pr-context.sh: fetch_inline_comments uses paginated API" {
     run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_inline_comments | grep -q 'gh api --paginate'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: fetch_inline_comments uses jq slurp for pagination" {
+    # jq -s is required to combine multiple pages into a single array
+    run bash -c "source '$PROJECT_ROOT/lib/pr-context.sh' && declare -f fetch_inline_comments | grep -q 'jq -s'"
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
Replace the single `fetch_pr_comments()` function with three specialized fetchers that capture all comment types:

- `fetch_conversation_comments()`: PR discussion thread (paginated)
- `fetch_inline_comments()`: Line-level code review comments (paginated)
- `fetch_reviews()`: Review summaries with state (APPROVED, etc.)

The comments field now returns structured JSON with conversation, reviews, and inline arrays instead of raw text. This enables review agents to avoid duplicate comments and understand reviewer concerns.