### PR TITLE
Add suggested comments section for reviewing others' PRs

### DIFF
--- a/commands/review-code.md
+++ b/commands/review-code.md
@@ -609,7 +609,7 @@ If this is a PR review and the reviewer is NOT the PR author, generate suggested
 Extract from session data (using the `$review_data` variable):
 
 ```bash
-is_own_pr=$(echo "$review_data" | jq -r '.is_own_pr // true')
+is_own_pr=$(echo "$review_data" | jq -r '.is_own_pr // false')
 inline_comments=$(echo "$review_data" | jq '.pr.comments.inline // []')
 ```
 

--- a/commands/review-code.md
+++ b/commands/review-code.md
@@ -600,6 +600,107 @@ Review complete!
 You can open it directly: file://$review_file
 ```
 
+### Generate Suggested Comments (PR Mode Only)
+
+If this is a PR review and the reviewer is NOT the PR author, generate suggested inline comments for the review file. This helps the reviewer quickly identify what comments to post on the PR.
+
+**Check if suggested comments should be generated:**
+
+Extract from session data (using the `$review_data` variable):
+
+```bash
+is_own_pr=$(echo "$review_data" | jq -r '.is_own_pr // true')
+inline_comments=$(echo "$review_data" | jq '.pr.comments.inline // []')
+```
+
+**If `is_own_pr` is "false":**
+
+When combining agent findings into the review document, add a "Suggested Comments" section with the following:
+
+1. **Extract findings with locations**: From each agent's output, identify findings that have a specific file path and line number.
+
+2. **Check against existing comments**: For each finding, check if there are existing inline comments (from `$inline_comments`) that:
+   - Are on the same file
+   - Are within 5 lines of the finding
+   - Address the same issue (use your judgment on semantic similarity)
+
+3. **Categorize findings**:
+   - **New comment**: No existing comment addresses this issue
+   - **Build upon existing**: Existing comment is related but incomplete
+   - **Already covered**: Existing comment fully addresses the finding
+
+4. **Format the section** following this structure:
+
+```markdown
+---
+
+## Suggested Comments
+
+These suggestions are for posting as inline PR review comments.
+
+### New Comments
+
+For each finding that needs a new comment:
+
+#### `<file_path>:<line_number>`
+
+```text
+<suggested comment text - clear, constructive, and actionable>
+```
+
+*From: <Agent Name> (<confidence>% confidence)*
+
+---
+
+### Build Upon Existing
+
+For findings where there's a related but incomplete existing comment:
+
+#### `<file_path>:<line_number>`
+
+**Existing comment by @<author>:**
+> <quote the existing comment>
+
+**Add to discussion:**
+
+```text
+<suggested addition that builds on the existing comment>
+```
+
+*From: <Agent Name> (<confidence>% confidence)*
+
+---
+
+### Already Covered
+
+List findings where existing comments are sufficient:
+
+- `<file_path>:<line_number>` - @<author>'s comment adequately addresses <brief description>
+
+---
+
+### Summary
+
+| Status | Count |
+|--------|-------|
+| New comments | X |
+| Build upon existing | Y |
+| Already covered | Z |
+```
+
+5. **Append to review file**: Add the "Suggested Comments" section after the main review content.
+
+6. **Display summary to user**: After saving, show a brief summary:
+
+```
+Suggested Comments:
+- X new comments to consider posting
+- Y comments that build on existing discussion
+- Z findings already covered by existing comments
+
+See the review file for copy/paste ready comments.
+```
+
 ### Cleanup Session
 
 After the review is complete, cleanup the session (replace `<SESSION_ID>` with the actual session ID):

--- a/lib/review-orchestrator.sh
+++ b/lib/review-orchestrator.sh
@@ -298,16 +298,17 @@ build_review_data() {
     fi
 
     # Detect if reviewing own PR (for suggested comments feature)
+    # Default to "false" (show suggested comments) - only suppress when we can
+    # confirm the reviewer is the PR author. This "fail open" approach ensures
+    # API failures don't hide the feature.
     local reviewer_username=""
-    local is_own_pr="true"
+    local is_own_pr="false"
     if [[ -n "${pr_context}" ]]; then
         local pr_author
         pr_author=$(echo "${pr_context}" | jq -r '.author // ""')
         reviewer_username=$(gh api user --jq '.login' 2> /dev/null || echo "")
-        if [[ -n "${reviewer_username}" && -n "${pr_author}" ]]; then
-            if [[ "${reviewer_username}" != "${pr_author}" ]]; then
-                is_own_pr="false"
-            fi
+        if [[ -n "${reviewer_username}" && -n "${pr_author}" && "${reviewer_username}" == "${pr_author}" ]]; then
+            is_own_pr="true"
         fi
     fi
 

--- a/lib/review-orchestrator.sh
+++ b/lib/review-orchestrator.sh
@@ -297,6 +297,20 @@ build_review_data() {
         pr_json="null"
     fi
 
+    # Detect if reviewing own PR (for suggested comments feature)
+    local reviewer_username=""
+    local is_own_pr="true"
+    if [[ -n "${pr_context}" ]]; then
+        local pr_author
+        pr_author=$(echo "${pr_context}" | jq -r '.author // ""')
+        reviewer_username=$(gh api user --jq '.login' 2> /dev/null || echo "")
+        if [[ -n "${reviewer_username}" && -n "${pr_author}" ]]; then
+            if [[ "${reviewer_username}" != "${pr_author}" ]]; then
+                is_own_pr="false"
+            fi
+        fi
+    fi
+
     local -a jq_args=(
         -n
         --arg mode "${mode}"
@@ -309,6 +323,8 @@ build_review_data() {
         --argjson summary "${summary}"
         --arg display "${display_summary}"
         --argjson pr "${pr_json}"
+        --arg reviewer_username "${reviewer_username}"
+        --arg is_own_pr "${is_own_pr}"
     )
 
     # Add mode-specific arguments
@@ -333,7 +349,7 @@ build_review_data() {
             next_step: "gather_architectural_context"
         }
         + (if $force_mode == "true" then {force: true} else {} end)
-        + (if $pr != null then {pr: $pr} else {} end)
+        + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"


### PR DESCRIPTION
When reviewing a PR authored by someone else, the review file now includes a "Suggested Comments" section with copy/paste ready inline comments. The feature:

- Detects if the reviewer is the PR author via gh API
- Checks findings against existing PR comments for deduplication
- Categorizes findings as: new comment, build upon existing, or already covered
- Formats suggestions with file:line for easy posting

This helps reviewers quickly identify what feedback to post without duplicating existing discussion.