### PR TITLE
feat: Add --draft flag to create pending GitHub reviews

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -31,6 +31,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 
 - `--force` or `-f` - Skip the confirmation prompt and proceed directly with review
 - `--draft` or `-d` - Create a pending GitHub review with inline comments (PR mode only)
+- `--self` - Allow creating draft review on your own PR (for testing)
 
 **Optional File Pattern:**
 
@@ -80,6 +81,7 @@ Examples:
 - `/review-code 123 --draft` - Review PR #123 and create draft review
 - `/review-code 123 --draft --force` - Review PR without confirmation and create draft
 - `/review-code 123 -d -f` - Short form, review PR #123, skip confirmation, create draft
+- `/review-code 123 --draft --self` - Create draft review on your own PR (for testing)
 
 ---
 
@@ -709,13 +711,14 @@ If `--draft` was specified and this is a PR review (not own PR), create a pendin
 ```bash
 draft_mode=$(jq -r '.draft // false' "$SESSION_FILE")
 is_own_pr=$(jq -r '.is_own_pr // false' "$SESSION_FILE")
+self_mode=$(jq -r '.self // false' "$SESSION_FILE")
 mode=$(jq -r '.mode' "$SESSION_FILE")
 ```
 
 **Only proceed if ALL conditions are true:**
 - `draft_mode` is "true"
 - `mode` is "pr"
-- `is_own_pr` is "false"
+- `is_own_pr` is "false" OR `self_mode` is "true"
 
 If any condition fails, skip draft review creation.
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -94,11 +94,9 @@ Examples:
 Initialize the review session by running the orchestrator and caching the result:
 
 ```bash
-bash -c '
-SESSION_ID=$(~/.claude/skills/review-code/scripts/review-status-handler.sh init "'"$ARGUMENTS"'")
+SESSION_ID=$(~/.claude/skills/review-code/scripts/review-status-handler.sh init $ARGUMENTS)
 STATUS=$(~/.claude/skills/review-code/scripts/review-status-handler.sh get-status "$SESSION_ID")
 echo "Session: $SESSION_ID, Status: $STATUS"
-'
 ```
 
 The `--force` and `-f` flags are handled automatically by the orchestrator. When present, the session data will include `"force": true`.

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -599,6 +599,8 @@ Review complete!
 You can open it directly: file://$review_file
 ```
 
+**CRITICAL: Do NOT post the full review to GitHub.** The detailed review is saved to the markdown file only. If `--draft` mode is enabled, a separate draft review with inline comments will be created in the next step - but that draft should contain only brief inline comments, NOT the full review summary.
+
 ### Generate Suggested Comments (PR Mode Only)
 
 If this is a PR review and the reviewer is NOT the PR author, generate suggested inline comments for the review file. This helps the reviewer quickly identify what comments to post on the PR.
@@ -704,6 +706,13 @@ See the review file for copy/paste ready comments.
 
 If `--draft` was specified and this is a PR review (not own PR), create a pending GitHub review with inline comments.
 
+**CRITICAL RULES for draft reviews:**
+- The draft review contains ONLY inline comments at specific file:line locations
+- The review summary should be a brief 1-2 sentence overview, NOT the full review
+- The full detailed review stays in the markdown file only
+- NEVER use `gh pr review` directly - always use `create-draft-review.sh`
+- NEVER post the full review summary to GitHub
+
 **Check if draft mode is enabled:**
 
 ```bash
@@ -761,7 +770,7 @@ echo "$mapping_input" | ~/.claude/skills/review-code/scripts/diff-position-mappe
   "repo": "<repo from session>",
   "pr_number": <number from session>,
   "reviewer_username": "<reviewer from session>",
-  "summary": "<overall review summary>",
+  "summary": "<BRIEF 1-2 sentence summary, e.g. 'Code review with 3 suggestions. See inline comments.'>",
   "comments": [
     {"path": "file.ts", "position": 23, "body": "Clean comment text"}
   ],
@@ -769,6 +778,9 @@ echo "$mapping_input" | ~/.claude/skills/review-code/scripts/diff-position-mappe
     {"description": "General finding that couldn't be mapped to diff"}
   ]
 }
+```
+
+**IMPORTANT**: The `summary` field should be a brief overview (1-2 sentences), NOT the full review. Example: "Code review complete with 3 inline suggestions for improved error handling." The detailed findings are in the markdown file.
 ```
 
 7. **Create the pending review**:
@@ -808,6 +820,13 @@ If failed, show the error and suggest using the review file manually.
 - **Own PR**: "Cannot create draft review on your own pull request"
 - **No mappable comments**: Create review with summary only, warn user
 - **API failure**: Display error, suggest using review file manually
+
+**What NOT to do:**
+- ❌ Do NOT use `gh pr review` or `gh api` directly to create reviews
+- ❌ Do NOT post the full review summary as the review body
+- ❌ Do NOT skip the `create-draft-review.sh` script
+- ✅ DO save detailed review to markdown file
+- ✅ DO use `create-draft-review.sh` with brief summary + inline comments only
 
 ### Cleanup Session
 

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -1,0 +1,399 @@
+#!/usr/bin/env bash
+# create-draft-review.sh - Create or amend a pending GitHub PR review with inline comments
+#
+# Creates a pending (draft) review on GitHub with inline comments. If a pending
+# review already exists from the same user, it performs a smart merge:
+# - Compares existing comments with new suggestions semantically
+# - Keeps comments that still apply (using new wording)
+# - Adds new comments not previously covered
+# - Removes outdated comments
+#
+# Usage:
+#   echo '<json_input>' | create-draft-review.sh
+#
+# Input JSON:
+#   {
+#     "owner": "org",
+#     "repo": "repo",
+#     "pr_number": 123,
+#     "reviewer_username": "haacked",
+#     "summary": "Overall review summary...",
+#     "comments": [
+#       {"path": "src/auth.ts", "position": 23, "body": "Consider..."},
+#       {"path": "src/utils.ts", "position": 15, "body": "This could..."}
+#     ],
+#     "unmapped_comments": [
+#       {"description": "Test coverage could be improved for X, Y, Z"}
+#     ]
+#   }
+#
+# Output JSON:
+#   {
+#     "success": true,
+#     "review_id": 12345,
+#     "review_url": "https://github.com/org/repo/pull/123#pullrequestreview-12345",
+#     "inline_count": 5,
+#     "summary_count": 2,
+#     "amended": true,
+#     "kept_comments": 3,
+#     "new_comments": 2,
+#     "removed_comments": 1
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+
+# Calculate word-based similarity between two strings (0-100)
+# Uses Jaccard similarity on word sets
+# Args: $1 = text1, $2 = text2
+# Output: Similarity percentage (0-100)
+calculate_similarity() {
+    local text1="$1"
+    local text2="$2"
+
+    # Normalize: lowercase, remove punctuation, split to words
+    local words1 words2
+    words1=$(echo "${text1}" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | sort -u | grep -v '^$' || true)
+    words2=$(echo "${text2}" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '\n' | sort -u | grep -v '^$' || true)
+
+    # Handle empty cases
+    if [[ -z "${words1}" ]] && [[ -z "${words2}" ]]; then
+        echo "100"
+        return
+    fi
+    if [[ -z "${words1}" ]] || [[ -z "${words2}" ]]; then
+        echo "0"
+        return
+    fi
+
+    # Count common words and total unique words
+    local common total_unique
+    common=$(comm -12 <(echo "${words1}") <(echo "${words2}") | wc -l | tr -d ' ')
+    total_unique=$(cat <(echo "${words1}") <(echo "${words2}") | sort -u | wc -l | tr -d ' ')
+
+    # Jaccard similarity: intersection / union
+    if [[ "${total_unique}" -eq 0 ]]; then
+        echo "0"
+    else
+        echo $(( (common * 100) / total_unique ))
+    fi
+}
+
+# Check if two comments match semantically
+# Args: $1 = existing comment JSON, $2 = new comment JSON
+# Output: "true" if match, "false" otherwise
+comments_match() {
+    local existing="$1"
+    local new="$2"
+
+    # Extract fields
+    local existing_path existing_line existing_body
+    local new_path new_position new_body
+
+    existing_path=$(echo "${existing}" | jq -r '.path')
+    existing_line=$(echo "${existing}" | jq -r '.line // .position // 0')
+    existing_body=$(echo "${existing}" | jq -r '.body')
+
+    new_path=$(echo "${new}" | jq -r '.path')
+    new_position=$(echo "${new}" | jq -r '.position // 0')
+    new_body=$(echo "${new}" | jq -r '.body')
+
+    # Must be same file
+    if [[ "${existing_path}" != "${new_path}" ]]; then
+        echo "false"
+        return
+    fi
+
+    # Line must be within ±5 lines
+    local line_diff=$(( existing_line - new_position ))
+    if [[ ${line_diff} -lt 0 ]]; then
+        line_diff=$(( -line_diff ))
+    fi
+    if [[ ${line_diff} -gt 5 ]]; then
+        echo "false"
+        return
+    fi
+
+    # Content similarity must be > 60%
+    local similarity
+    similarity=$(calculate_similarity "${existing_body}" "${new_body}")
+    if [[ ${similarity} -ge 60 ]]; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Fetch existing pending review and its comments
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = reviewer_username
+# Output: JSON with review_id and comments, or null if no pending review
+get_existing_pending_review() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local reviewer="$4"
+
+    # Get all reviews for this PR
+    local reviews
+    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
+
+    # Find pending review from this user
+    local pending_review
+    pending_review=$(echo "${reviews}" | jq -r --arg user "${reviewer}" \
+        '[.[] | select(.state == "PENDING" and .user.login == $user)] | first // null')
+
+    if [[ "${pending_review}" == "null" ]]; then
+        echo "null"
+        return
+    fi
+
+    local review_id
+    review_id=$(echo "${pending_review}" | jq -r '.id')
+
+    # Fetch comments for this pending review
+    local comments
+    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
+
+    # Return review info with comments
+    jq -n \
+        --argjson review "${pending_review}" \
+        --argjson comments "${comments}" \
+        '{
+            review_id: $review.id,
+            body: $review.body,
+            comments: [$comments[] | {
+                id: .id,
+                path: .path,
+                line: (.line // .original_line // .position),
+                position: .position,
+                body: .body
+            }]
+        }'
+}
+
+# Delete a pending review
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = review_id
+delete_pending_review() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local review_id="$4"
+
+    gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
+        warning "Failed to delete existing pending review ${review_id}"
+        return 1
+    }
+}
+
+# Create a new pending review
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = body, $5 = comments_json
+# Output: JSON with review result
+create_pending_review() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local body="$4"
+    local comments_json="$5"
+
+    local result
+    if [[ "${comments_json}" == "[]" ]]; then
+        # No inline comments, just create review with body
+        result=$(gh api --method POST "repos/${owner}/${repo}/pulls/${pr_number}/reviews" \
+            -f body="${body}" 2>&1) || {
+            echo "${result}" >&2
+            return 1
+        }
+    else
+        # Create review with inline comments
+        # Build the request body as JSON and use stdin
+        local request_body
+        request_body=$(jq -n \
+            --arg body "${body}" \
+            --argjson comments "${comments_json}" \
+            '{body: $body, comments: $comments}')
+
+        result=$(echo "${request_body}" | gh api --method POST "repos/${owner}/${repo}/pulls/${pr_number}/reviews" \
+            --input - 2>&1) || {
+            echo "${result}" >&2
+            return 1
+        }
+    fi
+
+    echo "${result}"
+}
+
+main() {
+    # Read input JSON from stdin
+    local input
+    input=$(cat)
+
+    # Validate input
+    if ! echo "${input}" | jq empty 2>/dev/null; then
+        error "Invalid JSON input"
+        exit 1
+    fi
+
+    # Extract fields
+    local owner repo pr_number reviewer summary comments unmapped_comments
+    owner=$(echo "${input}" | jq -r '.owner')
+    repo=$(echo "${input}" | jq -r '.repo')
+    pr_number=$(echo "${input}" | jq -r '.pr_number')
+    reviewer=$(echo "${input}" | jq -r '.reviewer_username')
+    summary=$(echo "${input}" | jq -r '.summary // ""')
+    comments=$(echo "${input}" | jq -c '.comments // []')
+    unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
+
+    # Validate required fields
+    if [[ -z "${owner}" ]] || [[ "${owner}" == "null" ]]; then
+        jq -n '{success: false, error: "Missing owner"}'
+        exit 1
+    fi
+    if [[ -z "${repo}" ]] || [[ "${repo}" == "null" ]]; then
+        jq -n '{success: false, error: "Missing repo"}'
+        exit 1
+    fi
+    if [[ -z "${pr_number}" ]] || [[ "${pr_number}" == "null" ]]; then
+        jq -n '{success: false, error: "Missing pr_number"}'
+        exit 1
+    fi
+    if [[ -z "${reviewer}" ]] || [[ "${reviewer}" == "null" ]]; then
+        jq -n '{success: false, error: "Missing reviewer_username"}'
+        exit 1
+    fi
+
+    # Check for existing pending review
+    local existing_review
+    existing_review=$(get_existing_pending_review "${owner}" "${repo}" "${pr_number}" "${reviewer}")
+
+    local amended="false"
+    local kept_count=0
+    local new_count=0
+    local removed_count=0
+    local merged_comments="${comments}"
+
+    if [[ "${existing_review}" != "null" ]]; then
+        # Smart merge with existing review
+        amended="true"
+        local existing_comments
+        existing_comments=$(echo "${existing_review}" | jq -c '.comments // []')
+        local existing_review_id
+        existing_review_id=$(echo "${existing_review}" | jq -r '.review_id')
+
+        # Compare and categorize
+        local new_comments_arr="[]"
+        local kept_comments_arr="[]"
+
+        # For each new comment, check if it matches an existing one
+        while IFS= read -r new_comment; do
+            local found_match="false"
+            while IFS= read -r existing_comment; do
+                if [[ $(comments_match "${existing_comment}" "${new_comment}") == "true" ]]; then
+                    found_match="true"
+                    # Use new comment (fresher wording)
+                    kept_comments_arr=$(echo "${kept_comments_arr}" | jq --argjson c "${new_comment}" '. + [$c]')
+                    break
+                fi
+            done < <(echo "${existing_comments}" | jq -c '.[]')
+
+            if [[ "${found_match}" == "false" ]]; then
+                new_comments_arr=$(echo "${new_comments_arr}" | jq --argjson c "${new_comment}" '. + [$c]')
+            fi
+        done < <(echo "${comments}" | jq -c '.[]')
+
+        kept_count=$(echo "${kept_comments_arr}" | jq 'length')
+        new_count=$(echo "${new_comments_arr}" | jq 'length')
+
+        # Count removed (existing comments with no match in new)
+        local existing_count
+        existing_count=$(echo "${existing_comments}" | jq 'length')
+        removed_count=$(( existing_count - kept_count ))
+        if [[ ${removed_count} -lt 0 ]]; then
+            removed_count=0
+        fi
+
+        # Merge: kept + new
+        merged_comments=$(echo "${kept_comments_arr}" | jq --argjson new "${new_comments_arr}" '. + $new')
+
+        # Delete existing pending review
+        if ! delete_pending_review "${owner}" "${repo}" "${pr_number}" "${existing_review_id}"; then
+            warning "Proceeding without deleting existing review…"
+        fi
+    else
+        # No existing review, all comments are new
+        new_count=$(echo "${comments}" | jq 'length')
+    fi
+
+    # Build review body
+    local review_body="${summary}"
+
+    # Add unmapped comments to the body
+    local unmapped_count
+    unmapped_count=$(echo "${unmapped_comments}" | jq 'length')
+    if [[ ${unmapped_count} -gt 0 ]]; then
+        review_body="${review_body}
+
+**Additional Notes:**
+"
+        while IFS= read -r unmapped; do
+            local desc
+            desc=$(echo "${unmapped}" | jq -r '.description // .body // .')
+            review_body="${review_body}
+- ${desc}"
+        done < <(echo "${unmapped_comments}" | jq -c '.[]')
+    fi
+
+    # Add note about removed comments if any
+    if [[ ${removed_count} -gt 0 ]]; then
+        review_body="${review_body}
+
+*Note: ${removed_count} previous draft comment(s) were removed as they no longer apply.*"
+    fi
+
+    # Create the pending review
+    local create_result
+    create_result=$(create_pending_review "${owner}" "${repo}" "${pr_number}" "${review_body}" "${merged_comments}") || {
+        jq -n \
+            --arg error "Failed to create review: ${create_result}" \
+            '{success: false, error: $error}'
+        exit 1
+    }
+
+    # Extract review info from result
+    local review_id review_url
+    review_id=$(echo "${create_result}" | jq -r '.id')
+    review_url="https://github.com/${owner}/${repo}/pull/${pr_number}#pullrequestreview-${review_id}"
+
+    local inline_count
+    inline_count=$(echo "${merged_comments}" | jq 'length')
+
+    # Return success result
+    jq -n \
+        --argjson success true \
+        --argjson review_id "${review_id}" \
+        --arg review_url "${review_url}" \
+        --argjson inline_count "${inline_count}" \
+        --argjson summary_count "${unmapped_count}" \
+        --argjson amended "$(echo "${amended}" | jq -R 'if . == "true" then true else false end')" \
+        --argjson kept_comments "${kept_count}" \
+        --argjson new_comments "${new_count}" \
+        --argjson removed_comments "${removed_count}" \
+        '{
+            success: $success,
+            review_id: $review_id,
+            review_url: $review_url,
+            inline_count: $inline_count,
+            summary_count: $summary_count,
+            amended: $amended,
+            kept_comments: $kept_comments,
+            new_comments: $new_comments,
+            removed_comments: $removed_comments
+        }'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -245,7 +245,7 @@ main() {
         --arg review_url "${review_url}" \
         --argjson inline_count "${inline_count}" \
         --argjson summary_count "${unmapped_count}" \
-        --argjson replaced_existing "$(echo "${replaced_existing}" | jq -R 'if . == "true" then true else false end')" \
+        --argjson replaced_existing "${replaced_existing}" \
         '{
             success: $success,
             review_id: $review_id,

--- a/skills/review-code/scripts/diff-position-mapper.sh
+++ b/skills/review-code/scripts/diff-position-mapper.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# diff-position-mapper.sh - Map file line numbers to diff positions for GitHub API
+#
+# GitHub's PR review comment API requires a "position" that represents the
+# line number in the unified diff, counting from the first "@@" hunk header.
+# This script maps file:line targets to their corresponding diff positions.
+#
+# Usage:
+#   echo '<json_input>' | diff-position-mapper.sh
+#
+# Input JSON:
+#   {
+#     "diff": "<unified diff content>",
+#     "targets": [
+#       {"path": "src/auth.ts", "line": 42},
+#       {"path": "src/utils.ts", "line": 15}
+#     ]
+#   }
+#
+# Output JSON:
+#   {
+#     "mappings": [
+#       {"path": "src/auth.ts", "line": 42, "position": 23, "side": "RIGHT"},
+#       {"path": "src/utils.ts", "line": 15, "position": null, "error": "line not in diff"}
+#     ]
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+
+# Parse the diff and build a lookup table mapping file paths and line numbers to positions
+# The position is the 1-based line number within the unified diff, counting from the first @@
+#
+# Args: $1 = diff content
+# Output: JSON object with structure: { "file/path.ts": { "42": {"position": 5, "side": "RIGHT"}, ... }, ... }
+build_position_map() {
+    local diff="$1"
+
+    # Use awk to parse the diff and output JSON (BSD awk compatible)
+    echo "${diff}" | awk '
+    BEGIN {
+        current_file = ""
+        position = 0
+        old_line = 0
+        new_line = 0
+        print "{"
+        first_file = 1
+    }
+
+    # Match diff header to get file path
+    # Format: diff --git a/path/to/file b/path/to/file
+    /^diff --git/ {
+        # Extract the b/ path (new file) - find last " b/" and take everything after
+        idx = match($0, / b\//)
+        if (idx > 0) {
+            if (current_file != "") {
+                print "}"
+            }
+            if (!first_file) {
+                print ","
+            }
+            first_file = 0
+            current_file = substr($0, idx + 3)
+            # Escape quotes in file path
+            gsub(/"/, "\\\"", current_file)
+            printf "  \"%s\": {", current_file
+            position = 0
+            first_line = 1
+        }
+        next
+    }
+
+    # Match hunk header
+    # Format: @@ -old_start,old_count +new_start,new_count @@
+    /^@@/ {
+        # Parse hunk header manually for BSD awk compatibility
+        # Find the +N part for new line start
+        idx = index($0, "+")
+        if (idx > 0) {
+            rest = substr($0, idx + 1)
+            # Extract number until comma or space
+            gsub(/[^0-9].*/, "", rest)
+            new_line = rest + 0
+        }
+        # Find the -N part for old line start
+        idx = index($0, "-")
+        if (idx > 0) {
+            rest = substr($0, idx + 1)
+            gsub(/[^0-9].*/, "", rest)
+            old_line = rest + 0
+        }
+        position++
+        next
+    }
+
+    # Skip if no current file (before first diff header)
+    current_file == "" { next }
+
+    # Context line (space prefix) - both sides have this line
+    /^ / {
+        position++
+        old_line++
+        new_line++
+        next
+    }
+
+    # Added line (+) - only in new file (RIGHT side)
+    /^\+/ && !/^\+\+\+/ {
+        position++
+        if (!first_line) printf ","
+        first_line = 0
+        printf "\n    \"%d\": {\"position\": %d, \"side\": \"RIGHT\"}", new_line, position
+        new_line++
+        next
+    }
+
+    # Removed line (-) - only in old file (LEFT side)
+    /^-/ && !/^---/ {
+        position++
+        old_line++
+        next
+    }
+
+    END {
+        if (current_file != "") {
+            print "\n  }"
+        }
+        print "}"
+    }
+    '
+}
+
+# Look up a target in the position map
+# Args: $1 = position_map (JSON), $2 = path, $3 = line
+# Output: JSON object with position info or error
+lookup_position() {
+    local position_map="$1"
+    local path="$2"
+    local line="$3"
+
+    # Query the position map
+    local result
+    result=$(echo "${position_map}" | jq -r --arg path "${path}" --arg line "${line}" '
+        .[$path][$line] // null
+    ')
+
+    if [[ "${result}" == "null" ]]; then
+        # Check if file exists in diff at all
+        local file_exists
+        file_exists=$(echo "${position_map}" | jq -r --arg path "${path}" 'has($path)')
+
+        if [[ "${file_exists}" == "false" ]]; then
+            jq -n --arg path "${path}" --argjson line "${line}" \
+                '{path: $path, line: $line, position: null, error: "file not in diff"}'
+        else
+            jq -n --arg path "${path}" --argjson line "${line}" \
+                '{path: $path, line: $line, position: null, error: "line not in diff"}'
+        fi
+    else
+        # Return the position info with path and line included
+        echo "${result}" | jq --arg path "${path}" --argjson line "${line}" \
+            '{path: $path, line: $line} + .'
+    fi
+}
+
+main() {
+    # Read input JSON from stdin
+    local input
+    input=$(cat)
+
+    # Validate input
+    if ! echo "${input}" | jq empty 2>/dev/null; then
+        error "Invalid JSON input"
+        exit 1
+    fi
+
+    # Extract diff and targets
+    local diff targets
+    diff=$(echo "${input}" | jq -r '.diff // ""')
+    targets=$(echo "${input}" | jq -c '.targets // []')
+
+    if [[ -z "${diff}" ]]; then
+        error "No diff provided in input"
+        exit 1
+    fi
+
+    # Build the position map once
+    local position_map
+    position_map=$(build_position_map "${diff}")
+
+    # Process each target
+    local mappings="[]"
+    while IFS= read -r target; do
+        local path line
+        path=$(echo "${target}" | jq -r '.path')
+        line=$(echo "${target}" | jq -r '.line')
+
+        local mapping
+        mapping=$(lookup_position "${position_map}" "${path}" "${line}")
+        mappings=$(echo "${mappings}" | jq --argjson m "${mapping}" '. + [$m]')
+    done < <(echo "${targets}" | jq -c '.[]')
+
+    # Output result
+    jq -n --argjson mappings "${mappings}" '{mappings: $mappings}'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 FORCE_MODE="false"
 FIND_MODE="false"
 DRAFT_MODE="false"
+SELF_MODE="false"
 remaining_args=()
 
 for arg_item in "$@"; do
@@ -17,6 +18,8 @@ for arg_item in "$@"; do
         FORCE_MODE="true"
     elif [[ "${arg_item}" == "--draft" ]] || [[ "${arg_item}" == "-d" ]]; then
         DRAFT_MODE="true"
+    elif [[ "${arg_item}" == "--self" ]]; then
+        SELF_MODE="true"
     else
         remaining_args+=("${arg_item}")
     fi
@@ -144,6 +147,11 @@ build_json_output() {
     # Add draft_mode if enabled
     if [[ "${DRAFT_MODE}" == "true" ]]; then
         jq_args+=("--arg" "draft_mode" "true")
+    fi
+
+    # Add self_mode if enabled
+    if [[ "${SELF_MODE}" == "true" ]]; then
+        jq_args+=("--arg" "self_mode" "true")
     fi
 
     jq -nc "${jq_args[@]}" "${jq_filter}"

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -9,11 +9,14 @@ set -euo pipefail
 # This ensures flags can appear anywhere and remaining args are properly ordered
 FORCE_MODE="false"
 FIND_MODE="false"
+DRAFT_MODE="false"
 remaining_args=()
 
 for arg_item in "$@"; do
     if [[ "${arg_item}" == "--force" ]] || [[ "${arg_item}" == "-f" ]]; then
         FORCE_MODE="true"
+    elif [[ "${arg_item}" == "--draft" ]] || [[ "${arg_item}" == "-d" ]]; then
+        DRAFT_MODE="true"
     else
         remaining_args+=("${arg_item}")
     fi
@@ -136,6 +139,11 @@ build_json_output() {
     # Add force_mode if enabled
     if [[ "${FORCE_MODE}" == "true" ]]; then
         jq_args+=("--arg" "force_mode" "true")
+    fi
+
+    # Add draft_mode if enabled
+    if [[ "${DRAFT_MODE}" == "true" ]]; then
+        jq_args+=("--arg" "draft_mode" "true")
     fi
 
     jq -nc "${jq_args[@]}" "${jq_filter}"

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -117,6 +117,9 @@ build_json_output() {
     local mode=$1
     shift
 
+    # Validate draft mode compatibility before building output
+    validate_draft_mode "${mode}"
+
     local -a jq_args=("--arg" "mode" "${mode}")
     # shellcheck disable=SC2016  # $ARGS is a jq variable, not a shell variable
     local jq_filter='$ARGS.named'
@@ -162,6 +165,16 @@ build_json_error() {
     local error_msg=$1
     jq -nc --arg mode "error" --arg error "${error_msg}" \
         '{mode: $mode, error: $error}' >&2
+}
+
+# Helper: Validate draft mode is only used with PR mode
+# Exits with error if draft flag used with incompatible mode
+validate_draft_mode() {
+    local mode=$1
+    if [[ "${DRAFT_MODE}" == "true" ]] && [[ "${mode}" != "pr" ]]; then
+        build_json_error "--draft flag only works when reviewing a PR. Use '/review-code <pr_number>' with --draft"
+        exit 1
+    fi
 }
 
 # Detector: Check for area-specific review keywords

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -44,6 +44,8 @@ main() {
     force_mode=$(echo "${parse_result}" | jq -r '.force_mode // "false"')
     local draft_mode
     draft_mode=$(echo "${parse_result}" | jq -r '.draft_mode // "false"')
+    local self_mode
+    self_mode=$(echo "${parse_result}" | jq -r '.self_mode // "false"')
 
     # Extract org/repo early for git-based modes
     # Cache git org/repo to avoid redundant operations
@@ -333,9 +335,10 @@ build_review_data() {
     # Add mode-specific arguments
     jq_args+=("$@")
 
-    # Add force_mode and draft_mode to jq args
+    # Add force_mode, draft_mode, and self_mode to jq args
     jq_args+=(--arg force_mode "${force_mode}")
     jq_args+=(--arg draft_mode "${draft_mode}")
+    jq_args+=(--arg self_mode "${self_mode}")
 
     # Single jq invocation with conditional pr field
     final_output=$(jq "${jq_args[@]}" \
@@ -354,6 +357,7 @@ build_review_data() {
         }
         + (if $force_mode == "true" then {force: true} else {} end)
         + (if $draft_mode == "true" then {draft: true} else {} end)
+        + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -42,6 +42,8 @@ main() {
     pattern=$(echo "${parse_result}" | jq -r '.file_pattern // empty')
     local force_mode
     force_mode=$(echo "${parse_result}" | jq -r '.force_mode // "false"')
+    local draft_mode
+    draft_mode=$(echo "${parse_result}" | jq -r '.draft_mode // "false"')
 
     # Extract org/repo early for git-based modes
     # Cache git org/repo to avoid redundant operations
@@ -331,8 +333,9 @@ build_review_data() {
     # Add mode-specific arguments
     jq_args+=("$@")
 
-    # Add force_mode to jq args
+    # Add force_mode and draft_mode to jq args
     jq_args+=(--arg force_mode "${force_mode}")
+    jq_args+=(--arg draft_mode "${draft_mode}")
 
     # Single jq invocation with conditional pr field
     final_output=$(jq "${jq_args[@]}" \
@@ -350,6 +353,7 @@ build_review_data() {
             next_step: "gather_architectural_context"
         }
         + (if $force_mode == "true" then {force: true} else {} end)
+        + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"

--- a/tests/fixtures/diffs/simple-single-file.diff
+++ b/tests/fixtures/diffs/simple-single-file.diff
@@ -1,0 +1,21 @@
+diff --git a/src/utils.ts b/src/utils.ts
+new file mode 100644
+index 0000000..a1b2c3d
+--- /dev/null
++++ b/src/utils.ts
+@@ -0,0 +1,15 @@
++export function formatDate(date: Date): string {
++    return date.toISOString().split('T')[0];
++}
++
++export function capitalize(str: string): string {
++    if (!str) return str;
++    return str.charAt(0).toUpperCase() + str.slice(1);
++}
++
++export function delay(ms: number): Promise<void> {
++    return new Promise(resolve => setTimeout(resolve, ms));
++}
++
++export const VERSION = '1.0.0';
++export const MAX_RETRIES = 3;

--- a/tests/fixtures/reviews/pending-review.json
+++ b/tests/fixtures/reviews/pending-review.json
@@ -1,0 +1,15 @@
+{
+  "id": 12345678,
+  "node_id": "PRR_kwDOTest",
+  "user": {
+    "login": "testuser",
+    "id": 1234,
+    "type": "User"
+  },
+  "body": "Draft review in progress",
+  "state": "PENDING",
+  "html_url": "https://github.com/test-owner/test-repo/pull/42#pullrequestreview-12345678",
+  "pull_request_url": "https://api.github.com/repos/test-owner/test-repo/pulls/42",
+  "submitted_at": null,
+  "commit_id": "abc123def456"
+}

--- a/tests/fixtures/reviews/review-comments.json
+++ b/tests/fixtures/reviews/review-comments.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": 111111,
+    "path": "src/utils.ts",
+    "line": 5,
+    "position": 5,
+    "body": "Consider adding input validation here"
+  },
+  {
+    "id": 222222,
+    "path": "src/utils.ts",
+    "line": 10,
+    "position": 10,
+    "body": "This could be simplified"
+  }
+]

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -1,0 +1,342 @@
+#!/usr/bin/env bats
+# Tests for create-draft-review.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/create-draft-review.sh"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures/reviews"
+
+    # Create temp directory for mock scripts
+    MOCK_DIR=$(mktemp -d)
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+# Helper to create a mock gh command
+create_mock_gh() {
+    local response="$1"
+    cat > "$MOCK_DIR/gh" << EOF
+#!/bin/bash
+echo '$response'
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# Helper to create a mock gh that fails
+create_failing_mock_gh() {
+    local error_msg="$1"
+    cat > "$MOCK_DIR/gh" << EOF
+#!/bin/bash
+echo '$error_msg' >&2
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "create-draft-review: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: uses set -euo pipefail" {
+    run bash -c "head -40 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: has require_field function" {
+    run bash -c "grep -q '^require_field()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: has get_existing_pending_review function" {
+    run bash -c "grep -q '^get_existing_pending_review()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: has delete_pending_review function" {
+    run bash -c "grep -q '^delete_pending_review()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: has create_pending_review function" {
+    run bash -c "grep -q '^create_pending_review()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: has main function" {
+    run bash -c "grep -q '^main()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# require_field tests
+# =============================================================================
+
+@test "create-draft-review: require_field accepts valid value" {
+    run bash -c "source '$SCRIPT' && require_field 'test_value' 'field_name'"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: require_field rejects empty value" {
+    run bash -c "source '$SCRIPT' && require_field '' 'field_name'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"success": false'* ]]
+    [[ "$output" == *'"error": "Missing field_name"'* ]]
+}
+
+@test "create-draft-review: require_field rejects null value" {
+    run bash -c "source '$SCRIPT' && require_field 'null' 'field_name'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"success": false'* ]]
+    [[ "$output" == *'"error": "Missing field_name"'* ]]
+}
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "create-draft-review: rejects invalid JSON input" {
+    run bash -c "echo 'not json' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid JSON"* ]]
+}
+
+@test "create-draft-review: rejects missing owner" {
+    local input='{"repo": "test", "pr_number": 1, "reviewer_username": "user"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing owner"* ]]
+}
+
+@test "create-draft-review: rejects missing repo" {
+    local input='{"owner": "org", "pr_number": 1, "reviewer_username": "user"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing repo"* ]]
+}
+
+@test "create-draft-review: rejects missing pr_number" {
+    local input='{"owner": "org", "repo": "test", "reviewer_username": "user"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing pr_number"* ]]
+}
+
+@test "create-draft-review: rejects missing reviewer_username" {
+    local input='{"owner": "org", "repo": "test", "pr_number": 1}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing reviewer_username"* ]]
+}
+
+# =============================================================================
+# get_existing_pending_review tests
+# =============================================================================
+
+@test "create-draft-review: get_existing_pending_review returns null when no pending review" {
+    create_mock_gh '[]'
+
+    run bash -c "source '$SCRIPT' && get_existing_pending_review 'owner' 'repo' '42' 'testuser'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "null" ]
+}
+
+@test "create-draft-review: get_existing_pending_review finds pending review" {
+    local reviews
+    reviews=$(cat "$FIXTURES_DIR/pending-review.json")
+    # Wrap in array for the reviews endpoint response
+    create_mock_gh "[$reviews]"
+
+    run bash -c "source '$SCRIPT' && get_existing_pending_review 'test-owner' 'test-repo' '42' 'testuser'"
+    [ "$status" -eq 0 ]
+    # Should return review info with review_id
+    [[ "$output" == *'"review_id":'* ]]
+}
+
+# =============================================================================
+# Main flow tests with mocks
+# =============================================================================
+
+@test "create-draft-review: creates review successfully" {
+    # Mock gh to return empty reviews and then success on create
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 99999, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test review", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"review_id": 99999'* ]]
+}
+
+@test "create-draft-review: creates review with inline comments" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 88888, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "test.ts", "position": 5, "body": "Fix this"}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"inline_count": 1'* ]]
+}
+
+@test "create-draft-review: replaces existing pending review" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[{"id": 11111, "state": "PENDING", "user": {"login": "user"}, "body": "old"}]'
+elif [[ "$*" == *"/reviews/11111/comments"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method DELETE"* ]]; then
+    echo '{}'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 22222, "body": "new"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "New review", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"replaced_existing": true'* ]]
+}
+
+@test "create-draft-review: includes unmapped comments in body" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 77777, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [], "unmapped_comments": [{"description": "General note"}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"summary_count": 1'* ]]
+}
+
+@test "create-draft-review: handles API failure gracefully" {
+    create_failing_mock_gh "API rate limit exceeded"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'"success": false'* ]]
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "create-draft-review: outputs valid JSON on success" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 66666, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT' | jq empty"
+    [ "$status" -eq 0 ]
+}
+
+@test "create-draft-review: includes review_url in output" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 55555, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "reviewer_username": "user", "summary": "Test", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"review_url": "https://github.com/org/test/pull/42#pullrequestreview-55555"'* ]]
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+@test "create-draft-review: handles empty summary" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 44444, "body": ""}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+}
+
+@test "create-draft-review: handles null comments array" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 33333, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"inline_count": 0'* ]]
+}

--- a/tests/unit/test-diff-position-mapper.bats
+++ b/tests/unit/test-diff-position-mapper.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# Tests for diff-position-mapper.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/diff-position-mapper.sh"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures/diffs"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "diff-position-mapper: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "diff-position-mapper: uses set -euo pipefail" {
+    run bash -c "head -30 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "diff-position-mapper: has build_position_map function" {
+    run bash -c "grep -q '^build_position_map()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "diff-position-mapper: has lookup_position function" {
+    run bash -c "grep -q '^lookup_position()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "diff-position-mapper: has main function" {
+    run bash -c "grep -q '^main()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "diff-position-mapper: rejects invalid JSON input" {
+    run bash -c "echo 'not json' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid JSON"* ]]
+}
+
+@test "diff-position-mapper: rejects missing diff field" {
+    run bash -c "echo '{\"targets\": []}' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"No diff provided"* ]]
+}
+
+@test "diff-position-mapper: accepts empty targets array" {
+    local input='{"diff": "diff --git a/test.txt b/test.txt", "targets": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"mappings": []'* ]]
+}
+
+# =============================================================================
+# build_position_map tests
+# =============================================================================
+
+@test "diff-position-mapper: maps single file diff correctly" {
+    local input
+    input=$(cat "$FIXTURES_DIR/simple-single-file.diff" | jq -Rs '{diff: ., targets: [{path: "src/utils.ts", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Line 1 in a new file has position 2 (position 1 is the @@ hunk header)
+    local position
+    position=$(echo "$output" | jq -r '.mappings[0].position')
+    [ "$position" = "2" ]
+}
+
+@test "diff-position-mapper: maps multiple lines in same file" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 1}, {path: "src/utils.ts", line: 5}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Should have 2 mappings
+    local count
+    count=$(echo "$output" | jq '.mappings | length')
+    [ "$count" -eq 2 ]
+}
+
+@test "diff-position-mapper: includes side field in mapping" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Added lines should have side "RIGHT"
+    local side
+    side=$(echo "$output" | jq -r '.mappings[0].side')
+    [ "$side" = "RIGHT" ]
+}
+
+# =============================================================================
+# lookup_position tests
+# =============================================================================
+
+@test "diff-position-mapper: returns error for file not in diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "nonexistent.ts", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local error
+    error=$(echo "$output" | jq -r '.mappings[0].error')
+    [ "$error" = "file not in diff" ]
+}
+
+@test "diff-position-mapper: returns error for line not in diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 999}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local error
+    error=$(echo "$output" | jq -r '.mappings[0].error')
+    [ "$error" = "line not in diff" ]
+}
+
+@test "diff-position-mapper: returns null position for unmapped lines" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 999}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local position
+    position=$(echo "$output" | jq '.mappings[0].position')
+    [ "$position" = "null" ]
+}
+
+# =============================================================================
+# Multi-file diff tests
+# =============================================================================
+
+@test "diff-position-mapper: handles multi-file diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/python-flask.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "api/app.py", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Should successfully map the first line
+    local position
+    position=$(echo "$output" | jq -r '.mappings[0].position')
+    [ "$position" != "null" ]
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+@test "diff-position-mapper: handles empty diff content gracefully" {
+    local input='{"diff": "", "targets": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+}
+
+@test "diff-position-mapper: preserves path in output" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local path
+    path=$(echo "$output" | jq -r '.mappings[0].path')
+    [ "$path" = "src/utils.ts" ]
+}
+
+@test "diff-position-mapper: preserves line in output" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 5}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local line
+    line=$(echo "$output" | jq '.mappings[0].line')
+    [ "$line" = "5" ]
+}
+
+@test "diff-position-mapper: outputs valid JSON" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "src/utils.ts", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT' | jq empty"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Integration tests with realistic diffs
+# =============================================================================
+
+@test "diff-position-mapper: maps typescript-react diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/typescript-react.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: []}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "diff-position-mapper: maps rust-web diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/rust-web.diff")
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: []}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Adds the ability to create a pending (draft) GitHub review with inline comments directly from suggested comments. The flag works only in PR mode and for reviewing others' PRs.

New scripts:
- diff-position-mapper.sh: Maps file line numbers to GitHub diff positions
- create-draft-review.sh: Creates/amends pending reviews via GitHub API

Features:
- Smart amend: merges with existing pending review using semantic matching
- Unmapped comments go into review summary
- Clean comment text without agent metadata