### PR TITLE
feat: Add self-learning from PR review outcomes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,14 @@ jobs:
         git config --global user.email "ci@github.com"
         git config --global user.name "GitHub CI"
 
-        # Install all system dependencies
+        # Install system dependencies
         sudo apt-get update
-        sudo apt-get install -y jq shellcheck
+        sudo apt-get install -y shellcheck
+
+        # Install jq 1.7.1 (apt has older 1.6 which has syntax incompatibilities)
+        JQ_VERSION="1.7.1"
+        curl -fsSL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -o /tmp/jq
+        sudo install -m 755 /tmp/jq /usr/local/bin/jq
 
         # Install bats-core (1.11.1 includes IFS fix for test compatibility)
         sudo npm install -g bats@1.11.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y jq shellcheck
 
-        # Install bats-core (pinned version for supply chain security)
-        sudo npm install -g bats@1.10.0
+        # Install bats-core (1.11.1 includes IFS fix for test compatibility)
+        sudo npm install -g bats@1.11.1
 
         # Verify installations
         echo "=== Dependency Versions ==="

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ target/
 # Learning data (created per-installation, not committed)
 skills/review-code/learnings/index.jsonl
 skills/review-code/learnings/analyzed.json
+skills/review-code/learnings/status-cache.json
 
 # Package manager files (not applicable here, but good to have)
 node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,9 @@ dist/
 build/
 target/
 
+# Learning data (created per-installation, not committed)
+skills/review-code/learnings/index.jsonl
+skills/review-code/learnings/analyzed.json
+
 # Package manager files (not applicable here, but good to have)
 node_modules/

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Run specialized code review agents on code changes or pull requests
-argument-hint: [find|pr|commit|branch|range|area]
+argument-hint: [find|learn|pr|commit|branch|range|area]
 ---
 
 Run specialized code review agent(s) with comprehensive context on local changes or pull requests.
@@ -11,6 +11,10 @@ Run specialized code review agent(s) with comprehensive context on local changes
   - `find` - Find review for current branch/PR
   - `find <pr-number>` - Find review for specific PR (e.g., `find 123`)
   - `find <branch>` - Find review for specific branch (e.g., `find feature-branch`)
+- `learn` - Learn from PR review outcomes to improve future reviews
+  - `learn <pr-number>` - Analyze outcomes of a specific PR (e.g., `learn 123`)
+  - `learn` - Batch analyze all unanalyzed PRs with existing reviews
+  - `learn --apply` - Apply accumulated learnings to context files
 - `<pr-url>` - Review Pull Request by URL - works from anywhere (e.g., `https://github.com/org/repo/pull/123`)
   - Uses `gh` CLI to fetch PR context from GitHub
   - No git repository required - review any PR without cloning
@@ -61,6 +65,12 @@ Examples:
 - `/review-code find 123` - Find review for PR #123
 - `/review-code find feature-branch` - Find review for a specific branch
 
+**Learn from review outcomes:**
+
+- `/review-code learn 123` - Analyze what happened after reviewing PR #123
+- `/review-code learn` - Batch analyze all recently merged PRs with reviews
+- `/review-code learn --apply` - Apply accumulated learnings to improve future reviews
+
 **With file patterns:**
 
 - `/review-code 356ded2..HEAD "*.sh"` - Review only shell script changes in range
@@ -90,6 +100,17 @@ Examples:
 **NOTE**: Uses session-based caching to run the orchestrator once and reuse the data across multiple bash invocations. This reduces token usage by ~60%.
 
 **⚠️ CRITICAL**: This skill MUST follow the structured session flow below. If session initialization fails, STOP and inform the user. NEVER improvise by running review agents manually or posting to GitHub directly - this can cause unintended side effects like submitting reviews that should be drafts.
+
+### Step 0: Check for Learn Mode
+
+Before initializing a review session, check if this is a learn command:
+
+```bash
+PARSE_RESULT=$(~/.claude/skills/review-code/scripts/parse-review-arg.sh $ARGUMENTS)
+MODE=$(echo "$PARSE_RESULT" | jq -r '.mode')
+```
+
+If MODE is "learn", skip to the **Handler: "learn"** section below. Otherwise, continue with Step 1.
 
 ### Step 1: Initialize Session
 
@@ -859,3 +880,308 @@ echo "Session cleaned up: $SESSION_ID"
 ```
 
 This removes the temporary session files and frees up disk space.
+
+---
+
+## Handler: "learn"
+
+The learn mode analyzes PR review outcomes to improve future reviews. It has three submodes based on the parsed arguments.
+
+### Determine Learn Submode
+
+Extract the learn submode from the parse result:
+
+```bash
+LEARN_SUBMODE=$(echo "$PARSE_RESULT" | jq -r '.learn_submode')
+PR_NUMBER=$(echo "$PARSE_RESULT" | jq -r '.pr_number // empty')
+```
+
+Based on `LEARN_SUBMODE`, proceed to the appropriate handler:
+
+### Learn Submode: "single"
+
+Analyze a specific PR's outcomes.
+
+**Step 1: Run cross-reference analysis**
+
+```bash
+LEARN_DATA=$(~/.claude/skills/review-code/scripts/learn-from-pr.sh "$PR_NUMBER")
+```
+
+**Step 2: Display cross-reference summary**
+
+Extract and display the summary:
+
+```bash
+echo "$LEARN_DATA" | jq -r '
+"📊 Cross-Reference Summary for PR #\(.pr_number)
+
+**Claude'\''s Findings (\(.summary.claude_total) total):**
+- \(.summary.claude_addressed) likely addressed in subsequent commits ✓
+- \(.summary.claude_not_addressed) not modified after review
+- \(.summary.claude_total - .summary.claude_addressed - .summary.claude_not_addressed) unclear
+
+**Other Reviewers Found (\(.summary.other_total) total):**
+- \(.summary.other_caught_by_claude) also caught by Claude ✓
+- \(.summary.other_missed_by_claude) Claude missed
+"'
+```
+
+**Step 3: Process prompts for uncertain items**
+
+For each item in `prompts_needed`, ask the user interactively:
+
+**For "unaddressed" findings (Claude found, not modified):**
+
+Use AskUserQuestion:
+- Question: "Claude flagged this issue, but the file wasn't modified. What happened?"
+- Display the finding details: file, line, description, agent, confidence
+- Options:
+  1. "False positive" - Claude was wrong, this doesn't need fixing
+  2. "Correct but deferred" - Valid issue, but postponed for later
+  3. "Correct but low priority" - Valid but not worth changing
+  4. "Skip" - Don't record this learning
+
+**For "missed" findings (other reviewer found, Claude missed):**
+
+Use AskUserQuestion:
+- Question: "Another reviewer found this issue that Claude missed. Should Claude learn to detect this?"
+- Display the finding details: file, line, description, author
+- Options:
+  1. "Yes, add to patterns" - Claude should catch this in future reviews
+  2. "No, too specific" - This was a one-off case
+  3. "Skip" - Don't record this learning
+
+**Step 4: Record learnings**
+
+For each user response (except "Skip"), create a learning record:
+
+```json
+{
+  "timestamp": "2026-02-02T10:30:00Z",
+  "pr_number": 123,
+  "org": "from learn_data",
+  "repo": "from learn_data",
+  "type": "false_positive | missed_pattern | valid_catch | deferred",
+  "source": "claude | other_reviewer",
+  "agent": "from finding",
+  "finding": {
+    "file": "from finding",
+    "line": "from finding",
+    "description": "from finding"
+  },
+  "context": {
+    "language": "detect from file extension",
+    "framework": "if known"
+  },
+  "user_feedback": "user's selection reason if any"
+}
+```
+
+Append the learning to the index file:
+
+```bash
+LEARNINGS_DIR=~/.claude/skills/review-code/learnings
+mkdir -p "$LEARNINGS_DIR"
+echo "$LEARNING_JSON" >> "$LEARNINGS_DIR/index.jsonl"
+```
+
+**Step 5: Mark PR as analyzed**
+
+Update the analyzed.json tracker:
+
+```bash
+ANALYZED_FILE="$LEARNINGS_DIR/analyzed.json"
+ORG=$(echo "$LEARN_DATA" | jq -r '.org')
+REPO=$(echo "$LEARN_DATA" | jq -r '.repo')
+
+# Read existing or create new
+if [[ -f "$ANALYZED_FILE" ]]; then
+    ANALYZED=$(cat "$ANALYZED_FILE")
+else
+    ANALYZED='{}'
+fi
+
+# Update with this PR
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+ANALYZED=$(echo "$ANALYZED" | jq --arg key "$ORG/$REPO" --arg pr "$PR_NUMBER" --arg ts "$TIMESTAMP" \
+    '.[$key] //= {} | .[$key][$pr] = $ts')
+
+echo "$ANALYZED" > "$ANALYZED_FILE"
+```
+
+**Step 6: Display completion**
+
+```
+✅ Learning complete for PR #123
+
+Learnings recorded:
+- 2 false positives
+- 1 missed pattern added
+
+Run '/review-code learn --apply' when ready to update context files.
+```
+
+### Learn Submode: "batch"
+
+Analyze all unanalyzed PRs with existing reviews.
+
+**Step 1: Find unanalyzed PRs**
+
+```bash
+UNANALYZED=$(~/.claude/skills/review-code/scripts/learn-batch.sh --limit 5)
+COUNT=$(echo "$UNANALYZED" | jq 'length')
+```
+
+**Step 2: Check if any PRs to analyze**
+
+If COUNT is 0:
+```
+No unanalyzed PRs found with existing reviews.
+
+To create reviews for analysis:
+1. Run '/review-code <pr-number>' on PRs
+2. Wait for PRs to be merged
+3. Run '/review-code learn' to analyze outcomes
+```
+
+**Step 3: Process each PR**
+
+For each PR in the batch:
+
+```bash
+while read -r PR_JSON; do
+    PR_NUM=$(echo "$PR_JSON" | jq -r '.pr_number')
+    ORG=$(echo "$PR_JSON" | jq -r '.org')
+    REPO=$(echo "$PR_JSON" | jq -r '.repo')
+
+    echo "Analyzing PR #$PR_NUM ($ORG/$REPO)..."
+done < <(echo "$UNANALYZED" | jq -c '.[]')
+```
+
+For each PR, run the "single" submode flow (Steps 1-5 above).
+
+After each PR, ask if the user wants to continue:
+
+Use AskUserQuestion:
+- Question: "Continue to next PR?"
+- Options:
+  1. "Yes, analyze next PR"
+  2. "Stop here"
+
+If user selects "Stop here", exit the batch loop.
+
+**Step 4: Display batch summary**
+
+```
+📊 Batch Analysis Complete
+
+PRs analyzed: 3/5
+Learnings recorded: 7 total
+- 3 false positives
+- 2 deferred issues
+- 2 missed patterns
+
+Run '/review-code learn --apply' to update context files.
+```
+
+### Learn Submode: "apply"
+
+Synthesize accumulated learnings into context file updates.
+
+**Step 1: Analyze learnings**
+
+```bash
+PROPOSALS=$(~/.claude/skills/review-code/scripts/learn-apply.sh)
+ACTIONABLE=$(echo "$PROPOSALS" | jq '.summary.actionable_proposals')
+```
+
+**Step 2: Check if any proposals**
+
+If ACTIONABLE is 0:
+```
+No patterns ready for context updates.
+
+Requirements:
+- At least 3 occurrences of the same pattern type
+- Learnings must share language/framework context
+
+Current learnings: X total
+Grouped patterns: Y
+Patterns meeting threshold: 0
+
+Continue collecting learnings with '/review-code learn <pr>'
+```
+
+**Step 3: Present each proposal**
+
+For each proposal in `proposals`:
+
+Display the proposal:
+```
+📝 Proposed Context Update
+
+**Target file:** context/languages/python.md
+**Section:** ## Python Patterns
+**Based on:** 4 learnings
+
+**Proposed content:**
+```
+<proposed content from script>
+```
+
+This pattern was identified from PRs: #123, #456, #789, #101
+```
+
+Use AskUserQuestion:
+- Question: "Apply this update to the context file?"
+- Options:
+  1. "Apply" - Add this content to the context file
+  2. "Edit first" - Let me modify the content before applying
+  3. "Skip" - Don't add this pattern
+  4. "Stop" - Stop processing proposals
+
+**If "Apply":**
+
+1. Check if target file exists
+2. If not, create it with a header
+3. Append the proposed content
+4. Confirm: "Added to context/languages/python.md"
+
+**If "Edit first":**
+
+1. Display the proposed content in a code block
+2. Ask user to provide edited version
+3. Apply the edited version
+
+**If "Skip":**
+
+Continue to next proposal.
+
+**If "Stop":**
+
+Exit the apply loop.
+
+**Step 4: Clear applied learnings (optional)**
+
+After applying proposals, ask:
+
+Use AskUserQuestion:
+- Question: "Clear the learnings that were applied?"
+- Options:
+  1. "Yes, clear applied" - Remove learnings that were used in applied proposals
+  2. "No, keep all" - Keep learnings for future reference
+
+If "Yes", filter out the applied learnings from index.jsonl.
+
+**Step 5: Display apply summary**
+
+```
+✅ Context Updates Applied
+
+Files updated:
+- context/languages/python.md (2 patterns)
+- context/frameworks/django.md (1 pattern)
+
+These improvements will be used in future reviews.
+```

--- a/skills/review-code/learnings/README.md
+++ b/skills/review-code/learnings/README.md
@@ -1,0 +1,61 @@
+# Learnings Directory
+
+This directory stores learning data from code review outcomes. Files are created per-installation (not committed to git).
+
+## Files
+
+### `index.jsonl`
+
+Append-only file of individual learnings from PR analysis. Each line is a JSON object:
+
+```json
+{
+  "timestamp": "2026-02-02T10:30:00Z",
+  "pr_number": 123,
+  "org": "posthog",
+  "repo": "posthog",
+  "type": "false_positive | missed_pattern | valid_catch | deferred",
+  "source": "claude | other_reviewer",
+  "agent": "security",
+  "finding": {
+    "file": "auth.py",
+    "line": 45,
+    "description": "SQL injection warning"
+  },
+  "context": {
+    "language": "python",
+    "framework": "django"
+  },
+  "user_feedback": "Django ORM auto-parameterizes queries"
+}
+```
+
+**Types:**
+- `valid_catch`: Claude found issue, code was fixed
+- `false_positive`: Claude found issue, user confirmed it's incorrect
+- `deferred`: Claude found issue, valid but low priority/deferred
+- `missed_pattern`: Other reviewer found issue Claude missed, code was fixed
+
+### `analyzed.json`
+
+Tracks which PRs have been analyzed to avoid re-processing:
+
+```json
+{
+  "posthog/posthog": {
+    "123": "2026-02-02T10:30:00Z",
+    "456": "2026-02-03T14:00:00Z"
+  },
+  "haacked/review-code": {
+    "22": "2026-02-01T09:15:00Z"
+  }
+}
+```
+
+## Data Flow
+
+1. `/review-code learn 123` analyzes PR #123 outcomes
+2. Interactive prompts categorize uncertain findings
+3. Learnings appended to `index.jsonl`
+4. PR marked as analyzed in `analyzed.json`
+5. `/review-code learn --apply` synthesizes patterns into context updates

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -39,6 +39,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/helpers/error-helpers.sh
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=lib/helpers/json-helpers.sh
+source "${SCRIPT_DIR}/helpers/json-helpers.sh"
 
 # Validate a required field
 # Args: $1 = value, $2 = field name
@@ -164,10 +166,7 @@ main() {
     input=$(cat)
 
     # Validate input
-    if ! echo "${input}" | jq empty 2>/dev/null; then
-        error "Invalid JSON input"
-        exit 1
-    fi
+    validate_json "${input}" || exit 1
 
     # Extract fields
     local owner repo pr_number reviewer summary comments unmapped_comments

--- a/skills/review-code/scripts/diff-position-mapper.sh
+++ b/skills/review-code/scripts/diff-position-mapper.sh
@@ -30,6 +30,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/helpers/error-helpers.sh
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=lib/helpers/json-helpers.sh
+source "${SCRIPT_DIR}/helpers/json-helpers.sh"
 
 # Parse the diff and build a lookup table mapping file paths and line numbers to positions
 # The position is the 1-based line number within the unified diff, counting from the first @@
@@ -172,10 +174,7 @@ main() {
     input=$(cat)
 
     # Validate input
-    if ! echo "${input}" | jq empty 2>/dev/null; then
-        error "Invalid JSON input"
-        exit 1
-    fi
+    validate_json "${input}" || exit 1
 
     # Extract diff and targets
     local diff targets

--- a/skills/review-code/scripts/get-review-diff.sh
+++ b/skills/review-code/scripts/get-review-diff.sh
@@ -9,9 +9,6 @@ source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 
 set -euo pipefail
 
-# Get the directory where this script lives
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
 # Source shared exclusion patterns
 source "${SCRIPT_DIR}/helpers/exclusion-patterns.sh"
 

--- a/skills/review-code/scripts/helpers/config-helpers.sh
+++ b/skills/review-code/scripts/helpers/config-helpers.sh
@@ -92,3 +92,29 @@ load_config_safely() {
 
     return 0
 }
+
+# Get the review root path from configuration
+# Usage: review_root=$(get_review_root)
+#
+# Loads the REVIEW_ROOT_PATH from the configuration file if it exists,
+# otherwise returns the default path ~/dev/ai/reviews
+#
+# Returns:
+#   The review root path on stdout
+get_review_root() {
+    local review_root="${HOME}/dev/ai/reviews"
+    local config_file=""
+
+    if [[ -f "${HOME}/.claude/skills/review-code/.env" ]]; then
+        config_file="${HOME}/.claude/skills/review-code/.env"
+    elif [[ -f "${HOME}/.claude/review-code.env" ]]; then
+        config_file="${HOME}/.claude/review-code.env"
+    fi
+
+    if [[ -n "${config_file}" ]]; then
+        load_config_safely "${config_file}"
+        review_root="${REVIEW_ROOT_PATH:-${HOME}/dev/ai/reviews}"
+    fi
+
+    echo "${review_root}"
+}

--- a/skills/review-code/scripts/helpers/date-helpers.sh
+++ b/skills/review-code/scripts/helpers/date-helpers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Cross-platform date handling helpers
+# Handles differences between BSD (macOS) and GNU (Linux) date commands
+
+# Get file modification time as epoch seconds
+# Usage: get_file_mtime <file_path>
+# Returns: epoch seconds on stdout, or empty string on error
+get_file_mtime() {
+    local file_path="$1"
+
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        stat -f '%m' "${file_path}" 2>/dev/null
+    else
+        stat -c '%Y' "${file_path}" 2>/dev/null
+    fi
+}
+
+# Convert ISO 8601 date to epoch seconds
+# Handles both "Z" suffix and "+HH:MM" offset formats
+# Usage: iso_to_epoch <iso_date>
+# Returns: epoch seconds on stdout, or "0" on error
+iso_to_epoch() {
+    local iso_date="$1"
+
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        # BSD date requires specific format handling:
+        # - "2026-02-02T10:30:00Z" (Zulu time)
+        # - "2026-02-02T10:30:00+00:00" (offset format)
+        # BSD date's %z expects +HHMM not +HH:MM
+        if [[ "${iso_date}" == *Z ]]; then
+            date -j -f "%Y-%m-%dT%H:%M:%SZ" "${iso_date}" +%s 2>/dev/null || echo "0"
+        else
+            # Normalize +HH:MM or -HH:MM to +HHMM/-HHMM for BSD date
+            local normalized_date
+            normalized_date=$(echo "${iso_date}" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
+            date -j -f "%Y-%m-%dT%H:%M:%S%z" "${normalized_date}" +%s 2>/dev/null || echo "0"
+        fi
+    else
+        date -d "${iso_date}" +%s 2>/dev/null || echo "0"
+    fi
+}
+
+# Get ISO 8601 date for N days ago (UTC)
+# Usage: days_ago_iso <days>
+# Returns: ISO 8601 date string on stdout (e.g., "2026-01-01T00:00:00Z")
+days_ago_iso() {
+    local days="$1"
+
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        date -v-"${days}"d -u +"%Y-%m-%dT%H:%M:%SZ"
+    else
+        date -d "${days} days ago" -u +"%Y-%m-%dT%H:%M:%SZ"
+    fi
+}

--- a/skills/review-code/scripts/helpers/json-helpers.sh
+++ b/skills/review-code/scripts/helpers/json-helpers.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# JSON helper functions for lib scripts
+
+# Validate that input is valid JSON
+# Args: $1 = JSON string to validate
+# Returns: 0 if valid, 1 if invalid (with error message to stderr)
+validate_json() {
+    local input="$1"
+    if ! echo "${input}" | jq empty 2>/dev/null; then
+        error "Invalid JSON input"
+        return 1
+    fi
+}

--- a/skills/review-code/scripts/helpers/validation-helpers.sh
+++ b/skills/review-code/scripts/helpers/validation-helpers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Validation helper functions for argument parsing
+
+# Validate that a value is a positive integer
+# Usage: require_positive_int <option_name> <value>
+# Exits with error if validation fails
+require_positive_int() {
+    local option_name="$1"
+    local value="$2"
+
+    if ! [[ "${value}" =~ ^[0-9]+$ ]] || [[ "${value}" -le 0 ]]; then
+        error "${option_name} must be a positive integer, got: \"${value}\""
+        exit 1
+    fi
+}

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -36,7 +36,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
-CONTEXT_DIR="${SCRIPT_DIR}/../../../context"
 
 # Source helpers
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -70,12 +70,9 @@ main() {
         exit 0
     fi
 
-    # Read all learnings
-    local learnings="[]"
-    while IFS= read -r line; do
-        [[ -z "${line}" ]] && continue
-        learnings=$(echo "${learnings}" | jq --argjson l "${line}" '. + [$l]')
-    done < "${learnings_file}"
+    # Read all learnings using jq slurp (O(n) instead of O(n²) bash loop)
+    local learnings
+    learnings=$(jq -s '[.[] | select(. != null)]' "${learnings_file}" 2>/dev/null || echo "[]")
 
     local total_learnings
     total_learnings=$(echo "${learnings}" | jq 'length')

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -88,7 +88,7 @@ main() {
     # consecutive elements with the same key
     local grouped
     grouped=$(echo "${learnings}" | jq '
-        sort_by(.type, (.context.language // "unknown"), (.context.framework // "none"))
+        sort_by([.type, (.context.language // "unknown"), (.context.framework // "none")])
         | group_by(.type + "_" + (.context.language // "unknown") + "_" + (.context.framework // "none"))
         | map({
             key: .[0].type + "_" + (.[0].context.language // "unknown") + "_" + (.[0].context.framework // "none"),

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# learn-apply.sh - Synthesize learnings into context file updates
+#
+# Usage:
+#   learn-apply.sh [--threshold N]
+#
+# Description:
+#   Analyzes accumulated learnings from learnings/index.jsonl and proposes
+#   context file updates for recurring patterns. Groups learnings by type
+#   and target context file, and suggests updates for patterns with 3+
+#   occurrences (configurable via --threshold).
+#
+# Options:
+#   --threshold N   Minimum occurrences to propose update (default: 3)
+#
+# Output:
+#   JSON with proposed context updates:
+#   {
+#     "proposals": [
+#       {
+#         "target_file": "context/languages/python.md",
+#         "section": "## Django Patterns",
+#         "content": "Flag ForeignKey access in loops...",
+#         "learnings_count": 4,
+#         "learnings": [...]
+#       }
+#     ],
+#     "summary": {
+#       "total_learnings": 15,
+#       "grouped_patterns": 5,
+#       "actionable_proposals": 2
+#     }
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
+CONTEXT_DIR="${SCRIPT_DIR}/../../../context"
+
+# Source helpers
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+
+main() {
+    local threshold=3
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --threshold)
+                threshold="$2"
+                shift 2
+                ;;
+            *)
+                error "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Check for learnings file
+    local learnings_file="${LEARNINGS_DIR}/index.jsonl"
+    if [[ ! -f "${learnings_file}" ]]; then
+        echo '{"proposals":[],"summary":{"total_learnings":0,"grouped_patterns":0,"actionable_proposals":0}}'
+        exit 0
+    fi
+
+    # Read all learnings
+    local learnings="[]"
+    while IFS= read -r line; do
+        [[ -z "${line}" ]] && continue
+        learnings=$(echo "${learnings}" | jq --argjson l "${line}" '. + [$l]')
+    done < "${learnings_file}"
+
+    local total_learnings
+    total_learnings=$(echo "${learnings}" | jq 'length')
+
+    if [[ "${total_learnings}" -eq 0 ]]; then
+        echo '{"proposals":[],"summary":{"total_learnings":0,"grouped_patterns":0,"actionable_proposals":0}}'
+        exit 0
+    fi
+
+    # Group learnings by type and context
+    # Key = type + language + framework (if any)
+    local grouped
+    grouped=$(echo "${learnings}" | jq '
+        group_by(.type + "_" + (.context.language // "unknown") + "_" + (.context.framework // "none"))
+        | map({
+            key: .[0].type + "_" + (.[0].context.language // "unknown") + "_" + (.[0].context.framework // "none"),
+            type: .[0].type,
+            language: (.[0].context.language // "unknown"),
+            framework: (.[0].context.framework // null),
+            count: length,
+            learnings: .
+        })
+        | sort_by(-.count)
+    ')
+
+    local grouped_patterns
+    grouped_patterns=$(echo "${grouped}" | jq 'length')
+
+    # Filter to patterns meeting threshold
+    local proposals="[]"
+    while IFS= read -r group_json; do
+        local count type language framework
+        count=$(echo "${group_json}" | jq -r '.count')
+        type=$(echo "${group_json}" | jq -r '.type')
+        language=$(echo "${group_json}" | jq -r '.language')
+        framework=$(echo "${group_json}" | jq -r '.framework')
+
+        # Skip if below threshold
+        [[ ${count} -lt ${threshold} ]] && continue
+
+        # Determine target context file
+        local target_file section_name
+        if [[ "${framework}" != "null" ]] && [[ -n "${framework}" ]]; then
+            target_file="context/frameworks/${framework}.md"
+            section_name="## ${framework^} Patterns"
+        elif [[ "${language}" != "unknown" ]]; then
+            target_file="context/languages/${language}.md"
+            section_name="## ${language^} Patterns"
+        else
+            target_file="context/general.md"
+            section_name="## General Patterns"
+        fi
+
+        # Generate proposed content based on type
+        local proposed_content=""
+        case "${type}" in
+            "false_positive")
+                # Collect unique feedback patterns
+                local feedback_summary
+                feedback_summary=$(echo "${group_json}" | jq -r '[.learnings[].user_feedback // empty] | unique | join("; ")')
+
+                proposed_content="### False Positive: ${language^}
+
+When reviewing ${language} code, be aware of these common false positives:
+
+${feedback_summary}
+
+These patterns are typically safe and don't require flagging."
+                ;;
+            "missed_pattern")
+                # Collect descriptions of what was missed
+                local missed_descriptions
+                missed_descriptions=$(echo "${group_json}" | jq -r '[.learnings[].finding.description // empty] | unique | .[:3] | join("\n- ")')
+
+                proposed_content="### Patterns to Detect: ${language^}
+
+Flag these patterns in ${language} code:
+
+- ${missed_descriptions}
+
+These were identified by other reviewers and should be caught."
+                ;;
+            "valid_catch")
+                # Reinforce patterns that work
+                proposed_content="### Validated Patterns: ${language^}
+
+The following patterns are confirmed valuable for ${language} reviews:
+
+$(echo "${group_json}" | jq -r '[.learnings[].finding.description // empty] | unique | .[:3] | map("- " + .) | join("\n")')
+"
+                ;;
+            "deferred")
+                proposed_content="### Lower Priority: ${language^}
+
+These issues are valid but often deferred for ${language} code. Consider reducing confidence:
+
+$(echo "${group_json}" | jq -r '[.learnings[].finding.description // empty] | unique | .[:3] | map("- " + .) | join("\n")')
+"
+                ;;
+        esac
+
+        # Add to proposals
+        proposals=$(echo "${proposals}" | jq \
+            --arg target "${target_file}" \
+            --arg section "${section_name}" \
+            --arg content "${proposed_content}" \
+            --argjson count "${count}" \
+            --argjson learnings "$(echo "${group_json}" | jq '.learnings')" \
+            '. + [{
+                target_file: $target,
+                section: $section,
+                content: $content,
+                learnings_count: $count,
+                learnings: $learnings
+            }]')
+    done < <(echo "${grouped}" | jq -c '.[]')
+
+    local actionable_proposals
+    actionable_proposals=$(echo "${proposals}" | jq 'length')
+
+    # Build final output
+    jq -n \
+        --argjson proposals "${proposals}" \
+        --argjson total "${total_learnings}" \
+        --argjson grouped "${grouped_patterns}" \
+        --argjson actionable "${actionable_proposals}" \
+        '{
+            proposals: $proposals,
+            summary: {
+                total_learnings: $total,
+                grouped_patterns: $grouped,
+                actionable_proposals: $actionable
+            }
+        }'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -39,6 +39,7 @@ LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
 
 # Source helpers
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 
 main() {
     local threshold=3
@@ -51,10 +52,7 @@ main() {
                     error "Missing value for --threshold"
                     exit 1
                 fi
-                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
-                    error "--threshold must be a positive integer, got: \"$2\""
-                    exit 1
-                fi
+                require_positive_int "--threshold" "$2"
                 threshold="$2"
                 shift 2
                 ;;

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -37,7 +37,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
 
-# Source helpers
+# Source helpers (error-helpers first, then alphabetical)
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -47,6 +47,14 @@ main() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             --threshold)
+                if [[ $# -lt 2 ]]; then
+                    error "Missing value for --threshold"
+                    exit 1
+                fi
+                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
+                    error "--threshold must be a positive integer, got: \"$2\""
+                    exit 1
+                fi
                 threshold="$2"
                 shift 2
                 ;;

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -82,9 +82,12 @@ main() {
 
     # Group learnings by type and context
     # Key = type + language + framework (if any)
+    # Note: sort_by is required before group_by because jq's group_by only groups
+    # consecutive elements with the same key
     local grouped
     grouped=$(echo "${learnings}" | jq '
-        group_by(.type + "_" + (.context.language // "unknown") + "_" + (.context.framework // "none"))
+        sort_by(.type, (.context.language // "unknown"), (.context.framework // "none"))
+        | group_by(.type + "_" + (.context.language // "unknown") + "_" + (.context.framework // "none"))
         | map({
             key: .[0].type + "_" + (.[0].context.language // "unknown") + "_" + (.[0].context.framework // "none"),
             type: .[0].type,

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -91,7 +91,7 @@ main() {
         sort_by([.type, (.context.language // "unknown"), (.context.framework // "none")])
         | group_by(.type + "_" + (.context.language // "unknown") + "_" + (.context.framework // "none"))
         | map({
-            key: .[0].type + "_" + (.[0].context.language // "unknown") + "_" + (.[0].context.framework // "none"),
+            key: (.[0].type + "_" + (.[0].context.language // "unknown") + "_" + (.[0].context.framework // "none")),
             type: .[0].type,
             language: (.[0].context.language // "unknown"),
             framework: (.[0].context.framework // null),

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -33,6 +33,7 @@ LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
+source "${SCRIPT_DIR}/helpers/date-helpers.sh"
 
 main() {
     local limit=10
@@ -82,11 +83,7 @@ main() {
 
     # Calculate cutoff date
     local cutoff_date
-    if [[ "${OSTYPE}" == "darwin"* ]]; then
-        cutoff_date=$(date -v-"${days}"d -u +"%Y-%m-%dT%H:%M:%SZ")
-    else
-        cutoff_date=$(date -d "${days} days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
-    fi
+    cutoff_date=$(days_ago_iso "${days}")
 
     # Find all PR review files
     local unanalyzed_prs="[]"

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -126,8 +126,9 @@ main() {
         fi
 
         # Check if already analyzed
+        # Use // {} to handle missing repo key gracefully instead of relying on error suppression
         local repo_key="${org}/${repo}"
-        if echo "${analyzed_data}" | jq -e --arg key "${repo_key}" --arg pr "${pr_number}" '.[$key][$pr] != null' > /dev/null 2>&1; then
+        if echo "${analyzed_data}" | jq -e --arg key "${repo_key}" --arg pr "${pr_number}" '(.[$key] // {})[$pr] != null' > /dev/null 2>&1; then
             continue
         fi
 

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# learn-batch.sh - Find unanalyzed PRs with Claude reviews
+#
+# Usage:
+#   learn-batch.sh [--limit N] [--days N]
+#
+# Description:
+#   Finds recently merged PRs that have Claude review files but haven't been
+#   analyzed for learning yet. Tracks analyzed PRs in learnings/analyzed.json.
+#
+# Options:
+#   --limit N   Maximum number of PRs to return (default: 10)
+#   --days N    Only consider PRs merged in the last N days (default: 30)
+#
+# Output:
+#   JSON array of unanalyzed PRs:
+#   [
+#     {
+#       "org": "posthog",
+#       "repo": "posthog",
+#       "pr_number": 123,
+#       "review_file": "/path/to/pr-123.md",
+#       "merged_at": "2026-01-15T10:30:00Z"
+#     }
+#   ]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
+
+# Source helpers
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+source "${SCRIPT_DIR}/helpers/config-helpers.sh"
+
+main() {
+    local limit=10
+    local days=30
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --limit)
+                limit="$2"
+                shift 2
+                ;;
+            --days)
+                days="$2"
+                shift 2
+                ;;
+            *)
+                error "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Load review root path from config
+    local review_root="${HOME}/dev/ai/reviews"
+    local config_file=""
+    if [[ -f "${HOME}/.claude/skills/review-code/.env" ]]; then
+        config_file="${HOME}/.claude/skills/review-code/.env"
+    elif [[ -f "${HOME}/.claude/review-code.env" ]]; then
+        config_file="${HOME}/.claude/review-code.env"
+    fi
+    if [[ -n "${config_file}" ]]; then
+        load_config_safely "${config_file}"
+        review_root="${REVIEW_ROOT_PATH:-${HOME}/dev/ai/reviews}"
+    fi
+
+    # Ensure learnings directory exists
+    mkdir -p "${LEARNINGS_DIR}"
+
+    # Load analyzed PRs tracker
+    local analyzed_file="${LEARNINGS_DIR}/analyzed.json"
+    local analyzed_data="{}"
+    if [[ -f "${analyzed_file}" ]]; then
+        analyzed_data=$(cat "${analyzed_file}")
+    fi
+
+    # Calculate cutoff date
+    local cutoff_date
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        cutoff_date=$(date -v-"${days}"d -u +"%Y-%m-%dT%H:%M:%SZ")
+    else
+        cutoff_date=$(date -d "${days} days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
+    fi
+
+    # Find all PR review files
+    local unanalyzed_prs="[]"
+    local count=0
+
+    # Check if review_root exists
+    if [[ ! -d "${review_root}" ]]; then
+        echo "${unanalyzed_prs}"
+        exit 0
+    fi
+
+    # Find all pr-*.md files in the review directory
+    while IFS= read -r review_file; do
+        [[ ${count} -ge ${limit} ]] && break
+
+        # Extract org, repo, and PR number from path
+        # Path format: {review_root}/{org}/{repo}/pr-{number}.md
+        local relative_path="${review_file#"${review_root}/"}"
+        local org repo pr_number
+
+        # Parse path components
+        org=$(echo "${relative_path}" | cut -d'/' -f1)
+        repo=$(echo "${relative_path}" | cut -d'/' -f2)
+        local filename
+        filename=$(basename "${review_file}")
+
+        # Extract PR number from filename (pr-123.md -> 123)
+        if [[ "${filename}" =~ ^pr-([0-9]+)\.md$ ]]; then
+            pr_number="${BASH_REMATCH[1]}"
+        else
+            continue
+        fi
+
+        # Check if already analyzed
+        local repo_key="${org}/${repo}"
+        if echo "${analyzed_data}" | jq -e --arg key "${repo_key}" --arg pr "${pr_number}" '.[$key][$pr] != null' > /dev/null 2>&1; then
+            continue
+        fi
+
+        # Check PR state and merge date via GitHub API
+        local pr_data
+        pr_data=$(gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
+
+        local pr_state pr_merged_at
+        pr_state=$(echo "${pr_data}" | jq -r '.state')
+        pr_merged_at=$(echo "${pr_data}" | jq -r '.merged_at // empty')
+
+        # Skip if not merged
+        if [[ -z "${pr_merged_at}" ]] || [[ "${pr_merged_at}" == "null" ]]; then
+            continue
+        fi
+
+        # Skip if merged before cutoff date
+        if [[ "${pr_merged_at}" < "${cutoff_date}" ]]; then
+            continue
+        fi
+
+        # Add to results
+        unanalyzed_prs=$(echo "${unanalyzed_prs}" | jq \
+            --arg org "${org}" \
+            --arg repo "${repo}" \
+            --arg pr_number "${pr_number}" \
+            --arg review_file "${review_file}" \
+            --arg merged_at "${pr_merged_at}" \
+            '. + [{
+                org: $org,
+                repo: $repo,
+                pr_number: ($pr_number | tonumber),
+                review_file: $review_file,
+                merged_at: $merged_at
+            }]')
+
+        count=$((count + 1))
+    done < <(find "${review_root}" -name "pr-*.md" -type f 2> /dev/null | sort -r)
+
+    echo "${unanalyzed_prs}"
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -29,11 +29,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
 
-# Source helpers
+# Source helpers (error-helpers first, then alphabetical)
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
-source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 source "${SCRIPT_DIR}/helpers/date-helpers.sh"
+source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 
 main() {
     local limit=10

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -31,6 +31,7 @@ LEARNINGS_DIR="${SCRIPT_DIR}/../learnings"
 
 # Source helpers
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 
 main() {
@@ -45,10 +46,7 @@ main() {
                     error "Missing value for --limit"
                     exit 1
                 fi
-                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
-                    error "--limit must be a positive integer, got: \"$2\""
-                    exit 1
-                fi
+                require_positive_int "--limit" "$2"
                 limit="$2"
                 shift 2
                 ;;
@@ -57,10 +55,7 @@ main() {
                     error "Missing value for --days"
                     exit 1
                 fi
-                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
-                    error "--days must be a positive integer, got: \"$2\""
-                    exit 1
-                fi
+                require_positive_int "--days" "$2"
                 days="$2"
                 shift 2
                 ;;

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -41,10 +41,26 @@ main() {
     while [[ $# -gt 0 ]]; do
         case $1 in
             --limit)
+                if [[ $# -lt 2 ]]; then
+                    error "Missing value for --limit"
+                    exit 1
+                fi
+                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
+                    error "--limit must be a positive integer, got: \"$2\""
+                    exit 1
+                fi
                 limit="$2"
                 shift 2
                 ;;
             --days)
+                if [[ $# -lt 2 ]]; then
+                    error "Missing value for --days"
+                    exit 1
+                fi
+                if ! [[ "$2" =~ ^[0-9]+$ ]] || [[ "$2" -le 0 ]]; then
+                    error "--days must be a positive integer, got: \"$2\""
+                    exit 1
+                fi
                 days="$2"
                 shift 2
                 ;;

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -56,17 +56,8 @@ main() {
     done
 
     # Load review root path from config
-    local review_root="${HOME}/dev/ai/reviews"
-    local config_file=""
-    if [[ -f "${HOME}/.claude/skills/review-code/.env" ]]; then
-        config_file="${HOME}/.claude/skills/review-code/.env"
-    elif [[ -f "${HOME}/.claude/review-code.env" ]]; then
-        config_file="${HOME}/.claude/review-code.env"
-    fi
-    if [[ -n "${config_file}" ]]; then
-        load_config_safely "${config_file}"
-        review_root="${REVIEW_ROOT_PATH:-${HOME}/dev/ai/reviews}"
-    fi
+    local review_root
+    review_root=$(get_review_root)
 
     # Ensure learnings directory exists
     mkdir -p "${LEARNINGS_DIR}"

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -128,8 +128,7 @@ main() {
         local pr_data
         pr_data=$(gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
 
-        local pr_state pr_merged_at
-        pr_state=$(echo "${pr_data}" | jq -r '.state')
+        local pr_merged_at
         pr_merged_at=$(echo "${pr_data}" | jq -r '.merged_at // empty')
 
         # Skip if not merged

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -27,11 +27,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source helpers
+# Source helpers (error-helpers first, then alphabetical)
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
-source "${SCRIPT_DIR}/helpers/git-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 source "${SCRIPT_DIR}/helpers/date-helpers.sh"
+source "${SCRIPT_DIR}/helpers/git-helpers.sh"
 
 main() {
     local pr_identifier="${1:-}"

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# learn-from-pr.sh - Cross-reference engine for learning from PR outcomes
+#
+# Usage:
+#   learn-from-pr.sh <pr_number> [--org ORG] [--repo REPO]
+#   learn-from-pr.sh <pr_url>
+#
+# Description:
+#   Analyzes a PR's final state to learn from review outcomes:
+#   1. Loads Claude's review notes from ~/dev/ai/reviews/{org}/{repo}/pr-{number}.md
+#   2. Fetches GitHub review comments (changes requested / resolved threads)
+#   3. Gets commit history after reviews were posted
+#   4. Cross-references to determine outcomes
+#
+# Output:
+#   JSON with cross-reference results:
+#   {
+#     "pr_number": 123,
+#     "org": "posthog",
+#     "repo": "posthog",
+#     "claude_findings": [...],
+#     "other_findings": [...],
+#     "prompts_needed": [...]
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helpers
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+source "${SCRIPT_DIR}/helpers/git-helpers.sh"
+source "${SCRIPT_DIR}/helpers/config-helpers.sh"
+
+main() {
+    local pr_identifier="${1:-}"
+    local org=""
+    local repo=""
+
+    if [[ -z "${pr_identifier}" ]]; then
+        error "Usage: learn-from-pr.sh <pr_number> [--org ORG] [--repo REPO]"
+        exit 1
+    fi
+
+    # Parse arguments
+    shift
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --org)
+                org="$2"
+                shift 2
+                ;;
+            --repo)
+                repo="$2"
+                shift 2
+                ;;
+            *)
+                error "Unknown argument: $1"
+                exit 1
+                ;;
+        esac
+    done
+
+    # Extract PR number from URL if needed
+    local pr_number
+    if [[ "${pr_identifier}" =~ ^https://github.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        org="${BASH_REMATCH[1]}"
+        repo="${BASH_REMATCH[2]}"
+        pr_number="${BASH_REMATCH[3]}"
+    elif [[ "${pr_identifier}" =~ ^[0-9]+$ ]]; then
+        pr_number="${pr_identifier}"
+    else
+        error "Invalid PR identifier: ${pr_identifier}"
+        exit 1
+    fi
+
+    # Get org/repo from git if not provided
+    if [[ -z "${org}" ]] || [[ -z "${repo}" ]]; then
+        if git rev-parse --git-dir > /dev/null 2>&1; then
+            local git_data
+            git_data=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
+            org="${org:-${git_data%|*}}"
+            repo="${repo:-${git_data#*|}}"
+        else
+            error "Not in a git repository and --org/--repo not provided"
+            exit 1
+        fi
+    fi
+
+    # Load review root path from config
+    local review_root="${HOME}/dev/ai/reviews"
+    local config_file=""
+    if [[ -f "${HOME}/.claude/skills/review-code/.env" ]]; then
+        config_file="${HOME}/.claude/skills/review-code/.env"
+    elif [[ -f "${HOME}/.claude/review-code.env" ]]; then
+        config_file="${HOME}/.claude/review-code.env"
+    fi
+    if [[ -n "${config_file}" ]]; then
+        load_config_safely "${config_file}"
+        review_root="${REVIEW_ROOT_PATH:-${HOME}/dev/ai/reviews}"
+    fi
+
+    # Check for review file
+    local review_file="${review_root}/${org}/${repo}/pr-${pr_number}.md"
+    if [[ ! -f "${review_file}" ]]; then
+        error "No review file found: ${review_file}"
+        error "Run '/review-code ${pr_number}' first to create a review"
+        exit 1
+    fi
+
+    # Parse Claude's findings from review file
+    local claude_findings
+    claude_findings=$("${SCRIPT_DIR}/parse-review-findings.sh" "${review_file}")
+
+    # Fetch PR data from GitHub
+    local pr_data
+    pr_data=$(gh pr view "${pr_number}" --repo "${org}/${repo}" --json number,title,state,mergedAt,createdAt,commits,files,reviews 2> /dev/null) || {
+        error "Failed to fetch PR data from GitHub"
+        exit 1
+    }
+
+    local pr_state
+    pr_state=$(echo "${pr_data}" | jq -r '.state')
+    local pr_merged_at
+    pr_merged_at=$(echo "${pr_data}" | jq -r '.mergedAt // empty')
+
+    # Fetch review comments with threads
+    local review_comments
+    review_comments=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/comments" --jq '
+        [.[] | {
+            id: .id,
+            path: .path,
+            line: .line,
+            body: .body,
+            author: .user.login,
+            created_at: .created_at,
+            in_reply_to_id: .in_reply_to_id
+        }]
+    ' 2> /dev/null || echo "[]")
+
+    # Fetch reviews (approve, request changes, comment)
+    local reviews
+    reviews=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/reviews" --jq '
+        [.[] | select(.state != "PENDING") | {
+            id: .id,
+            author: .user.login,
+            state: .state,
+            body: .body,
+            submitted_at: .submitted_at
+        }]
+    ' 2> /dev/null || echo "[]")
+
+    # Get commits after the review was created
+    # Find the earliest review timestamp
+    local review_file_mtime
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        review_file_mtime=$(stat -f '%m' "${review_file}")
+    else
+        review_file_mtime=$(stat -c '%Y' "${review_file}")
+    fi
+    local review_file_date
+    review_file_date=$(date -r "${review_file_mtime}" -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null || date -d "@${review_file_mtime}" -u +"%Y-%m-%dT%H:%M:%SZ" 2> /dev/null)
+
+    # Get commits on the PR
+    local pr_commits
+    pr_commits=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/commits" --jq '
+        [.[] | {
+            sha: .sha,
+            message: .commit.message,
+            date: .commit.committer.date,
+            files: []
+        }]
+    ' 2> /dev/null || echo "[]")
+
+    # Get the list of files changed in commits after the review
+    local files_changed_after_review="[]"
+    while IFS= read -r commit_json; do
+        local commit_sha commit_date
+        commit_sha=$(echo "${commit_json}" | jq -r '.sha')
+        commit_date=$(echo "${commit_json}" | jq -r '.date')
+
+        # Check if commit is after review file creation
+        if [[ "${commit_date}" > "${review_file_date}" ]]; then
+            # Get files changed in this commit
+            local commit_files
+            commit_files=$(gh api "repos/${org}/${repo}/commits/${commit_sha}" --jq '[.files[].filename]' 2> /dev/null || echo "[]")
+            files_changed_after_review=$(echo "${files_changed_after_review}" | jq --argjson files "${commit_files}" '. + $files | unique')
+        fi
+    done < <(echo "${pr_commits}" | jq -c '.[]')
+
+    # Cross-reference Claude's findings with commit history
+    local claude_results="[]"
+    while IFS= read -r finding_json; do
+        local finding_file finding_line finding_desc finding_agent finding_conf
+        finding_file=$(echo "${finding_json}" | jq -r '.file')
+        finding_line=$(echo "${finding_json}" | jq -r '.line')
+        finding_desc=$(echo "${finding_json}" | jq -r '.description')
+        finding_agent=$(echo "${finding_json}" | jq -r '.agent')
+        finding_conf=$(echo "${finding_json}" | jq -r '.confidence')
+
+        # Check if this file was modified after the review
+        local was_addressed="unknown"
+        if echo "${files_changed_after_review}" | jq -e --arg f "${finding_file}" 'index($f) != null' > /dev/null 2>&1; then
+            was_addressed="likely"
+        else
+            was_addressed="not_modified"
+        fi
+
+        claude_results=$(echo "${claude_results}" | jq --argjson finding "${finding_json}" \
+            --arg addressed "${was_addressed}" \
+            '. + [($finding + {addressed: $addressed})]')
+    done < <(echo "${claude_findings}" | jq -c '.[]')
+
+    # Extract findings from other reviewers
+    local other_findings="[]"
+    while IFS= read -r comment_json; do
+        local comment_path comment_line comment_body comment_author
+        comment_path=$(echo "${comment_json}" | jq -r '.path // empty')
+        comment_line=$(echo "${comment_json}" | jq -r '.line // 0')
+        comment_body=$(echo "${comment_json}" | jq -r '.body // empty')
+        comment_author=$(echo "${comment_json}" | jq -r '.author // empty')
+
+        # Skip comments without file paths (general PR comments)
+        [[ -z "${comment_path}" ]] && continue
+
+        # Check if file was modified after this comment
+        local was_addressed="unknown"
+        if echo "${files_changed_after_review}" | jq -e --arg f "${comment_path}" 'index($f) != null' > /dev/null 2>&1; then
+            was_addressed="likely"
+        else
+            was_addressed="not_modified"
+        fi
+
+        # Check if Claude caught this (same file, within 10 lines)
+        local claude_caught="false"
+        while IFS= read -r claude_finding; do
+            local cf_file cf_line
+            cf_file=$(echo "${claude_finding}" | jq -r '.file')
+            cf_line=$(echo "${claude_finding}" | jq -r '.line')
+
+            if [[ "${cf_file}" == "${comment_path}" ]]; then
+                local line_diff=$((comment_line - cf_line))
+                if [[ ${line_diff#-} -le 10 ]]; then
+                    claude_caught="true"
+                    break
+                fi
+            fi
+        done < <(echo "${claude_findings}" | jq -c '.[]')
+
+        other_findings=$(echo "${other_findings}" | jq \
+            --arg path "${comment_path}" \
+            --arg line "${comment_line}" \
+            --arg body "${comment_body}" \
+            --arg author "${comment_author}" \
+            --arg addressed "${was_addressed}" \
+            --arg claude_caught "${claude_caught}" \
+            '. + [{
+                file: $path,
+                line: ($line | tonumber),
+                description: $body,
+                author: $author,
+                addressed: $addressed,
+                claude_caught: ($claude_caught == "true")
+            }]')
+    done < <(echo "${review_comments}" | jq -c '.[]')
+
+    # Determine which findings need user prompts
+    local prompts_needed="[]"
+
+    # Claude findings that weren't addressed - ask if false positive
+    while IFS= read -r finding_json; do
+        local addressed
+        addressed=$(echo "${finding_json}" | jq -r '.addressed')
+        if [[ "${addressed}" == "not_modified" ]]; then
+            prompts_needed=$(echo "${prompts_needed}" | jq --argjson finding "${finding_json}" \
+                '. + [{type: "unaddressed", finding: $finding}]')
+        fi
+    done < <(echo "${claude_results}" | jq -c '.[]')
+
+    # Other reviewer findings that Claude missed - ask if should learn
+    while IFS= read -r finding_json; do
+        local claude_caught addressed
+        claude_caught=$(echo "${finding_json}" | jq -r '.claude_caught')
+        addressed=$(echo "${finding_json}" | jq -r '.addressed')
+        if [[ "${claude_caught}" == "false" ]] && [[ "${addressed}" == "likely" ]]; then
+            prompts_needed=$(echo "${prompts_needed}" | jq --argjson finding "${finding_json}" \
+                '. + [{type: "missed", finding: $finding}]')
+        fi
+    done < <(echo "${other_findings}" | jq -c '.[]')
+
+    # Build final output
+    jq -n \
+        --arg pr_number "${pr_number}" \
+        --arg org "${org}" \
+        --arg repo "${repo}" \
+        --arg state "${pr_state}" \
+        --arg merged_at "${pr_merged_at}" \
+        --arg review_file "${review_file}" \
+        --argjson claude_findings "${claude_results}" \
+        --argjson other_findings "${other_findings}" \
+        --argjson prompts_needed "${prompts_needed}" \
+        --argjson files_changed "${files_changed_after_review}" \
+        '{
+            pr_number: ($pr_number | tonumber),
+            org: $org,
+            repo: $repo,
+            state: $state,
+            merged_at: (if $merged_at == "" then null else $merged_at end),
+            review_file: $review_file,
+            claude_findings: $claude_findings,
+            other_findings: $other_findings,
+            prompts_needed: $prompts_needed,
+            files_changed_after_review: $files_changed,
+            summary: {
+                claude_total: ($claude_findings | length),
+                claude_addressed: ([$claude_findings[] | select(.addressed == "likely")] | length),
+                claude_not_addressed: ([$claude_findings[] | select(.addressed == "not_modified")] | length),
+                other_total: ($other_findings | length),
+                other_caught_by_claude: ([$other_findings[] | select(.claude_caught == true)] | length),
+                other_missed_by_claude: ([$other_findings[] | select(.claude_caught == false)] | length)
+            }
+        }'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -129,18 +129,6 @@ main() {
         }]
     ' 2> /dev/null || echo "[]")
 
-    # Fetch reviews (approve, request changes, comment)
-    local reviews
-    reviews=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/reviews" --jq '
-        [.[] | select(.state != "PENDING") | {
-            id: .id,
-            author: .user.login,
-            state: .state,
-            body: .body,
-            submitted_at: .submitted_at
-        }]
-    ' 2> /dev/null || echo "[]")
-
     # Get commits after the review was created
     # Find the earliest review timestamp
     local review_file_mtime

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -169,12 +169,8 @@ main() {
     # Cross-reference Claude's findings with commit history
     local claude_results="[]"
     while IFS= read -r finding_json; do
-        local finding_file finding_line finding_desc finding_agent finding_conf
+        local finding_file
         finding_file=$(echo "${finding_json}" | jq -r '.file')
-        finding_line=$(echo "${finding_json}" | jq -r '.line')
-        finding_desc=$(echo "${finding_json}" | jq -r '.description')
-        finding_agent=$(echo "${finding_json}" | jq -r '.agent')
-        finding_conf=$(echo "${finding_json}" | jq -r '.confidence')
 
         # Check if this file was modified after the review
         local was_addressed="unknown"

--- a/skills/review-code/scripts/learn-orchestrator.sh
+++ b/skills/review-code/scripts/learn-orchestrator.sh
@@ -30,32 +30,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 
-# Output JSON result
-output_json() {
-    local status="$1"
-    shift
-    local json="{\"status\":\"${status}\""
-
-    # Add key-value pairs
-    while [[ $# -ge 2 ]]; do
-        local key="$1"
-        local value="$2"
-        shift 2
-
-        # Check if value is already JSON (starts with { or [)
-        if [[ "${value}" =~ ^[\{\[] ]]; then
-            json="${json},\"${key}\":${value}"
-        else
-            # Escape the value for JSON
-            value=$(echo "${value}" | jq -Rs '.')
-            json="${json},\"${key}\":${value}"
-        fi
-    done
-
-    json="${json}}"
-    echo "${json}"
-}
-
 # Output JSON error
 output_error() {
     local message="$1"

--- a/skills/review-code/scripts/learn-orchestrator.sh
+++ b/skills/review-code/scripts/learn-orchestrator.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source helpers
+# Source helpers (error-helpers first, then alphabetical)
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 

--- a/skills/review-code/scripts/learn-orchestrator.sh
+++ b/skills/review-code/scripts/learn-orchestrator.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# learn-orchestrator.sh - Orchestrates learn mode workflow
+#
+# Usage:
+#   learn-orchestrator.sh <submode> [arguments]
+#
+# Submodes:
+#   single <pr_number> [--org ORG] [--repo REPO]
+#     Analyze outcomes of a specific PR
+#
+#   batch [--limit N]
+#     Find and list unanalyzed PRs with existing reviews
+#
+#   apply [--threshold N]
+#     Synthesize learnings into context file proposals
+#
+# Description:
+#   Handles all learn mode workflow orchestration:
+#   - Coordinates the learn-from-pr.sh, learn-batch.sh, and learn-apply.sh scripts
+#   - Outputs structured JSON for Claude to process interactively
+#
+# Output:
+#   JSON object with status and data for Claude to handle user interaction
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source helpers
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+source "${SCRIPT_DIR}/helpers/config-helpers.sh"
+
+# Output JSON result
+output_json() {
+    local status="$1"
+    shift
+    local json="{\"status\":\"${status}\""
+
+    # Add key-value pairs
+    while [[ $# -ge 2 ]]; do
+        local key="$1"
+        local value="$2"
+        shift 2
+
+        # Check if value is already JSON (starts with { or [)
+        if [[ "${value}" =~ ^[\{\[] ]]; then
+            json="${json},\"${key}\":${value}"
+        else
+            # Escape the value for JSON
+            value=$(echo "${value}" | jq -Rs '.')
+            json="${json},\"${key}\":${value}"
+        fi
+    done
+
+    json="${json}}"
+    echo "${json}"
+}
+
+# Output JSON error
+output_error() {
+    local message="$1"
+    jq -n --arg msg "${message}" '{"status":"error","error":$msg}'
+}
+
+# Handle single PR analysis
+handle_single() {
+    local pr_number=""
+    local org=""
+    local repo=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --org)
+                org="$2"
+                shift 2
+                ;;
+            --repo)
+                repo="$2"
+                shift 2
+                ;;
+            *)
+                if [[ -z "${pr_number}" ]]; then
+                    pr_number="$1"
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [[ -z "${pr_number}" ]]; then
+        output_error "PR number required for single mode"
+        exit 1
+    fi
+
+    # Build arguments for learn-from-pr.sh
+    local args=("${pr_number}")
+    [[ -n "${org}" ]] && args+=("--org" "${org}")
+    [[ -n "${repo}" ]] && args+=("--repo" "${repo}")
+
+    # Run the analysis
+    local learn_data
+    if ! learn_data=$("${SCRIPT_DIR}/learn-from-pr.sh" "${args[@]}" 2>&1); then
+        output_error "Failed to analyze PR #${pr_number}: ${learn_data}"
+        exit 1
+    fi
+
+    # Check if it's an error response
+    if echo "${learn_data}" | jq -e '.error' > /dev/null 2>&1; then
+        local err_msg
+        err_msg=$(echo "${learn_data}" | jq -r '.error')
+        output_error "${err_msg}"
+        exit 1
+    fi
+
+    # Extract summary for display
+    local summary
+    summary=$(echo "${learn_data}" | jq '{
+        pr_number: .pr_number,
+        org: .org,
+        repo: .repo,
+        claude_total: .summary.claude_total,
+        claude_addressed: .summary.claude_addressed,
+        claude_not_addressed: .summary.claude_not_addressed,
+        other_total: .summary.other_total,
+        other_caught_by_claude: .summary.other_caught_by_claude,
+        other_missed_by_claude: .summary.other_missed_by_claude,
+        prompts_count: (.prompts_needed | length)
+    }')
+
+    # Output structured result
+    jq -n \
+        --arg status "ready" \
+        --argjson summary "${summary}" \
+        --argjson learn_data "${learn_data}" \
+        '{
+            status: $status,
+            submode: "single",
+            summary: $summary,
+            learn_data: $learn_data
+        }'
+}
+
+# Handle batch mode
+handle_batch() {
+    local limit=5
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --limit)
+                limit="$2"
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    # Find unanalyzed PRs
+    local unanalyzed
+    if ! unanalyzed=$("${SCRIPT_DIR}/learn-batch.sh" --limit "${limit}" 2>&1); then
+        output_error "Failed to find unanalyzed PRs: ${unanalyzed}"
+        exit 1
+    fi
+
+    # Check if it's an error response
+    if echo "${unanalyzed}" | jq -e '.error' > /dev/null 2>&1; then
+        local err_msg
+        err_msg=$(echo "${unanalyzed}" | jq -r '.error')
+        output_error "${err_msg}"
+        exit 1
+    fi
+
+    local count
+    count=$(echo "${unanalyzed}" | jq 'length')
+
+    # Output structured result
+    jq -n \
+        --arg status "ready" \
+        --argjson count "${count}" \
+        --argjson prs "${unanalyzed}" \
+        '{
+            status: $status,
+            submode: "batch",
+            count: $count,
+            prs: $prs
+        }'
+}
+
+# Handle apply mode
+handle_apply() {
+    local threshold=3
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --threshold)
+                threshold="$2"
+                shift 2
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+
+    # Get proposals
+    local proposals
+    if ! proposals=$("${SCRIPT_DIR}/learn-apply.sh" --threshold "${threshold}" 2>&1); then
+        output_error "Failed to generate proposals: ${proposals}"
+        exit 1
+    fi
+
+    # Check if it's an error response
+    if echo "${proposals}" | jq -e '.error' > /dev/null 2>&1; then
+        local err_msg
+        err_msg=$(echo "${proposals}" | jq -r '.error')
+        output_error "${err_msg}"
+        exit 1
+    fi
+
+    local actionable
+    actionable=$(echo "${proposals}" | jq '.summary.actionable_proposals')
+
+    # Output structured result
+    jq -n \
+        --arg status "ready" \
+        --argjson actionable "${actionable}" \
+        --argjson proposals "${proposals}" \
+        '{
+            status: $status,
+            submode: "apply",
+            actionable: $actionable,
+            proposals: $proposals
+        }'
+}
+
+# Main function
+main() {
+    local submode="${1:-}"
+
+    if [[ -z "${submode}" ]]; then
+        output_error "Submode required: single, batch, or apply"
+        exit 1
+    fi
+
+    shift
+
+    case "${submode}" in
+        single)
+            handle_single "$@"
+            ;;
+        batch)
+            handle_batch "$@"
+            ;;
+        apply)
+            handle_apply "$@"
+            ;;
+        *)
+            output_error "Unknown submode: ${submode}. Use single, batch, or apply."
+            exit 1
+            ;;
+    esac
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/learn-orchestrator.sh
+++ b/skills/review-code/scripts/learn-orchestrator.sh
@@ -26,9 +26,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Source helpers (error-helpers first, then alphabetical)
+# Source helpers
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
-source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 
 # Output JSON error
 output_error() {

--- a/skills/review-code/scripts/load-review-context.sh
+++ b/skills/review-code/scripts/load-review-context.sh
@@ -30,11 +30,11 @@
 set -euo pipefail
 
 # Source debug helpers
-SCRIPT_DIR_EARLY="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/helpers/debug-helpers.sh
-source "${SCRIPT_DIR_EARLY}/helpers/debug-helpers.sh"
+source "${SCRIPT_DIR}/helpers/debug-helpers.sh"
 # shellcheck source=lib/helpers/config-helpers.sh
-source "${SCRIPT_DIR_EARLY}/helpers/config-helpers.sh"
+source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 
 debug_time "04-context-loading" "start"
 
@@ -53,8 +53,7 @@ if [[ -n "${CONFIG_FILE}" ]]; then
     load_config_safely "${CONFIG_FILE}"
 fi
 
-# Get the directory where this script lives and derive context directory
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Derive context directory from script location
 REVIEW_CODE_DIR="$(dirname "${SCRIPT_DIR}")"
 
 # Use CONTEXT_PATH from (1) external env, (2) config file, or (3) relative path

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -41,7 +41,8 @@ if [[ "${arg}" == "find" ]]; then
 fi
 
 # Check for 'learn' mode - if present, shift remaining args
-if [[ "${arg}" == "learn" ]]; then
+# Note: Don't activate learn mode if find mode is already active (handles 'find learn' collision)
+if [[ "${arg}" == "learn" ]] && [[ "${FIND_MODE}" != "true" ]]; then
     LEARN_MODE="true"
     arg="${remaining_args[1]:-}"
     file_pattern="${remaining_args[2]:-}"

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# parse-review-findings.sh - Extract structured findings from review markdown files
+#
+# Usage:
+#   parse-review-findings.sh <review-file-path>
+#
+# Description:
+#   Parses a code review markdown file and extracts structured findings.
+#   Looks for patterns like:
+#   - File:line references in headers: #### `path/to/file.py:123`
+#   - Confidence markers: [Security 85%], (75% confidence)
+#   - Agent section headers: ## Security Review, ## Performance Review
+#
+# Output:
+#   JSON array of findings:
+#   [
+#     {
+#       "agent": "security",
+#       "confidence": 85,
+#       "file": "auth.py",
+#       "line": 45,
+#       "description": "SQL injection risk"
+#     }
+#   ]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source error helpers
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+
+main() {
+    local review_file="${1:-}"
+
+    if [[ -z "${review_file}" ]]; then
+        error "Usage: parse-review-findings.sh <review-file-path>"
+        exit 1
+    fi
+
+    if [[ ! -f "${review_file}" ]]; then
+        error "Review file not found: ${review_file}"
+        exit 1
+    fi
+
+    # Parse the review file and extract findings
+    local findings="[]"
+    local current_agent=""
+    local current_confidence=""
+    local in_finding=false
+    local finding_file=""
+    local finding_line=""
+    local finding_description=""
+
+    while IFS= read -r line || [[ -n "${line}" ]]; do
+        # Detect agent section headers (## Security Review, ## Performance Review, etc.)
+        if [[ "${line}" =~ ^##[[:space:]]+(Security|Performance|Correctness|Maintainability|Testing|Compatibility|Architecture|Frontend)[[:space:]]+Review ]]; then
+            # Save any pending finding before switching sections
+            if [[ "${in_finding}" == true ]] && [[ -n "${finding_file}" ]] && [[ -n "${finding_description}" ]]; then
+                finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+                findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+                    --arg conf "${current_confidence:-0}" \
+                    --arg file "${finding_file}" \
+                    --arg line "${finding_line}" \
+                    --arg desc "${finding_description}" \
+                    '. + [{
+                        agent: $agent,
+                        confidence: ($conf | tonumber),
+                        file: $file,
+                        line: ($line | tonumber),
+                        description: $desc
+                    }]')
+                in_finding=false
+            fi
+            current_agent=$(echo "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+            finding_file=""
+            finding_line=""
+            finding_description=""
+            current_confidence=""
+            continue
+        fi
+
+        # Detect file:line reference patterns
+        # Pattern 1: #### `path/to/file.py:123`
+        if [[ "${line}" =~ ^\#{3,4}[[:space:]]+\`([^:]+):([0-9]+)\` ]]; then
+            # Save previous finding if exists
+            if [[ "${in_finding}" == true ]] && [[ -n "${finding_file}" ]] && [[ -n "${finding_description}" ]]; then
+                finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+                findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+                    --arg conf "${current_confidence:-0}" \
+                    --arg file "${finding_file}" \
+                    --arg line "${finding_line}" \
+                    --arg desc "${finding_description}" \
+                    '. + [{
+                        agent: $agent,
+                        confidence: ($conf | tonumber),
+                        file: $file,
+                        line: ($line | tonumber),
+                        description: $desc
+                    }]')
+            fi
+
+            finding_file="${BASH_REMATCH[1]}"
+            finding_line="${BASH_REMATCH[2]}"
+            finding_description=""
+            current_confidence=""
+            in_finding=true
+            continue
+        fi
+
+        # Pattern 2: - **`path/to/file.py:123`**: description
+        if [[ "${line}" =~ ^-[[:space:]]+\*\*\`([^:]+):([0-9]+)\`\*\*:[[:space:]]*(.*)$ ]]; then
+            # Save previous finding if needed
+            if [[ "${in_finding}" == true ]] && [[ -n "${finding_file}" ]] && [[ -n "${finding_description}" ]]; then
+                finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+                findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+                    --arg conf "${current_confidence:-0}" \
+                    --arg file "${finding_file}" \
+                    --arg line "${finding_line}" \
+                    --arg desc "${finding_description}" \
+                    '. + [{
+                        agent: $agent,
+                        confidence: ($conf | tonumber),
+                        file: $file,
+                        line: ($line | tonumber),
+                        description: $desc
+                    }]')
+            fi
+
+            finding_file="${BASH_REMATCH[1]}"
+            finding_line="${BASH_REMATCH[2]}"
+            finding_description="${BASH_REMATCH[3]}"
+
+            # Check for confidence in the description
+            if [[ "${finding_description}" =~ \[([0-9]+)%\] ]] || [[ "${finding_description}" =~ \(([0-9]+)%[[:space:]]*confidence\) ]]; then
+                current_confidence="${BASH_REMATCH[1]}"
+            fi
+
+            # This pattern includes the description inline, so save it immediately
+            finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+            findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+                --arg conf "${current_confidence:-0}" \
+                --arg file "${finding_file}" \
+                --arg line "${finding_line}" \
+                --arg desc "${finding_description}" \
+                '. + [{
+                    agent: $agent,
+                    confidence: ($conf | tonumber),
+                    file: $file,
+                    line: ($line | tonumber),
+                    description: $desc
+                }]')
+
+            finding_file=""
+            finding_line=""
+            finding_description=""
+            current_confidence=""
+            in_finding=false
+            continue
+        fi
+
+        # Pattern 3: [Agent 85%] description (file.py:123)
+        if [[ "${line}" =~ \[(Security|Performance|Correctness|Maintainability|Testing|Compatibility|Architecture|Frontend)[[:space:]]+([0-9]+)%\][[:space:]]+(.+)[[:space:]]+\(([^:]+):([0-9]+)\) ]]; then
+            # Save previous finding if needed
+            if [[ "${in_finding}" == true ]] && [[ -n "${finding_file}" ]] && [[ -n "${finding_description}" ]]; then
+                finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+                findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+                    --arg conf "${current_confidence:-0}" \
+                    --arg file "${finding_file}" \
+                    --arg line "${finding_line}" \
+                    --arg desc "${finding_description}" \
+                    '. + [{
+                        agent: $agent,
+                        confidence: ($conf | tonumber),
+                        file: $file,
+                        line: ($line | tonumber),
+                        description: $desc
+                    }]')
+            fi
+
+            local agent_name
+            agent_name=$(echo "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')
+            current_confidence="${BASH_REMATCH[2]}"
+            finding_description="${BASH_REMATCH[3]}"
+            finding_file="${BASH_REMATCH[4]}"
+            finding_line="${BASH_REMATCH[5]}"
+
+            # Save this finding immediately (inline pattern)
+            finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+            findings=$(echo "${findings}" | jq --arg agent "${agent_name}" \
+                --arg conf "${current_confidence}" \
+                --arg file "${finding_file}" \
+                --arg line "${finding_line}" \
+                --arg desc "${finding_description}" \
+                '. + [{
+                    agent: $agent,
+                    confidence: ($conf | tonumber),
+                    file: $file,
+                    line: ($line | tonumber),
+                    description: $desc
+                }]')
+
+            finding_file=""
+            finding_line=""
+            finding_description=""
+            current_confidence=""
+            in_finding=false
+            continue
+        fi
+
+        # Detect confidence markers in current context
+        if [[ "${line}" =~ \[([0-9]+)%\] ]] || [[ "${line}" =~ \(([0-9]+)%[[:space:]]*confidence\) ]]; then
+            current_confidence="${BASH_REMATCH[1]}"
+        fi
+
+        # Accumulate description lines when in a finding (skip empty lines and headers)
+        if [[ "${in_finding}" == true ]] && [[ -n "${line}" ]] && [[ ! "${line}" =~ ^# ]]; then
+            # Skip confidence-only lines
+            if [[ "${line}" =~ ^\[([0-9]+)%\]$ ]] || [[ "${line}" =~ ^\(([0-9]+)%[[:space:]]*confidence\)$ ]]; then
+                continue
+            fi
+            if [[ -n "${finding_description}" ]]; then
+                finding_description="${finding_description} ${line}"
+            else
+                finding_description="${line}"
+            fi
+        fi
+    done < "${review_file}"
+
+    # Handle any remaining finding at end of file
+    if [[ "${in_finding}" == true ]] && [[ -n "${finding_file}" ]] && [[ -n "${finding_description}" ]]; then
+        finding_description=$(echo "${finding_description}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+        findings=$(echo "${findings}" | jq --arg agent "${current_agent:-unknown}" \
+            --arg conf "${current_confidence:-0}" \
+            --arg file "${finding_file}" \
+            --arg line "${finding_line}" \
+            --arg desc "${finding_description}" \
+            '. + [{
+                agent: $agent,
+                confidence: ($conf | tonumber),
+                file: $file,
+                line: ($line | tonumber),
+                description: $desc
+            }]')
+    fi
+
+    echo "${findings}"
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/review-file-path.sh
+++ b/skills/review-code/scripts/review-file-path.sh
@@ -297,19 +297,9 @@ main() {
         fi
     fi
 
-    # Load review root path from config, default to ~/dev/ai/reviews
-    # Check new location first, fall back to old location for backward compatibility
-    local review_root="${HOME}/dev/ai/reviews"
-    local config_file=""
-    if [[ -f "${HOME}/.claude/skills/review-code/.env" ]]; then
-        config_file="${HOME}/.claude/skills/review-code/.env"
-    elif [[ -f "${HOME}/.claude/review-code.env" ]]; then
-        config_file="${HOME}/.claude/review-code.env"
-    fi
-    if [[ -n "${config_file}" ]]; then
-        load_config_safely "${config_file}"
-        review_root="${REVIEW_ROOT_PATH:-${HOME}/dev/ai/reviews}"
-    fi
+    # Load review root path from config
+    local review_root
+    review_root=$(get_review_root)
 
     # Resolve review_root to canonical path to handle symlinks consistently
     # Create the directory if it doesn't exist (needed for canonical resolution)

--- a/tests/unit/test-learn-apply.bats
+++ b/tests/unit/test-learn-apply.bats
@@ -1,0 +1,340 @@
+#!/usr/bin/env bats
+# Tests for learn-apply.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create temporary directory for testing
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+
+    # Create mock learnings directory structure
+    MOCK_LEARNINGS_DIR="$TEST_DIR/learnings"
+    mkdir -p "$MOCK_LEARNINGS_DIR"
+    export MOCK_LEARNINGS_DIR
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# Helper to create a learning entry
+create_learning() {
+    local type="$1"
+    local language="$2"
+    local framework="${3:-null}"
+    local description="${4:-Test finding}"
+
+    if [[ "$framework" == "null" ]]; then
+        cat << EOF
+{"type":"$type","context":{"language":"$language"},"finding":{"description":"$description"}}
+EOF
+    else
+        cat << EOF
+{"type":"$type","context":{"language":"$language","framework":"$framework"},"finding":{"description":"$description"}}
+EOF
+    fi
+}
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+@test "learn-apply.sh: exists and is executable" {
+    [ -x "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" ]
+}
+
+@test "learn-apply.sh: can be sourced without executing main" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh' && echo 'sourced ok'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sourced ok"* ]]
+}
+
+# =============================================================================
+# Argument validation tests
+# =============================================================================
+
+@test "learn-apply.sh: rejects unknown arguments" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+@test "learn-apply.sh: --threshold requires a value" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" --threshold
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Missing value"* ]]
+}
+
+@test "learn-apply.sh: --threshold must be a positive integer" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" --threshold abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-apply.sh: --threshold rejects zero" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" --threshold 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-apply.sh: --threshold rejects negative numbers" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh" --threshold -3
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-apply.sh: accepts valid --threshold" {
+    # Create empty learnings file
+    touch "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    # Override SCRIPT_DIR to use mock learnings
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        mkdir -p '$TEST_DIR/../learnings'
+        touch '$TEST_DIR/../learnings/index.jsonl'
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 5
+    "
+    [[ "$output" != *"positive integer"* ]]
+}
+
+# =============================================================================
+# Empty/missing learnings tests
+# =============================================================================
+
+@test "learn-apply.sh: returns empty proposals when no learnings file exists" {
+    # Don't create index.jsonl
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals | length == 0' > /dev/null
+    echo "$output" | jq -e '.summary.total_learnings == 0' > /dev/null
+}
+
+@test "learn-apply.sh: returns empty proposals when learnings file is empty" {
+    touch "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals | length == 0' > /dev/null
+    echo "$output" | jq -e '.summary.total_learnings == 0' > /dev/null
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "learn-apply.sh: produces valid JSON output" {
+    touch "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq . > /dev/null
+    echo "$output" | jq -e 'has("proposals")' > /dev/null
+    echo "$output" | jq -e 'has("summary")' > /dev/null
+}
+
+@test "learn-apply.sh: summary contains required fields" {
+    touch "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.summary | has("total_learnings")' > /dev/null
+    echo "$output" | jq -e '.summary | has("grouped_patterns")' > /dev/null
+    echo "$output" | jq -e '.summary | has("actionable_proposals")' > /dev/null
+}
+
+# =============================================================================
+# Grouping and threshold tests
+# =============================================================================
+
+@test "learn-apply.sh: groups learnings by type and language" {
+    # Create 3 false_positive learnings for python (should meet default threshold)
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 3" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.summary.grouped_patterns >= 1' > /dev/null
+}
+
+@test "learn-apply.sh: respects threshold for proposals" {
+    # Create only 2 learnings (below default threshold of 3)
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main
+    "
+    [ "$status" -eq 0 ]
+    # Should have no actionable proposals (below threshold)
+    echo "$output" | jq -e '.summary.actionable_proposals == 0' > /dev/null
+}
+
+@test "learn-apply.sh: custom threshold affects proposals" {
+    # Create 2 learnings
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    # Use threshold of 2
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    # Should have 1 actionable proposal now
+    echo "$output" | jq -e '.summary.actionable_proposals == 1' > /dev/null
+}
+
+# =============================================================================
+# Learning type handling tests
+# =============================================================================
+
+@test "learn-apply.sh: handles false_positive type" {
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].content | contains("False Positive")' > /dev/null
+}
+
+@test "learn-apply.sh: handles missed_pattern type" {
+    create_learning "missed_pattern" "javascript" "null" "Missed 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "missed_pattern" "javascript" "null" "Missed 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].content | contains("Patterns to Detect")' > /dev/null
+}
+
+@test "learn-apply.sh: handles valid_catch type" {
+    create_learning "valid_catch" "go" "null" "Valid 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "valid_catch" "go" "null" "Valid 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].content | contains("Validated Patterns")' > /dev/null
+}
+
+@test "learn-apply.sh: handles deferred type" {
+    create_learning "deferred" "rust" "null" "Deferred 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "deferred" "rust" "null" "Deferred 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].content | contains("Lower Priority")' > /dev/null
+}
+
+# =============================================================================
+# Target file determination tests
+# =============================================================================
+
+@test "learn-apply.sh: targets language file when no framework" {
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].target_file | contains("languages/python.md")' > /dev/null
+}
+
+@test "learn-apply.sh: targets framework file when framework specified" {
+    create_learning "false_positive" "python" "django" "Django FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "django" "Django FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0].target_file | contains("frameworks/django.md")' > /dev/null
+}
+
+# =============================================================================
+# sort_by before group_by test
+# =============================================================================
+
+@test "learn-apply.sh: groups non-consecutive learnings correctly" {
+    # Create learnings in non-sorted order to test sort_by before group_by
+    create_learning "false_positive" "python" "null" "Python FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "javascript" "null" "JS FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "Python FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    # Python should have 2 learnings grouped together (meeting threshold)
+    echo "$output" | jq -e '.summary.actionable_proposals == 1' > /dev/null
+    echo "$output" | jq -e '.proposals[0].learnings_count == 2' > /dev/null
+}
+
+# =============================================================================
+# Proposal content tests
+# =============================================================================
+
+@test "learn-apply.sh: proposal contains required fields" {
+    create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+    create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
+
+    SCRIPT_DIR="$TEST_DIR" run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
+        LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
+        main --threshold 2
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals[0] | has("target_file")' > /dev/null
+    echo "$output" | jq -e '.proposals[0] | has("section")' > /dev/null
+    echo "$output" | jq -e '.proposals[0] | has("content")' > /dev/null
+    echo "$output" | jq -e '.proposals[0] | has("learnings_count")' > /dev/null
+    echo "$output" | jq -e '.proposals[0] | has("learnings")' > /dev/null
+}

--- a/tests/unit/test-learn-apply.bats
+++ b/tests/unit/test-learn-apply.bats
@@ -86,13 +86,9 @@ EOF
 }
 
 @test "learn-apply.sh: accepts valid --threshold" {
-    # Create empty learnings file
     touch "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    # Override SCRIPT_DIR to use mock learnings
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
-        mkdir -p '$TEST_DIR/../learnings'
-        touch '$TEST_DIR/../learnings/index.jsonl'
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 5
@@ -106,7 +102,7 @@ EOF
 
 @test "learn-apply.sh: returns empty proposals when no learnings file exists" {
     # Don't create index.jsonl
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
@@ -119,7 +115,7 @@ EOF
 @test "learn-apply.sh: returns empty proposals when learnings file is empty" {
     touch "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
@@ -136,7 +132,7 @@ EOF
 @test "learn-apply.sh: produces valid JSON output" {
     touch "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
@@ -150,7 +146,7 @@ EOF
 @test "learn-apply.sh: summary contains required fields" {
     touch "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
@@ -176,8 +172,6 @@ EOF
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
     "
-    echo '# DEBUG status=' "$status" >&3
-    echo '# DEBUG output=' "$output" >&3
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.summary.grouped_patterns >= 1' > /dev/null
 }
@@ -187,7 +181,7 @@ EOF
     create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
@@ -203,7 +197,7 @@ EOF
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
     # Use threshold of 2
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -221,7 +215,7 @@ EOF
     create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -234,7 +228,7 @@ EOF
     create_learning "missed_pattern" "javascript" "null" "Missed 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "missed_pattern" "javascript" "null" "Missed 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -247,7 +241,7 @@ EOF
     create_learning "valid_catch" "go" "null" "Valid 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "valid_catch" "go" "null" "Valid 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -260,7 +254,7 @@ EOF
     create_learning "deferred" "rust" "null" "Deferred 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "deferred" "rust" "null" "Deferred 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -277,7 +271,7 @@ EOF
     create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -290,7 +284,7 @@ EOF
     create_learning "false_positive" "python" "django" "Django FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "django" "Django FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -309,7 +303,7 @@ EOF
     create_learning "false_positive" "javascript" "null" "JS FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "Python FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2
@@ -328,7 +322,7 @@ EOF
     create_learning "false_positive" "python" "null" "FP 1" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main --threshold 2

--- a/tests/unit/test-learn-apply.bats
+++ b/tests/unit/test-learn-apply.bats
@@ -171,11 +171,13 @@ EOF
     create_learning "false_positive" "python" "null" "FP 2" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
     create_learning "false_positive" "python" "null" "FP 3" >> "$MOCK_LEARNINGS_DIR/index.jsonl"
 
-    SCRIPT_DIR="$TEST_DIR" run bash -c "
+    run bash -c "
         source '$PROJECT_ROOT/skills/review-code/scripts/learn-apply.sh'
         LEARNINGS_DIR='$MOCK_LEARNINGS_DIR'
         main
     "
+    echo '# DEBUG status=' "$status" >&3
+    echo '# DEBUG output=' "$output" >&3
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.summary.grouped_patterns >= 1' > /dev/null
 }

--- a/tests/unit/test-learn-batch.bats
+++ b/tests/unit/test-learn-batch.bats
@@ -1,0 +1,265 @@
+#!/usr/bin/env bats
+# Tests for learn-batch.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create temporary directories for testing
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+
+    # Create mock review root directory
+    MOCK_REVIEW_ROOT="$TEST_DIR/reviews"
+    mkdir -p "$MOCK_REVIEW_ROOT"
+    export MOCK_REVIEW_ROOT
+
+    # Create mock learnings directory
+    MOCK_LEARNINGS_DIR="$TEST_DIR/learnings"
+    mkdir -p "$MOCK_LEARNINGS_DIR"
+    export MOCK_LEARNINGS_DIR
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+@test "learn-batch.sh: exists and is executable" {
+    [ -x "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" ]
+}
+
+@test "learn-batch.sh: can be sourced without executing main" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh' && echo 'sourced ok'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sourced ok"* ]]
+}
+
+# =============================================================================
+# Argument validation tests
+# =============================================================================
+
+@test "learn-batch.sh: rejects unknown arguments" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+@test "learn-batch.sh: --limit requires a value" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --limit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Missing value"* ]]
+}
+
+@test "learn-batch.sh: --days requires a value" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --days
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Missing value"* ]]
+}
+
+@test "learn-batch.sh: --limit must be a positive integer" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --limit abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: --limit rejects zero" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --limit 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: --limit rejects negative numbers" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --limit -5
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: --days must be a positive integer" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --days foo
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: --days rejects zero" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --days 0
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: accepts valid --limit" {
+    # This will fail later due to missing config, but argument parsing succeeds
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --limit 5
+    # Should not fail on argument parsing
+    [[ "$output" != *"positive integer"* ]]
+}
+
+@test "learn-batch.sh: accepts valid --days" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh" --days 14
+    [[ "$output" != *"positive integer"* ]]
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "learn-batch.sh: returns empty JSON array when no review root exists" {
+    # Create a config pointing to non-existent review root
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$TEST_DIR/nonexistent" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    # Override HOME to use our test config
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "learn-batch.sh: returns empty JSON array when no review files exist" {
+    # Create empty review root
+    mkdir -p "$MOCK_REVIEW_ROOT/testorg/testrepo"
+
+    # Create config pointing to our mock review root
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$MOCK_REVIEW_ROOT" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "learn-batch.sh: produces valid JSON output" {
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$MOCK_REVIEW_ROOT" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh"
+    [ "$status" -eq 0 ]
+    # Validate JSON
+    echo "$output" | jq . > /dev/null
+    echo "$output" | jq -e 'type == "array"' > /dev/null
+}
+
+# =============================================================================
+# PR file path parsing tests (using sourced functions)
+# =============================================================================
+
+@test "learn-batch.sh: extracts org from review file path" {
+    # Create a review file
+    mkdir -p "$MOCK_REVIEW_ROOT/myorg/myrepo"
+    echo "# Review" > "$MOCK_REVIEW_ROOT/myorg/myrepo/pr-123.md"
+
+    # Test that org extraction works
+    local review_file="$MOCK_REVIEW_ROOT/myorg/myrepo/pr-123.md"
+    local relative_path="${review_file#"$MOCK_REVIEW_ROOT/"}"
+    local org
+    org=$(echo "$relative_path" | cut -d'/' -f1)
+    [ "$org" = "myorg" ]
+}
+
+@test "learn-batch.sh: extracts repo from review file path" {
+    local review_file="$MOCK_REVIEW_ROOT/myorg/myrepo/pr-123.md"
+    local relative_path="${review_file#"$MOCK_REVIEW_ROOT/"}"
+    local repo
+    repo=$(echo "$relative_path" | cut -d'/' -f2)
+    [ "$repo" = "myrepo" ]
+}
+
+@test "learn-batch.sh: extracts PR number from filename" {
+    local filename="pr-456.md"
+    if [[ "$filename" =~ ^pr-([0-9]+)\.md$ ]]; then
+        local pr_number="${BASH_REMATCH[1]}"
+        [ "$pr_number" = "456" ]
+    else
+        fail "Pattern did not match"
+    fi
+}
+
+@test "learn-batch.sh: skips non-PR files" {
+    local filename="notes.md"
+    if [[ "$filename" =~ ^pr-([0-9]+)\.md$ ]]; then
+        fail "Should not match non-PR files"
+    fi
+}
+
+@test "learn-batch.sh: skips malformed PR files" {
+    local filename="pr-abc.md"
+    if [[ "$filename" =~ ^pr-([0-9]+)\.md$ ]]; then
+        fail "Should not match non-numeric PR"
+    fi
+}
+
+# =============================================================================
+# analyzed.json handling tests
+# =============================================================================
+
+@test "learn-batch.sh: handles missing analyzed.json gracefully" {
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$MOCK_REVIEW_ROOT" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    # Ensure no analyzed.json exists
+    rm -f "$MOCK_LEARNINGS_DIR/analyzed.json"
+
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-batch.sh"
+    [ "$status" -eq 0 ]
+}
+
+@test "learn-batch.sh: jq handles missing repo key in analyzed.json" {
+    # Test the fixed jq pattern with // {} fallback
+    local analyzed_data='{"other/repo": {"1": true}}'
+    local repo_key="missing/repo"
+    local pr_number="123"
+
+    # This should not error - the // {} handles missing keys
+    if echo "$analyzed_data" | jq -e --arg key "$repo_key" --arg pr "$pr_number" '(.[$key] // {})[$pr] != null' > /dev/null 2>&1; then
+        # Key was found (unexpected for missing key)
+        fail "Should not find missing repo key"
+    else
+        # Key was not found (expected)
+        true
+    fi
+}
+
+@test "learn-batch.sh: jq finds existing key in analyzed.json" {
+    local analyzed_data='{"existing/repo": {"456": true}}'
+    local repo_key="existing/repo"
+    local pr_number="456"
+
+    if echo "$analyzed_data" | jq -e --arg key "$repo_key" --arg pr "$pr_number" '(.[$key] // {})[$pr] != null' > /dev/null 2>&1; then
+        # Key was found (expected)
+        true
+    else
+        fail "Should find existing repo key"
+    fi
+}
+
+# =============================================================================
+# Date cutoff tests
+# =============================================================================
+
+@test "learn-batch.sh: calculates cutoff date correctly on macOS" {
+    if [[ "${OSTYPE}" != "darwin"* ]]; then
+        skip "macOS-specific test"
+    fi
+
+    local days=30
+    local cutoff_date
+    cutoff_date=$(date -v-"${days}"d -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Should be a valid ISO 8601 date
+    [[ "$cutoff_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}
+
+@test "learn-batch.sh: calculates cutoff date correctly on Linux" {
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        skip "Linux-specific test"
+    fi
+
+    local days=30
+    local cutoff_date
+    cutoff_date=$(date -d "${days} days ago" -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    # Should be a valid ISO 8601 date
+    [[ "$cutoff_date" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]
+}

--- a/tests/unit/test-learn-from-pr.bats
+++ b/tests/unit/test-learn-from-pr.bats
@@ -1,0 +1,346 @@
+#!/usr/bin/env bats
+# Tests for learn-from-pr.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create temporary directories for testing
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+
+    # Create mock review root directory
+    MOCK_REVIEW_ROOT="$TEST_DIR/reviews"
+    mkdir -p "$MOCK_REVIEW_ROOT"
+    export MOCK_REVIEW_ROOT
+
+    # Create a mock git repository
+    TEST_REPO=$(mktemp -d)
+    cd "$TEST_REPO"
+    git init -q
+    git config commit.gpgsign false
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git remote add origin "https://github.com/testorg/testrepo.git"
+    echo "initial" > file.txt
+    git add file.txt
+    git commit -q -m "Initial commit"
+    export TEST_REPO
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+    rm -rf "$TEST_REPO"
+}
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+@test "learn-from-pr.sh: exists and is executable" {
+    [ -x "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" ]
+}
+
+@test "learn-from-pr.sh: can be sourced without executing main" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh' && echo 'sourced ok'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sourced ok"* ]]
+}
+
+@test "learn-from-pr.sh: requires PR identifier argument" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# =============================================================================
+# Argument parsing tests
+# =============================================================================
+
+@test "learn-from-pr.sh: rejects unknown arguments" {
+    cd "$TEST_REPO"
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" 123 --unknown
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+@test "learn-from-pr.sh: accepts --org flag" {
+    cd "$TEST_REPO"
+    # Will fail later due to missing review file, but parsing should succeed
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" 123 --org myorg --repo myrepo
+    [[ "$output" != *"Unknown argument"* ]]
+}
+
+@test "learn-from-pr.sh: accepts --repo flag" {
+    cd "$TEST_REPO"
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" 123 --org myorg --repo myrepo
+    [[ "$output" != *"Unknown argument"* ]]
+}
+
+@test "learn-from-pr.sh: rejects invalid PR identifier" {
+    cd "$TEST_REPO"
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" "not-a-pr"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid PR identifier"* ]]
+}
+
+# =============================================================================
+# PR identifier parsing tests
+# =============================================================================
+
+@test "learn-from-pr.sh: extracts PR number from numeric input" {
+    # Test the regex pattern used in the script
+    local pr_identifier="123"
+    if [[ "${pr_identifier}" =~ ^[0-9]+$ ]]; then
+        [ "$pr_identifier" = "123" ]
+    else
+        fail "Should match numeric PR"
+    fi
+}
+
+@test "learn-from-pr.sh: extracts org/repo/PR from GitHub URL" {
+    local pr_identifier="https://github.com/haacked/review-code/pull/42"
+    if [[ "${pr_identifier}" =~ ^https://github.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        [ "${BASH_REMATCH[1]}" = "haacked" ]
+        [ "${BASH_REMATCH[2]}" = "review-code" ]
+        [ "${BASH_REMATCH[3]}" = "42" ]
+    else
+        fail "Should match GitHub URL pattern"
+    fi
+}
+
+@test "learn-from-pr.sh: handles URL with trailing segments" {
+    local pr_identifier="https://github.com/org/repo/pull/123/files"
+    if [[ "${pr_identifier}" =~ ^https://github.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        [ "${BASH_REMATCH[3]}" = "123" ]
+    else
+        fail "Should match URL with trailing path"
+    fi
+}
+
+@test "learn-from-pr.sh: rejects non-GitHub URLs" {
+    local pr_identifier="https://gitlab.com/org/repo/merge_requests/1"
+    if [[ "${pr_identifier}" =~ ^https://github.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        fail "Should not match GitLab URL"
+    fi
+}
+
+# =============================================================================
+# Review file detection tests
+# =============================================================================
+
+@test "learn-from-pr.sh: errors when review file not found" {
+    cd "$TEST_REPO"
+
+    # Create config pointing to our mock review root
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$MOCK_REVIEW_ROOT" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" 123 --org testorg --repo testrepo
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"No review file found"* ]]
+}
+
+@test "learn-from-pr.sh: suggests running review-code when no review exists" {
+    cd "$TEST_REPO"
+
+    mkdir -p "$TEST_DIR/.claude/skills/review-code"
+    echo "REVIEW_ROOT_PATH=$MOCK_REVIEW_ROOT" > "$TEST_DIR/.claude/skills/review-code/.env"
+
+    HOME="$TEST_DIR" run "$PROJECT_ROOT/skills/review-code/scripts/learn-from-pr.sh" 456 --org testorg --repo testrepo
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"/review-code"* ]]
+}
+
+# =============================================================================
+# Cross-reference logic tests (unit testing the patterns)
+# =============================================================================
+
+@test "learn-from-pr.sh: jq matches file in files_changed_after_review" {
+    local files_changed='["src/auth.py", "src/login.py", "tests/test_auth.py"]'
+    local finding_file="src/auth.py"
+
+    if echo "$files_changed" | jq -e --arg f "$finding_file" 'index($f) != null' > /dev/null 2>&1; then
+        true
+    else
+        fail "Should find file in changed files"
+    fi
+}
+
+@test "learn-from-pr.sh: jq correctly reports file not in files_changed_after_review" {
+    local files_changed='["src/auth.py", "src/login.py"]'
+    local finding_file="other/file.py"
+
+    if echo "$files_changed" | jq -e --arg f "$finding_file" 'index($f) != null' > /dev/null 2>&1; then
+        fail "Should not find file in changed files"
+    else
+        true
+    fi
+}
+
+@test "learn-from-pr.sh: line proximity check works within 10 lines" {
+    local comment_line=100
+    local finding_line=95
+    local line_diff=$((comment_line - finding_line))
+
+    [ ${line_diff#-} -le 10 ]
+}
+
+@test "learn-from-pr.sh: line proximity check fails beyond 10 lines" {
+    local comment_line=100
+    local finding_line=50
+    local line_diff=$((comment_line - finding_line))
+
+    [ ${line_diff#-} -gt 10 ]
+}
+
+@test "learn-from-pr.sh: handles negative line difference" {
+    local comment_line=50
+    local finding_line=100
+    local line_diff=$((comment_line - finding_line))
+
+    # ${line_diff#-} removes the negative sign for absolute value
+    [ ${line_diff#-} -eq 50 ]
+}
+
+# =============================================================================
+# Date comparison tests
+# =============================================================================
+
+@test "learn-from-pr.sh: epoch comparison works for dates" {
+    local review_file_epoch=1704067200  # Jan 1, 2024 00:00:00 UTC
+    local commit_epoch=1704153600       # Jan 2, 2024 00:00:00 UTC
+
+    [ "$commit_epoch" -gt "$review_file_epoch" ]
+}
+
+@test "learn-from-pr.sh: date conversion works on macOS" {
+    if [[ "${OSTYPE}" != "darwin"* ]]; then
+        skip "macOS-specific test"
+    fi
+
+    local commit_date="2024-01-15T10:30:00Z"
+    local commit_epoch
+    commit_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$commit_date" +%s 2>/dev/null)
+
+    [ -n "$commit_epoch" ]
+    [[ "$commit_epoch" =~ ^[0-9]+$ ]]
+}
+
+@test "learn-from-pr.sh: date conversion works on Linux" {
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        skip "Linux-specific test"
+    fi
+
+    local commit_date="2024-01-15T10:30:00Z"
+    local commit_epoch
+    commit_epoch=$(date -d "$commit_date" +%s 2>/dev/null)
+
+    [ -n "$commit_epoch" ]
+    [[ "$commit_epoch" =~ ^[0-9]+$ ]]
+}
+
+# =============================================================================
+# JSON output structure tests
+# =============================================================================
+
+@test "learn-from-pr.sh: output structure includes required fields" {
+    # Test the jq command that builds the final output
+    local output
+    output=$(jq -n \
+        --arg pr_number "123" \
+        --arg org "testorg" \
+        --arg repo "testrepo" \
+        --arg state "MERGED" \
+        --arg merged_at "2024-01-15T10:30:00Z" \
+        --arg review_file "/path/to/review.md" \
+        --argjson claude_findings "[]" \
+        --argjson other_findings "[]" \
+        --argjson prompts_needed "[]" \
+        --argjson files_changed "[]" \
+        '{
+            pr_number: ($pr_number | tonumber),
+            org: $org,
+            repo: $repo,
+            state: $state,
+            merged_at: $merged_at,
+            review_file: $review_file,
+            claude_findings: $claude_findings,
+            other_findings: $other_findings,
+            prompts_needed: $prompts_needed,
+            files_changed_after_review: $files_changed,
+            summary: {
+                claude_total: 0,
+                claude_addressed: 0,
+                claude_not_addressed: 0,
+                other_total: 0,
+                other_caught_by_claude: 0,
+                other_missed_by_claude: 0
+            }
+        }')
+
+    echo "$output" | jq -e 'has("pr_number")' > /dev/null
+    echo "$output" | jq -e 'has("org")' > /dev/null
+    echo "$output" | jq -e 'has("repo")' > /dev/null
+    echo "$output" | jq -e 'has("claude_findings")' > /dev/null
+    echo "$output" | jq -e 'has("other_findings")' > /dev/null
+    echo "$output" | jq -e 'has("prompts_needed")' > /dev/null
+    echo "$output" | jq -e 'has("summary")' > /dev/null
+}
+
+@test "learn-from-pr.sh: summary calculates addressed findings" {
+    local claude_findings='[{"addressed":"likely"},{"addressed":"not_modified"},{"addressed":"likely"}]'
+
+    local addressed_count
+    addressed_count=$(echo "$claude_findings" | jq '[.[] | select(.addressed == "likely")] | length')
+    [ "$addressed_count" -eq 2 ]
+
+    local not_addressed_count
+    not_addressed_count=$(echo "$claude_findings" | jq '[.[] | select(.addressed == "not_modified")] | length')
+    [ "$not_addressed_count" -eq 1 ]
+}
+
+@test "learn-from-pr.sh: summary calculates claude_caught for other findings" {
+    local other_findings='[{"claude_caught":true},{"claude_caught":false},{"claude_caught":true}]'
+
+    local caught_count
+    caught_count=$(echo "$other_findings" | jq '[.[] | select(.claude_caught == true)] | length')
+    [ "$caught_count" -eq 2 ]
+
+    local missed_count
+    missed_count=$(echo "$other_findings" | jq '[.[] | select(.claude_caught == false)] | length')
+    [ "$missed_count" -eq 1 ]
+}
+
+# =============================================================================
+# prompts_needed logic tests
+# =============================================================================
+
+@test "learn-from-pr.sh: identifies unaddressed findings for prompts" {
+    local finding='{"file":"auth.py","line":45,"addressed":"not_modified"}'
+    local prompts_needed="[]"
+
+    prompts_needed=$(echo "$prompts_needed" | jq --argjson finding "$finding" \
+        '. + [{type: "unaddressed", finding: $finding}]')
+
+    echo "$prompts_needed" | jq -e 'length == 1' > /dev/null
+    echo "$prompts_needed" | jq -e '.[0].type == "unaddressed"' > /dev/null
+}
+
+@test "learn-from-pr.sh: identifies missed findings for prompts" {
+    local finding='{"file":"auth.py","line":45,"claude_caught":false,"addressed":"likely"}'
+    local prompts_needed="[]"
+
+    local claude_caught
+    claude_caught=$(echo "$finding" | jq -r '.claude_caught')
+    local addressed
+    addressed=$(echo "$finding" | jq -r '.addressed')
+
+    if [[ "$claude_caught" == "false" ]] && [[ "$addressed" == "likely" ]]; then
+        prompts_needed=$(echo "$prompts_needed" | jq --argjson finding "$finding" \
+            '. + [{type: "missed", finding: $finding}]')
+    fi
+
+    echo "$prompts_needed" | jq -e 'length == 1' > /dev/null
+    echo "$prompts_needed" | jq -e '.[0].type == "missed"' > /dev/null
+}

--- a/tests/unit/test-learn-orchestrator.bats
+++ b/tests/unit/test-learn-orchestrator.bats
@@ -1,0 +1,177 @@
+#!/usr/bin/env bats
+# Tests for learn-orchestrator.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create a temporary directory for testing
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+
+    # Create a mock git repository for testing (suppress output)
+    TEST_REPO=$(mktemp -d)
+    cd "$TEST_REPO"
+    git init > /dev/null 2>&1
+    git config commit.gpgsign false
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git remote add origin "https://github.com/testorg/testrepo.git"
+
+    # Create initial commit (suppress output)
+    echo "initial" > file.txt
+    git add file.txt
+    git commit -m "Initial commit" > /dev/null 2>&1
+
+    # Set up mock learnings directory
+    LEARNINGS_DIR="$TEST_DIR/learnings"
+    mkdir -p "$LEARNINGS_DIR"
+}
+
+teardown() {
+    # Clean up test directories
+    rm -rf "$TEST_DIR"
+    rm -rf "$TEST_REPO"
+}
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+@test "learn-orchestrator.sh: exists and is executable" {
+    [ -x "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" ]
+}
+
+@test "learn-orchestrator.sh: requires submode argument" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh"
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+    echo "$output" | jq -e '.error | contains("Submode required")' > /dev/null
+}
+
+@test "learn-orchestrator.sh: rejects unknown submode" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "invalid"
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+    echo "$output" | jq -e '.error | contains("Unknown submode")' > /dev/null
+}
+
+@test "learn-orchestrator.sh: outputs valid JSON on error" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh"
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+}
+
+# =============================================================================
+# Single submode tests
+# =============================================================================
+
+@test "learn-orchestrator.sh: single requires PR number" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "single"
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+    echo "$output" | jq -e '.error | contains("PR number required")' > /dev/null
+}
+
+@test "learn-orchestrator.sh: single accepts PR number" {
+    # This will fail because there's no review file, but it should parse correctly
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "single" "123" --org testorg --repo testrepo
+    # Should fail with meaningful error about missing review file
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: single accepts --org and --repo flags" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "single" "456" --org myorg --repo myrepo
+    # Should fail with error (no review file) but parse arguments correctly
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e '.status == "error"' > /dev/null
+}
+
+# =============================================================================
+# Batch submode tests
+# =============================================================================
+
+@test "learn-orchestrator.sh: batch runs without arguments" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch"
+    # Should succeed with empty results (no reviews to analyze)
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "ready"' > /dev/null
+    echo "$output" | jq -e '.submode == "batch"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: batch accepts --limit flag" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch" --limit 10
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "ready"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: batch returns count field" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.count >= 0' > /dev/null
+}
+
+@test "learn-orchestrator.sh: batch returns prs array" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.prs | type == "array"' > /dev/null
+}
+
+# =============================================================================
+# Apply submode tests
+# =============================================================================
+
+@test "learn-orchestrator.sh: apply runs without arguments" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply"
+    # Should succeed with empty proposals (no learnings)
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "ready"' > /dev/null
+    echo "$output" | jq -e '.submode == "apply"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: apply accepts --threshold flag" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply" --threshold 5
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "ready"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: apply returns actionable count" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.actionable >= 0' > /dev/null
+}
+
+@test "learn-orchestrator.sh: apply returns proposals object" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.proposals | type == "object"' > /dev/null
+}
+
+# =============================================================================
+# JSON output structure tests
+# =============================================================================
+
+@test "learn-orchestrator.sh: all submodes return status field" {
+    # Batch mode (should succeed)
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch"
+    echo "$output" | jq -e '.status' > /dev/null
+
+    # Apply mode (should succeed)
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply"
+    echo "$output" | jq -e '.status' > /dev/null
+}
+
+@test "learn-orchestrator.sh: all submodes return submode field" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "batch"
+    echo "$output" | jq -e '.submode == "batch"' > /dev/null
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh" "apply"
+    echo "$output" | jq -e '.submode == "apply"' > /dev/null
+}
+
+@test "learn-orchestrator.sh: can be sourced without executing main" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/learn-orchestrator.sh' && echo 'sourced ok'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sourced ok"* ]]
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -1,0 +1,359 @@
+#!/usr/bin/env bats
+# Tests for parse-review-findings.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create temporary directory for test review files
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# =============================================================================
+# Basic functionality tests
+# =============================================================================
+
+@test "parse-review-findings.sh: exists and is executable" {
+    [ -x "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" ]
+}
+
+@test "parse-review-findings.sh: requires file argument" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+@test "parse-review-findings.sh: errors on non-existent file" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "/nonexistent/file.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "parse-review-findings.sh: returns empty array for empty file" {
+    echo "" > "$TEST_DIR/empty.md"
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/empty.md"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+# =============================================================================
+# Agent section header detection tests
+# =============================================================================
+
+@test "parse-review-findings.sh: detects Security Review header" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+SQL injection vulnerability
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].agent == "security"' > /dev/null
+}
+
+@test "parse-review-findings.sh: detects Performance Review header" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Performance Review
+
+#### `query.py:100`
+
+N+1 query detected
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].agent == "performance"' > /dev/null
+}
+
+@test "parse-review-findings.sh: detects all agent types" {
+    for agent in Security Performance Correctness Maintainability Testing Compatibility Architecture Frontend; do
+        cat > "$TEST_DIR/review.md" << EOF
+## ${agent} Review
+
+#### \`file.py:1\`
+
+Finding for ${agent}
+EOF
+        run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+        [ "$status" -eq 0 ]
+        local lower_agent
+        lower_agent=$(echo "$agent" | tr '[:upper:]' '[:lower:]')
+        echo "$output" | jq -e ".[0].agent == \"$lower_agent\"" > /dev/null
+    done
+}
+
+# =============================================================================
+# File:line pattern tests
+# =============================================================================
+
+@test "parse-review-findings.sh: Pattern 1 - #### backtick file:line" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth/login.py:123`
+
+This is a security issue
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].file == "src/auth/login.py"' > /dev/null
+    echo "$output" | jq -e '.[0].line == 123' > /dev/null
+}
+
+@test "parse-review-findings.sh: Pattern 2 - bullet with bold backtick file:line" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+- **`config.js:42`**: Hardcoded credentials detected
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].file == "config.js"' > /dev/null
+    echo "$output" | jq -e '.[0].line == 42' > /dev/null
+    echo "$output" | jq -e '.[0].description | contains("Hardcoded credentials")' > /dev/null
+}
+
+@test "parse-review-findings.sh: Pattern 3 - Location: backtick file:line" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Performance Review
+
+**Location**: `database/queries.py:256`
+
+Inefficient query pattern
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].file == "database/queries.py"' > /dev/null
+    echo "$output" | jq -e '.[0].line == 256' > /dev/null
+}
+
+@test "parse-review-findings.sh: Pattern 4 - [Agent NN%] description (file:line)" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+[Security 85%] SQL injection risk (api/users.py:78)
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].agent == "security"' > /dev/null
+    echo "$output" | jq -e '.[0].confidence == 85' > /dev/null
+    echo "$output" | jq -e '.[0].file == "api/users.py"' > /dev/null
+    echo "$output" | jq -e '.[0].line == 78' > /dev/null
+}
+
+# =============================================================================
+# Confidence marker tests
+# =============================================================================
+
+@test "parse-review-findings.sh: extracts [NN%] confidence" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+[75%] Possible XSS vulnerability
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].confidence == 75' > /dev/null
+}
+
+@test "parse-review-findings.sh: extracts (NN% confidence) format" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+(90% confidence) Critical security issue
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].confidence == 90' > /dev/null
+}
+
+@test "parse-review-findings.sh: confidence in inline pattern" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+- **`config.js:42`**: Hardcoded credentials detected [85%]
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].confidence == 85' > /dev/null
+}
+
+@test "parse-review-findings.sh: defaults confidence to 0 when missing" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+Issue without confidence marker
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].confidence == 0' > /dev/null
+}
+
+# =============================================================================
+# Multiple findings tests
+# =============================================================================
+
+@test "parse-review-findings.sh: extracts multiple findings" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+First security issue
+
+#### `login.py:100`
+
+Second security issue
+
+## Performance Review
+
+#### `query.py:200`
+
+Performance issue
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 3' > /dev/null
+    echo "$output" | jq -e '.[0].file == "auth.py"' > /dev/null
+    echo "$output" | jq -e '.[1].file == "login.py"' > /dev/null
+    echo "$output" | jq -e '.[2].file == "query.py"' > /dev/null
+}
+
+@test "parse-review-findings.sh: handles mixed patterns in same file" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+Pattern 1 finding
+
+- **`config.js:42`**: Pattern 2 finding
+
+**Location**: `db.py:100`
+
+Pattern 3 finding
+
+[Security 85%] Pattern 4 finding (api.py:200)
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 4' > /dev/null
+}
+
+# =============================================================================
+# Description accumulation tests
+# =============================================================================
+
+@test "parse-review-findings.sh: accumulates multi-line descriptions" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+This is line one of the description.
+This is line two.
+This is line three.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].description | contains("line one")' > /dev/null
+    echo "$output" | jq -e '.[0].description | contains("line two")' > /dev/null
+}
+
+@test "parse-review-findings.sh: truncates very long descriptions" {
+    # Generate a description longer than 500 chars
+    local long_desc
+    long_desc=$(printf 'a%.0s' {1..600})
+    cat > "$TEST_DIR/review.md" << EOF
+## Security Review
+
+#### \`auth.py:45\`
+
+${long_desc}
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    # Description should be truncated to 500 chars
+    local desc_len
+    desc_len=$(echo "$output" | jq -r '.[0].description | length')
+    [ "$desc_len" -le 500 ]
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+@test "parse-review-findings.sh: handles file paths with special characters" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/components/user-auth.tsx:45`
+
+Issue in TypeScript file
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].file == "src/components/user-auth.tsx"' > /dev/null
+}
+
+@test "parse-review-findings.sh: handles deeply nested file paths" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `a/b/c/d/e/f/file.py:1`
+
+Deep nesting
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].file == "a/b/c/d/e/f/file.py"' > /dev/null
+}
+
+@test "parse-review-findings.sh: assigns unknown agent when no section header" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+#### `auth.py:45`
+
+Finding without agent section
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].agent == "unknown"' > /dev/null
+}
+
+@test "parse-review-findings.sh: produces valid JSON" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+[85%] Security issue
+
+## Performance Review
+
+#### `query.py:100`
+
+(75% confidence) Performance issue
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    # Validate JSON structure
+    echo "$output" | jq . > /dev/null
+    echo "$output" | jq -e 'type == "array"' > /dev/null
+    echo "$output" | jq -e 'all(. | has("agent", "confidence", "file", "line", "description"))' > /dev/null
+}
+
+@test "parse-review-findings.sh: can be sourced without executing main" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh' && echo 'sourced ok'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"sourced ok"* ]]
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -349,7 +349,7 @@ EOF
     # Validate JSON structure
     echo "$output" | jq . > /dev/null
     echo "$output" | jq -e 'type == "array"' > /dev/null
-    echo "$output" | jq -e 'all(. | has("agent", "confidence", "file", "line", "description"))' > /dev/null
+    echo "$output" | jq -e 'all(.[]; has("agent") and has("confidence") and has("file") and has("line") and has("description"))' > /dev/null
 }
 
 @test "parse-review-findings.sh: can be sourced without executing main" {


### PR DESCRIPTION
Add `/review-code learn` command to analyze what happened after code reviews and improve future reviews based on actual outcomes.

New commands:
- `learn <pr>` - Analyze outcomes of a specific PR
- `learn` - Batch analyze all unanalyzed merged PRs with reviews
- `learn --apply` - Apply accumulated learnings to context files

New scripts:
- parse-review-findings.sh - Extract structured findings from reviews
- learn-from-pr.sh - Cross-reference engine comparing Claude's findings with other reviewers and commit history
- learn-batch.sh - Find unanalyzed PRs with existing reviews
- learn-apply.sh - Synthesize learnings into context file updates

The system tracks four learning types:
- valid_catch: Claude found issue, code was fixed
- false_positive: Claude was wrong
- deferred: Valid issue, postponed
- missed_pattern: Other reviewer found, Claude missed