### PR TITLE
fix: Use line/side instead of position for PR review comments

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -804,16 +804,16 @@ If any condition fails, skip draft review creation.
 diff=$(jq -r '.diff' "$SESSION_FILE")
 ```
 
-3. **Build targets for position mapping**: Create JSON with file:line targets from extracted comments.
+3. **Build targets for line mapping**: Create JSON with file:line targets from extracted comments.
 
-4. **Map line numbers to diff positions**: Use the diff-position-mapper script.
+4. **Map line numbers to diff lines**: Use the diff-position-mapper script.
 
 ```bash
 echo "$mapping_input" | ~/.claude/skills/review-code/scripts/diff-position-mapper.sh
 ```
 
 5. **Separate mappable vs unmappable comments**:
-   - Mappable: Comments with valid diff positions (will be inline comments)
+   - Mappable: Comments with valid line mappings (will be inline comments)
    - Unmappable: Comments where line not in diff (will go in summary)
 
 6. **Build input for create-draft-review.sh**:
@@ -826,7 +826,7 @@ echo "$mapping_input" | ~/.claude/skills/review-code/scripts/diff-position-mappe
   "reviewer_username": "<reviewer from session>",
   "summary": "<BRIEF 1-2 sentence summary, e.g. 'Code review with 3 suggestions. See inline comments.'>",
   "comments": [
-    {"path": "file.ts", "position": 23, "body": "Clean comment text"}
+    {"path": "file.ts", "line": 42, "side": "RIGHT", "body": "Clean comment text"}
   ],
   "unmapped_comments": [
     {"description": "General finding that couldn't be mapped to diff"}
@@ -835,7 +835,18 @@ echo "$mapping_input" | ~/.claude/skills/review-code/scripts/diff-position-mappe
 ```
 
 **IMPORTANT**: The `summary` field should be a brief overview (1-2 sentences), NOT the full review. Example: "Code review complete with 3 inline suggestions for improved error handling." The detailed findings are in the markdown file.
+
+**Code Suggestions:**
+
+When recommending a code change, use GitHub's suggestion syntax in the comment body:
+
+````markdown
+```suggestion
+replacement code here
 ```
+````
+
+This renders as an "Apply suggestion" button that the PR author can click to commit the change.
 
 7. **Create the pending review**:
 

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -16,8 +16,8 @@
 #     "reviewer_username": "haacked",
 #     "summary": "Overall review summary...",
 #     "comments": [
-#       {"path": "src/auth.ts", "position": 23, "body": "Consider..."},
-#       {"path": "src/utils.ts", "position": 15, "body": "This could..."}
+#       {"path": "src/auth.ts", "line": 42, "side": "RIGHT", "body": "Consider..."},
+#       {"path": "src/utils.ts", "line": 15, "side": "RIGHT", "body": "This could..."}
 #     ],
 #     "unmapped_comments": [
 #       {"description": "Test coverage could be improved for X, Y, Z"}
@@ -172,13 +172,13 @@ main() {
 
     # Validate comments have required fields and filter out invalid ones
     local valid_comments invalid_count
-    valid_comments=$(echo "${comments}" | jq -c '[.[] | select(.path != null and .position != null and .body != null)]')
-    invalid_count=$(echo "${comments}" | jq '[.[] | select(.path == null or .position == null or .body == null)] | length')
+    valid_comments=$(echo "${comments}" | jq -c '[.[] | select(.path != null and .line != null and .body != null)]')
+    invalid_count=$(echo "${comments}" | jq '[.[] | select(.path == null or .line == null or .body == null)] | length')
 
     if [[ "${invalid_count}" -gt 0 ]]; then
-        warning "${invalid_count} comments filtered out due to missing path, position, or body"
+        warning "${invalid_count} comments filtered out due to missing path, line, or body"
         echo "Filtered comments:" >&2
-        echo "${comments}" | jq -c '.[] | select(.path == null or .position == null or .body == null)' >&2
+        echo "${comments}" | jq -c '.[] | select(.path == null or .line == null or .body == null)' >&2
     fi
 
     # Use validated comments

--- a/skills/review-code/scripts/diff-position-mapper.sh
+++ b/skills/review-code/scripts/diff-position-mapper.sh
@@ -21,7 +21,7 @@
 #   {
 #     "mappings": [
 #       {"path": "src/auth.ts", "line": 42, "side": "RIGHT"},
-#       {"path": "src/utils.ts", "line": 15, "line": null, "error": "line not in diff"}
+#       {"path": "src/utils.ts", "line": 15, "error": "line not in diff"}
 #     ]
 #   }
 

--- a/skills/review-code/scripts/diff-position-mapper.sh
+++ b/skills/review-code/scripts/diff-position-mapper.sh
@@ -102,6 +102,10 @@ build_position_map() {
     current_file == "" { next }
 
     # Context line (space prefix) - both sides have this line
+    # We map context lines to RIGHT because review comments target the new version
+    # of the file. While context lines exist in both old and new versions, GitHub
+    # displays them on the right side of split diff view, making RIGHT the natural
+    # choice for comment placement.
     /^ / {
         position++
         if (!first_line) printf ","

--- a/skills/review-code/scripts/diff-position-mapper.sh
+++ b/skills/review-code/scripts/diff-position-mapper.sh
@@ -45,7 +45,6 @@ build_position_map() {
     echo "${diff}" | awk '
     BEGIN {
         current_file = ""
-        position = 0
         old_line = 0
         new_line = 0
         print "{"
@@ -69,7 +68,6 @@ build_position_map() {
             # Escape quotes in file path
             gsub(/"/, "\\\"", current_file)
             printf "  \"%s\": {", current_file
-            position = 0
             first_line = 1
         }
         next
@@ -94,7 +92,6 @@ build_position_map() {
             gsub(/[^0-9].*/, "", rest)
             old_line = rest + 0
         }
-        position++
         next
     }
 
@@ -107,7 +104,6 @@ build_position_map() {
     # displays them on the right side of split diff view, making RIGHT the natural
     # choice for comment placement.
     /^ / {
-        position++
         if (!first_line) printf ","
         first_line = 0
         printf "\n    \"%d\": {\"line\": %d, \"side\": \"RIGHT\"}", new_line, new_line
@@ -118,7 +114,6 @@ build_position_map() {
 
     # Added line (+) - only in new file (RIGHT side)
     /^\+/ && !/^\+\+\+/ {
-        position++
         if (!first_line) printf ","
         first_line = 0
         printf "\n    \"%d\": {\"line\": %d, \"side\": \"RIGHT\"}", new_line, new_line
@@ -128,7 +123,6 @@ build_position_map() {
 
     # Removed line (-) - only in old file (LEFT side)
     /^-/ && !/^---/ {
-        position++
         old_line++
         next
     }

--- a/tests/fixtures/reviews/review-comments.json
+++ b/tests/fixtures/reviews/review-comments.json
@@ -3,14 +3,14 @@
     "id": 111111,
     "path": "src/utils.ts",
     "line": 5,
-    "position": 5,
+    "side": "RIGHT",
     "body": "Consider adding input validation here"
   },
   {
     "id": 222222,
     "path": "src/utils.ts",
     "line": 10,
-    "position": 10,
+    "side": "RIGHT",
     "body": "This could be simplified"
   }
 ]

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -199,7 +199,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "test.ts", "position": 5, "body": "Fix this"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "test.ts", "line": 5, "body": "Fix this"}]}'
     run bash -c "echo '$input' | '$SCRIPT'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"success": true'* ]]
@@ -358,14 +358,14 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"position": 10, "body": "Missing path"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"line": 10, "body": "Missing path"}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
     [[ "$output" == *'"inline_count": 0'* ]]
 }
 
-@test "create-draft-review: filters comments missing position field" {
+@test "create-draft-review: filters comments missing line field" {
     cat > "$MOCK_DIR/gh" << 'EOF'
 #!/bin/bash
 if [[ "$*" == *"/reviews --paginate"* ]]; then
@@ -378,7 +378,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "body": "Missing position"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "body": "Missing line"}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
@@ -398,7 +398,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "position": 5}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "line": 5}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
@@ -418,14 +418,14 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": null, "position": 5, "body": "Null path"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": null, "line": 5, "body": "Null path"}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
     [[ "$output" == *'"inline_count": 0'* ]]
 }
 
-@test "create-draft-review: filters comments with null position" {
+@test "create-draft-review: filters comments with null line" {
     cat > "$MOCK_DIR/gh" << 'EOF'
 #!/bin/bash
 if [[ "$*" == *"/reviews --paginate"* ]]; then
@@ -438,7 +438,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "position": null, "body": "Null position"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "line": null, "body": "Null line"}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
@@ -458,7 +458,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "position": 5, "body": null}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "line": 5, "body": null}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"1 comments filtered out"* ]]
@@ -479,9 +479,9 @@ EOF
     chmod +x "$MOCK_DIR/gh"
 
     local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [
-        {"path": "good.ts", "position": 5, "body": "Valid comment"},
-        {"position": 10, "body": "Missing path"},
-        {"path": "also-good.ts", "position": 15, "body": "Another valid"}
+        {"path": "good.ts", "line": 5, "body": "Valid comment"},
+        {"line": 10, "body": "Missing path"},
+        {"path": "also-good.ts", "line": 15, "body": "Another valid"}
     ]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
@@ -503,9 +503,9 @@ EOF
     chmod +x "$MOCK_DIR/gh"
 
     local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [
-        {"path": "a.ts", "position": 1, "body": "Comment 1"},
-        {"path": "b.ts", "position": 2, "body": "Comment 2"},
-        {"path": "c.ts", "position": 3, "body": "Comment 3"}
+        {"path": "a.ts", "line": 1, "body": "Comment 1"},
+        {"path": "b.ts", "line": 2, "body": "Comment 2"},
+        {"path": "c.ts", "line": 3, "body": "Comment 3"}
     ]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
@@ -527,8 +527,8 @@ EOF
     chmod +x "$MOCK_DIR/gh"
 
     local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [
-        {"position": 5, "body": "Missing path"},
-        {"path": "file.ts", "body": "Missing position"}
+        {"line": 5, "body": "Missing path"},
+        {"path": "file.ts", "body": "Missing line"}
     ]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
@@ -550,7 +550,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "position": 5, "body": ""}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "line": 5, "body": ""}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" != *"filtered out"* ]]
@@ -570,7 +570,7 @@ fi
 EOF
     chmod +x "$MOCK_DIR/gh"
 
-    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"position": 10, "body": "No path here"}]}'
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"line": 10, "body": "No path here"}]}'
     run bash -c "echo '$input' | '$SCRIPT' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Filtered comments:"* ]]

--- a/tests/unit/test-diff-position-mapper.bats
+++ b/tests/unit/test-diff-position-mapper.bats
@@ -221,6 +221,67 @@ setup() {
 }
 
 # =============================================================================
+# Context line mapping tests
+# =============================================================================
+
+@test "diff-position-mapper: maps context lines (unchanged lines in diff)" {
+    # Context lines are lines with a space prefix in the diff - they appear in
+    # both old and new versions. The mapper should include them so comments can
+    # reference unchanged code visible in the diff view.
+    local diff
+    diff=$(cat "$FIXTURES_DIR/large-changes.diff")
+
+    # Line 1 in large-changes.diff is a context line: " {"
+    # (the opening brace of package.json, unchanged between versions)
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [{path: "package-lock.json", line: 1}]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Context line should be mapped successfully (no error)
+    local error
+    error=$(echo "$output" | jq -r '.mappings[0].error // "none"')
+    [ "$error" = "none" ]
+
+    # Context lines map to RIGHT side
+    local side
+    side=$(echo "$output" | jq -r '.mappings[0].side')
+    [ "$side" = "RIGHT" ]
+
+    # Line number should be preserved
+    local line
+    line=$(echo "$output" | jq '.mappings[0].line')
+    [ "$line" = "1" ]
+}
+
+@test "diff-position-mapper: maps multiple context lines" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/large-changes.diff")
+
+    # Lines 1, 2, 3 are all context lines in the diff
+    local input
+    input=$(jq -n --arg d "$diff" '{diff: $d, targets: [
+        {path: "package-lock.json", line: 1},
+        {path: "package-lock.json", line: 2},
+        {path: "package-lock.json", line: 3}
+    ]}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # All three context lines should be mapped successfully
+    local error_count
+    error_count=$(echo "$output" | jq '[.mappings[] | select(.error != null)] | length')
+    [ "$error_count" = "0" ]
+
+    # All should have side RIGHT
+    local right_count
+    right_count=$(echo "$output" | jq '[.mappings[] | select(.side == "RIGHT")] | length')
+    [ "$right_count" = "3" ]
+}
+
+# =============================================================================
 # Integration tests with realistic diffs
 # =============================================================================
 

--- a/tests/unit/test-diff-position-mapper.bats
+++ b/tests/unit/test-diff-position-mapper.bats
@@ -71,10 +71,10 @@ setup() {
     run bash -c "echo '$input' | '$SCRIPT'"
     [ "$status" -eq 0 ]
 
-    # Line 1 in a new file has position 2 (position 1 is the @@ hunk header)
-    local position
-    position=$(echo "$output" | jq -r '.mappings[0].position')
-    [ "$position" = "2" ]
+    # Line 1 in a new file should map to line 1
+    local line
+    line=$(echo "$output" | jq -r '.mappings[0].line')
+    [ "$line" = "1" ]
 }
 
 @test "diff-position-mapper: maps multiple lines in same file" {
@@ -139,7 +139,7 @@ setup() {
     [ "$error" = "line not in diff" ]
 }
 
-@test "diff-position-mapper: returns null position for unmapped lines" {
+@test "diff-position-mapper: returns error for unmapped lines" {
     local diff
     diff=$(cat "$FIXTURES_DIR/simple-single-file.diff")
     local input
@@ -148,9 +148,9 @@ setup() {
     run bash -c "echo '$input' | '$SCRIPT'"
     [ "$status" -eq 0 ]
 
-    local position
-    position=$(echo "$output" | jq '.mappings[0].position')
-    [ "$position" = "null" ]
+    local error
+    error=$(echo "$output" | jq -r '.mappings[0].error')
+    [ "$error" = "line not in diff" ]
 }
 
 # =============================================================================
@@ -166,10 +166,10 @@ setup() {
     run bash -c "echo '$input' | '$SCRIPT'"
     [ "$status" -eq 0 ]
 
-    # Should successfully map the first line
-    local position
-    position=$(echo "$output" | jq -r '.mappings[0].position')
-    [ "$position" != "null" ]
+    # Should successfully map the first line (no error means it was mapped)
+    local error
+    error=$(echo "$output" | jq -r '.mappings[0].error // "none"')
+    [ "$error" = "none" ]
 }
 
 # =============================================================================

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -103,7 +103,7 @@ preserve_reviews() {
         return
     fi
     local dir_contents
-    dir_contents=$(ls -A "${REVIEWS_DIR}" 2>/dev/null) || true
+    dir_contents=$(ls -A "${REVIEWS_DIR}" 2> /dev/null) || true
     if [[ -z "${dir_contents}" ]]; then
         return
     fi


### PR DESCRIPTION
## Summary

- Fix line positioning: comments now appear on correct lines in GitHub PR reviews
- Add support for context lines in diff mapping
- Add documentation for GitHub's suggestion syntax

## Problem

The draft review feature was using GitHub's deprecated `position` parameter which counts lines from the `@@` header in the diff. This caused comments to appear on wrong lines.

## Solution

Switch to the preferred `line` + `side` parameters which use actual file line numbers:

```json
// Before (deprecated)
{"path": "file.ts", "position": 23, "body": "..."}

// After (preferred)
{"path": "file.ts", "line": 42, "side": "RIGHT", "body": "..."}
```

## Changes

- **diff-position-mapper.sh**: Output `line` instead of `position`, map context lines
- **create-draft-review.sh**: Validate `line` field instead of `position`
- **SKILL.md**: Update documentation, add suggestion syntax docs
- **Tests**: Update all assertions and fixtures

## Design Note: Context Line Mapping

The diff mapper now intentionally maps context lines (unchanged lines shown with space prefix in diffs), not just added lines. This allows review comments to be placed on any line visible in the diff view, which GitHub's API supports. This is useful for comments like "consider the interaction with this existing code" that reference unchanged context.

## Test plan

- [x] All 899 tests pass (887 unit + 12 integration)
- [ ] Test with real PR using `/review-code --draft <pr-url>`
- [ ] Verify comments appear on correct lines in GitHub