### PR TITLE
fix: Skip pre-flight prompt when context is already fresh

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -135,6 +135,7 @@ If user selects "No, continue anyway", proceed with Step 0.
 
 **Skip this prompt entirely if:**
 - This is a `find` or `learn` command (lightweight operations that don't need fresh context)
+- The context is already fresh (e.g., the user just ran `/clear` or this is the first command in the conversation)
 
 **Note:** To determine if the command is `find` or `learn`, parse the arguments first:
 ```bash


### PR DESCRIPTION
## Summary

- Skip the pre-flight context clear prompt when the context is already fresh (e.g., user just ran `/clear` or it's the first command in the conversation)

## Test plan

- [ ] Run `/clear` then `/review-code <pr-url>` - should skip the context clear prompt
- [ ] Run `/review-code` with prior conversation - should still show the prompt
- [ ] Run `/review-code --force` - should skip the prompt (existing behavior)