### PR TITLE
fix: Unset DEBUG env var for gh CLI invocations

### DIFF
--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -66,7 +66,7 @@ get_existing_pending_review() {
 
     # Get all reviews for this PR
     local reviews
-    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
+    reviews=$(DEBUG= gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
 
     # Find pending review from this user
     local pending_review
@@ -83,7 +83,7 @@ get_existing_pending_review() {
 
     # Fetch comments for this pending review
     local comments
-    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
+    comments=$(DEBUG= gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
 
     # Return review info with comments
     jq -n \
@@ -110,7 +110,7 @@ delete_pending_review() {
     local pr_number="$3"
     local review_id="$4"
 
-    gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
+    DEBUG= gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
         warning "Failed to delete existing pending review ${review_id}"
         return 1
     }
@@ -140,7 +140,7 @@ create_pending_review() {
         --argjson comments "${comments_json}" \
         '{body: $body, comments: $comments}')
 
-    if ! result=$(echo "${request_body}" | gh api --method POST \
+    if ! result=$(echo "${request_body}" | DEBUG= gh api --method POST \
         "repos/${owner}/${repo}/pulls/${pr_number}/reviews" \
         --input - 2>"${tmpfile}"); then
         error_output=$(<"${tmpfile}")

--- a/skills/review-code/scripts/helpers/git-helpers.sh
+++ b/skills/review-code/scripts/helpers/git-helpers.sh
@@ -25,7 +25,7 @@ get_git_org_repo() {
     # Try gh CLI first (most reliable, already authenticated and validated)
     if command -v gh > /dev/null 2>&1; then
         local gh_data
-        gh_data=$(gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
+        gh_data=$(DEBUG= gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
         if [[ -n "${gh_data}" ]]; then
             # Normalize org to lowercase for consistency
             local org="${gh_data%|*}"

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -170,7 +170,7 @@ main() {
         # If not cached or cache expired, fetch from API
         if [[ -z "${pr_state}" ]]; then
             local pr_data
-            pr_data=$(gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
+            pr_data=$(DEBUG= gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
 
             pr_merged_at=$(echo "${pr_data}" | jq -r '.merged_at // empty')
             local api_state

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -106,7 +106,7 @@ main() {
 
     # Fetch PR data from GitHub
     local pr_data
-    pr_data=$(gh pr view "${pr_number}" --repo "${org}/${repo}" --json number,title,state,mergedAt,createdAt,commits,files,reviews 2> /dev/null) || {
+    pr_data=$(DEBUG= gh pr view "${pr_number}" --repo "${org}/${repo}" --json number,title,state,mergedAt,createdAt,commits,files,reviews 2> /dev/null) || {
         error "Failed to fetch PR data from GitHub"
         exit 1
     }
@@ -118,7 +118,7 @@ main() {
 
     # Fetch review comments with threads
     local review_comments
-    review_comments=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/comments" --jq '
+    review_comments=$(DEBUG= gh api "repos/${org}/${repo}/pulls/${pr_number}/comments" --jq '
         [.[] | {
             id: .id,
             path: .path,

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -449,7 +449,7 @@ detect_no_arg() {
     if command -v gh > /dev/null 2>&1; then
         # Get all open PRs for this branch
         local pr_numbers
-        pr_numbers=$(gh pr list --head "${current_branch}" --state open --json number --jq '.[].number' 2> /dev/null || echo "")
+        pr_numbers=$(DEBUG= gh pr list --head "${current_branch}" --state open --json number --jq '.[].number' 2> /dev/null || echo "")
 
         if [[ -n "${pr_numbers}" ]]; then
             local pr_array

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -98,7 +98,7 @@ fetch_pr_metadata() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state
+    DEBUG= "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state
 }
 
 # Fetch PR diff
@@ -112,7 +112,7 @@ fetch_pr_diff() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    "${gh_cmd[@]}"
+    DEBUG= "${gh_cmd[@]}"
 }
 
 # Fetch PR conversation comments (main discussion thread)
@@ -125,7 +125,7 @@ fetch_conversation_comments() {
     validate_pr_number "${pr_number}" || return 1
     validate_repo_spec "${repo_spec}" || return 1
 
-    gh api --paginate "repos/${repo_spec}/issues/${pr_number}/comments" \
+    DEBUG= gh api --paginate "repos/${repo_spec}/issues/${pr_number}/comments" \
         | jq -s 'add | [.[] | {id, author: .user.login, body, created_at, url: .html_url}]'
 }
 
@@ -139,7 +139,7 @@ fetch_inline_comments() {
     validate_pr_number "${pr_number}" || return 1
     validate_repo_spec "${repo_spec}" || return 1
 
-    gh api --paginate "repos/${repo_spec}/pulls/${pr_number}/comments" \
+    DEBUG= gh api --paginate "repos/${repo_spec}/pulls/${pr_number}/comments" \
         | jq -s 'add | [.[] | {id, author: .user.login, body, path, line, side, diff_hunk, created_at, in_reply_to_id, url: .html_url}]'
 }
 
@@ -153,7 +153,7 @@ fetch_reviews() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    "${gh_cmd[@]}" | jq '.reviews | [.[] | {id, author: .author.login, state, body, submitted_at: .submittedAt}]'
+    DEBUG= "${gh_cmd[@]}" | jq '.reviews | [.[] | {id, author: .author.login, state, body, submitted_at: .submittedAt}]'
 }
 
 # Main logic

--- a/skills/review-code/scripts/review-file-path.sh
+++ b/skills/review-code/scripts/review-file-path.sh
@@ -349,7 +349,7 @@ main() {
             fi
 
             local pr_check
-            pr_check=$(gh pr list --head "${branch_to_check}" --json number --jq '.[0].number' 2> /dev/null || echo "")
+            pr_check=$(DEBUG= gh pr list --head "${branch_to_check}" --json number --jq '.[0].number' 2> /dev/null || echo "")
             if [[ -n "${pr_check}" ]]; then
                 local pr_file="${review_dir}/pr-${pr_check}.md"
                 verify_path_safety "${pr_file}" "${review_root}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -310,7 +310,7 @@ build_review_data() {
     if [[ -n "${pr_context}" ]]; then
         local pr_author
         pr_author=$(echo "${pr_context}" | jq -r '.author // ""')
-        reviewer_username=$(gh api user --jq '.login' 2> /dev/null || echo "")
+        reviewer_username=$(DEBUG= gh api user --jq '.login' 2> /dev/null || echo "")
         if [[ -n "${reviewer_username}" && -n "${pr_author}" && "${reviewer_username}" == "${pr_author}" ]]; then
             is_own_pr="true"
         fi


### PR DESCRIPTION
## Summary

- The `gh` CLI respects the `DEBUG` environment variable, outputting request debug lines to stdout when `DEBUG=1` is set (common in dev environments like PostHog's flox setup). This breaks JSON parsing in scripts that pipe `gh` output through `jq`.
- Prefix all `gh` invocations across 8 scripts with `DEBUG= ` to ensure clean JSON output regardless of environment configuration.

## Test plan

- [x] All 687 existing tests pass
- [ ] Verify with `DEBUG=1 ./scripts/pr-context.sh <pr-url>` produces valid JSON