### PR TITLE
Suppress gh CLI debug output via wrapper function

### DIFF
--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -41,6 +41,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 # shellcheck source=lib/helpers/json-helpers.sh
 source "${SCRIPT_DIR}/helpers/json-helpers.sh"
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 
 # Validate a required field
 # Args: $1 = value, $2 = field name
@@ -66,7 +68,7 @@ get_existing_pending_review() {
 
     # Get all reviews for this PR
     local reviews
-    reviews=$(DEBUG= gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
+    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
 
     # Find pending review from this user
     local pending_review
@@ -83,7 +85,7 @@ get_existing_pending_review() {
 
     # Fetch comments for this pending review
     local comments
-    comments=$(DEBUG= gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
+    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
 
     # Return review info with comments
     jq -n \
@@ -110,7 +112,7 @@ delete_pending_review() {
     local pr_number="$3"
     local review_id="$4"
 
-    DEBUG= gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
+    gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
         warning "Failed to delete existing pending review ${review_id}"
         return 1
     }
@@ -140,7 +142,7 @@ create_pending_review() {
         --argjson comments "${comments_json}" \
         '{body: $body, comments: $comments}')
 
-    if ! result=$(echo "${request_body}" | DEBUG= gh api --method POST \
+    if ! result=$(echo "${request_body}" | gh api --method POST \
         "repos/${owner}/${repo}/pulls/${pr_number}/reviews" \
         --input - 2>"${tmpfile}"); then
         error_output=$(<"${tmpfile}")

--- a/skills/review-code/scripts/helpers/gh-wrapper.sh
+++ b/skills/review-code/scripts/helpers/gh-wrapper.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Wrap gh CLI to prevent debug output when DEBUG is set in the environment.
+# The gh CLI interprets any non-empty DEBUG env var as a signal to emit verbose
+# output, which interferes with scripts that parse gh's stdout.
+
+if command -v gh > /dev/null 2>&1; then
+    gh() {
+        DEBUG= command gh "$@"
+    }
+fi

--- a/skills/review-code/scripts/helpers/git-helpers.sh
+++ b/skills/review-code/scripts/helpers/git-helpers.sh
@@ -11,6 +11,9 @@ _HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/helpers/error-helpers.sh
 source "${_HELPER_DIR}/error-helpers.sh"
 
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${_HELPER_DIR}/gh-wrapper.sh"
+
 validate_git_repo() {
     if ! git rev-parse --git-dir > /dev/null 2>&1; then
         error "Not in a git repository"
@@ -25,7 +28,7 @@ get_git_org_repo() {
     # Try gh CLI first (most reliable, already authenticated and validated)
     if command -v gh > /dev/null 2>&1; then
         local gh_data
-        gh_data=$(DEBUG= gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
+        gh_data=$(gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
         if [[ -n "${gh_data}" ]]; then
             # Normalize org to lowercase for consistency
             local org="${gh_data%|*}"

--- a/skills/review-code/scripts/learn-batch.sh
+++ b/skills/review-code/scripts/learn-batch.sh
@@ -32,6 +32,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 source "${SCRIPT_DIR}/helpers/date-helpers.sh"
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 source "${SCRIPT_DIR}/helpers/validation-helpers.sh"
 
 # Get learnings directory from config
@@ -170,7 +172,7 @@ main() {
         # If not cached or cache expired, fetch from API
         if [[ -z "${pr_state}" ]]; then
             local pr_data
-            pr_data=$(DEBUG= gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
+            pr_data=$(gh api "repos/${org}/${repo}/pulls/${pr_number}" --jq '{state: .state, merged_at: .merged_at}' 2> /dev/null || echo '{"state":"unknown","merged_at":null}')
 
             pr_merged_at=$(echo "${pr_data}" | jq -r '.merged_at // empty')
             local api_state

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -106,7 +106,7 @@ main() {
 
     # Fetch PR data from GitHub
     local pr_data
-    pr_data=$(DEBUG= gh pr view "${pr_number}" --repo "${org}/${repo}" --json number,title,state,mergedAt,createdAt,commits,files,reviews 2> /dev/null) || {
+    pr_data=$(gh pr view "${pr_number}" --repo "${org}/${repo}" --json number,title,state,mergedAt,createdAt,commits,files,reviews 2> /dev/null) || {
         error "Failed to fetch PR data from GitHub"
         exit 1
     }
@@ -118,7 +118,7 @@ main() {
 
     # Fetch review comments with threads
     local review_comments
-    review_comments=$(DEBUG= gh api "repos/${org}/${repo}/pulls/${pr_number}/comments" --jq '
+    review_comments=$(gh api "repos/${org}/${repo}/pulls/${pr_number}/comments" --jq '
         [.[] | {
             id: .id,
             path: .path,

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -5,6 +5,10 @@
 # shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
 # Process all arguments into an array, extracting flags first
 # This ensures flags can appear anywhere and remaining args are properly ordered
 FORCE_MODE="false"
@@ -449,7 +453,7 @@ detect_no_arg() {
     if command -v gh > /dev/null 2>&1; then
         # Get all open PRs for this branch
         local pr_numbers
-        pr_numbers=$(DEBUG= gh pr list --head "${current_branch}" --state open --json number --jq '.[].number' 2> /dev/null || echo "")
+        pr_numbers=$(gh pr list --head "${current_branch}" --state open --json number --jq '.[].number' 2> /dev/null || echo "")
 
         if [[ -n "${pr_numbers}" ]]; then
             local pr_array

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -35,6 +35,9 @@ source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 
 set -euo pipefail
 
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
 # Check if gh is installed
 if ! command -v gh &> /dev/null; then
     error "gh CLI is not installed. Install it with: brew install gh"
@@ -98,7 +101,7 @@ fetch_pr_metadata() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    DEBUG= "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state
+    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state
 }
 
 # Fetch PR diff
@@ -112,7 +115,7 @@ fetch_pr_diff() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    DEBUG= "${gh_cmd[@]}"
+    "${gh_cmd[@]}"
 }
 
 # Fetch PR conversation comments (main discussion thread)
@@ -125,7 +128,7 @@ fetch_conversation_comments() {
     validate_pr_number "${pr_number}" || return 1
     validate_repo_spec "${repo_spec}" || return 1
 
-    DEBUG= gh api --paginate "repos/${repo_spec}/issues/${pr_number}/comments" \
+    gh api --paginate "repos/${repo_spec}/issues/${pr_number}/comments" \
         | jq -s 'add | [.[] | {id, author: .user.login, body, created_at, url: .html_url}]'
 }
 
@@ -139,7 +142,7 @@ fetch_inline_comments() {
     validate_pr_number "${pr_number}" || return 1
     validate_repo_spec "${repo_spec}" || return 1
 
-    DEBUG= gh api --paginate "repos/${repo_spec}/pulls/${pr_number}/comments" \
+    gh api --paginate "repos/${repo_spec}/pulls/${pr_number}/comments" \
         | jq -s 'add | [.[] | {id, author: .user.login, body, path, line, side, diff_hunk, created_at, in_reply_to_id, url: .html_url}]'
 }
 
@@ -153,7 +156,7 @@ fetch_reviews() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    DEBUG= "${gh_cmd[@]}" | jq '.reviews | [.[] | {id, author: .author.login, state, body, submitted_at: .submittedAt}]'
+    "${gh_cmd[@]}" | jq '.reviews | [.[] | {id, author: .author.login, state, body, submitted_at: .submittedAt}]'
 }
 
 # Main logic

--- a/skills/review-code/scripts/review-file-path.sh
+++ b/skills/review-code/scripts/review-file-path.sh
@@ -42,10 +42,7 @@ source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 
 set -euo pipefail
 
-# Get the directory where this script lives
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-# Source shared git helper functions
+# Source shared git helper functions (also provides gh-wrapper.sh)
 source "${SCRIPT_DIR}/helpers/git-helpers.sh"
 
 # Sanitize path component to prevent directory traversal
@@ -349,7 +346,7 @@ main() {
             fi
 
             local pr_check
-            pr_check=$(DEBUG= gh pr list --head "${branch_to_check}" --json number --jq '.[0].number' 2> /dev/null || echo "")
+            pr_check=$(gh pr list --head "${branch_to_check}" --json number --jq '.[0].number' 2> /dev/null || echo "")
             if [[ -n "${pr_check}" ]]; then
                 local pr_file="${review_dir}/pr-${pr_check}.md"
                 verify_path_safety "${pr_file}" "${review_root}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -23,6 +23,9 @@ source "${SCRIPT_DIR}/helpers/debug-helpers.sh"
 
 set -euo pipefail
 
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
 # Main orchestration function
 main() {
     local arg="${1:-}"
@@ -310,7 +313,7 @@ build_review_data() {
     if [[ -n "${pr_context}" ]]; then
         local pr_author
         pr_author=$(echo "${pr_context}" | jq -r '.author // ""')
-        reviewer_username=$(DEBUG= gh api user --jq '.login' 2> /dev/null || echo "")
+        reviewer_username=$(gh api user --jq '.login' 2> /dev/null || echo "")
         if [[ -n "${reviewer_username}" && -n "${pr_author}" && "${reviewer_username}" == "${pr_author}" ]]; then
             is_own_pr="true"
         fi


### PR DESCRIPTION
## Summary

- Adds a `gh()` shell wrapper function that clears `DEBUG` for each `gh` invocation, preventing the CLI from emitting verbose output that corrupts JSON parsing
- Replaces per-script `unset DEBUG` / per-command `DEBUG=` prefixes with a single shared helper sourced by all scripts that call `gh`
- Keeps `DEBUG` available for other uses in the scripts (e.g. `REVIEW_CODE_DEBUG`)

## Test plan

- [x] All 919 unit tests pass
- [x] All 12 integration tests pass
- [ ] Manual test: run `/review-code` with `DEBUG=1` set in the environment and verify gh output doesn't leak into JSON