### PR TITLE
Add cross-branch PR review support

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -421,7 +421,7 @@ Build `$file_access_instructions` based on the review context. This block is inc
 {If file_ref is set:}
 ```
 **File Access:**
-You are reviewing from a different branch in the same repo. To read files as they appear in the PR, use `git show $file_ref:<path>` via the Bash tool. Do NOT use `git checkout` or `git switch` — this would modify the user's working tree. The Read, Grep, and Glob tools operate on the current working tree (which may differ from the PR branch), so use them for finding patterns and conventions but not for reading the PR's file contents. If `git show` fails for a file (e.g., a new file only in the PR), fall back to the diff content.
+You are reviewing from a different branch in the same repo. To read files as they appear in the PR, use `git show $file_ref:<path>` via the Bash tool. Do NOT use `git checkout` or `git switch` — this would modify the user's working tree. The Read, Grep, and Glob tools operate on the current working tree (which may differ from the PR branch), so use them for finding patterns and conventions but not for reading the PR's file contents. `git show` works for any file that exists at the ref, including files newly added in the PR. If `git show` fails (e.g., the file was deleted or renamed, the path is wrong, or the ref was not fetched), fall back to the diff content.
 ```
 
 {If file_ref is NOT set and working_dir is not null:}

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -406,12 +406,35 @@ From the session file JSON (already read via Read tool), extract these fields:
 - `git` — git repository context
 - `languages` — detected languages
 - `file_info.file_path` — where to save the review
+- `file_ref` — (optional) git ref for reading PR files when on a different branch
 
 **Extract mode-specific fields:**
 
-- **For PR mode:** `pr` — PR details (number, title, author, body, comments, etc.)
+- **For PR mode:** `pr` — PR details (number, title, author, body, comments, etc.); `file_ref` — git ref for file access (present when reviewing from a different branch in the same repo)
 - **For branch/commit/range modes:** `branch`, `base_branch`, `commit`, `range`
 - **For area-specific reviews:** `area`
+
+### Prepare File Access Instructions
+
+Build `$file_access_instructions` based on the review context. This block is included in both the context explorer and specialized agent prompts:
+
+{If file_ref is set:}
+```
+**File Access:**
+You are reviewing from a different branch in the same repo. To read files as they appear in the PR, use `git show $file_ref:<path>` via the Bash tool. Do NOT use `git checkout` or `git switch` — this would modify the user's working tree. The Read, Grep, and Glob tools operate on the current working tree (which may differ from the PR branch), so use them for finding patterns and conventions but not for reading the PR's file contents. If `git show` fails for a file (e.g., a new file only in the PR), fall back to the diff content.
+```
+
+{If file_ref is NOT set and working_dir is not null:}
+```
+**File Access:**
+You are on the PR's branch. Use the Read tool to read files normally.
+```
+
+{If working_dir is null:}
+```
+**File Access:**
+No local checkout available. Work from the diff content only.
+```
 
 ### Gather Architectural Context
 
@@ -427,6 +450,8 @@ $file_metadata
 
 **Diff:**
 $diff
+
+$file_access_instructions
 
 Explore the codebase to understand:
 - Full context of modified files
@@ -496,10 +521,12 @@ $architectural_context
 **Language/Framework-Specific Guidelines:**
 $review_context
 
+$file_access_instructions
+
 **Accuracy Requirements:**
 For each finding you report:
 1. Quote the exact code you're referencing
-2. Verify the line number by reading the actual file with the Read tool
+2. Verify the line number by reading the actual file (see File Access above)
 3. Only flag code in the diff - do not flag pre-existing issues in unchanged code
 4. For bug claims: read surrounding code to confirm the behavior before reporting
 Do NOT report anything as a bug unless you've verified the behavior by reading the code.

--- a/skills/review-code/scripts/helpers/git-helpers.sh
+++ b/skills/review-code/scripts/helpers/git-helpers.sh
@@ -30,10 +30,11 @@ get_git_org_repo() {
         local gh_data
         gh_data=$(gh repo view --json owner,name --jq '"\(.owner.login)|\(.name)"' 2> /dev/null || echo "")
         if [[ -n "${gh_data}" ]]; then
-            # Normalize org to lowercase for consistency
+            # Normalize to lowercase for case-insensitive comparison
             local org="${gh_data%|*}"
             local repo="${gh_data#*|}"
             org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+            repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
             echo "${org}|${repo}"
             return 0
         fi
@@ -56,8 +57,9 @@ get_git_org_repo() {
         local org="${BASH_REMATCH[2]}"
         local repo="${BASH_REMATCH[3]}"
 
-        # Normalize org to lowercase (PostHog → posthog)
+        # Normalize to lowercase (PostHog → posthog)
         org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
 
         # Remove .git suffix if present
         repo="${repo%.git}"
@@ -98,8 +100,9 @@ parse_pr_identifier() {
         local repo="${BASH_REMATCH[2]}"
         local pr_num="${BASH_REMATCH[3]}"
 
-        # Normalize org to lowercase
+        # Normalize to lowercase
         org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
 
         echo "${org}|${repo}|pr-${pr_num}"
     elif [[ "${identifier}" =~ ^[0-9]+$ ]]; then

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -17,7 +17,7 @@
 #     "body": "This PR fixes...",
 #     "url": "https://github.com/PostHog/posthog/pull/123",
 #     "author": "haacked",
-#     "head_ref": "haacked/fix-auth",
+#     "head_ref": "fix-auth",
 #     "base_ref": "main",
 #     "state": "open",
 #     "is_fork": false,

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -20,6 +20,7 @@
 #     "head_ref": "haacked/fix-auth",
 #     "base_ref": "main",
 #     "state": "open",
+#     "is_fork": false,
 #     "diff": "diff content...",
 #     "comments": {
 #       "conversation": [...],  # PR discussion thread comments
@@ -101,7 +102,7 @@ fetch_pr_metadata() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state
+    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state,isCrossRepository
 }
 
 # Fetch PR diff
@@ -215,6 +216,8 @@ main() {
     base_ref=$(echo "${metadata}" | jq -r '.baseRefName')
     local state
     state=$(echo "${metadata}" | jq -r '.state')
+    local is_fork
+    is_fork=$(echo "${metadata}" | jq -r '.isCrossRepository // false')
 
     # Extract org/repo from URL if not already set
     if [[ -z "${org}" ]]; then
@@ -222,6 +225,7 @@ main() {
             org="${BASH_REMATCH[1]}"
             repo="${BASH_REMATCH[2]}"
             org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+            repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
         fi
     fi
 
@@ -273,6 +277,7 @@ main() {
     "head_ref": "${head_ref}",
     "base_ref": "${base_ref}",
     "state": "${state}",
+    "is_fork": ${is_fork},
     "diff": ${diff},
     "comments": {
         "conversation": ${conversation_comments},

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -225,9 +225,15 @@ main() {
         if [[ ${url} =~ github\.com/([^/]+)/([^/]+)/pull/ ]]; then
             org="${BASH_REMATCH[1]}"
             repo="${BASH_REMATCH[2]}"
-            org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
-            repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
         fi
+    fi
+
+    # Normalize org/repo to lowercase regardless of how they were set
+    if [[ -n "${org}" ]]; then
+        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+    fi
+    if [[ -n "${repo}" ]]; then
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
     fi
 
     # Rebuild repo_spec now that we have org/repo

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -77,8 +77,9 @@ parse_pr_identifier() {
         local repo="${BASH_REMATCH[2]}"
         local number="${BASH_REMATCH[3]}"
 
-        # Normalize org to lowercase
+        # Normalize to lowercase for case-insensitive comparison
         org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
 
         echo "${org}|${repo}|${number}"
     elif [[ ${input} =~ ^[0-9]+$ ]]; then

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -876,6 +876,22 @@ handle_find_mode() {
         '{status: $status, file_info: $file_info, display_target: $display_target, file_summary: $file_summary}'
 }
 
+# Determine the git ref for reading PR files on a cross-branch review.
+# Returns the local ref path to fetch into, or empty string when on the
+# PR's branch (fast path). The caller handles the actual fetch.
+determine_file_ref() {
+    local current_branch="$1"
+    local head_ref="$2"
+    local pr_number="$3"
+
+    if [[ "${current_branch}" == "${head_ref}" ]]; then
+        echo ""
+        return
+    fi
+
+    echo "refs/review/pr-${pr_number}"
+}
+
 # Handle PR review
 handle_pr_review() {
     local pr_identifier="$1"
@@ -902,7 +918,7 @@ handle_pr_review() {
         source "${SCRIPT_DIR}/helpers/git-helpers.sh"
 
         local current_git_data
-        current_git_data=$(get_git_org_repo 2> /dev/null || echo "|")
+        current_git_data=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
         local current_org="${current_git_data%|*}"
         local current_repo="${current_git_data#*|}"
         local current_branch
@@ -911,23 +927,23 @@ handle_pr_review() {
         if [[ "${current_org}" = "${org}" ]] && [[ "${current_repo}" = "${repo}" ]]; then
             git_context=$("${SCRIPT_DIR}/git-context.sh")
 
-            if [[ "${current_branch}" != "${head_ref}" ]]; then
+            local expected_ref
+            expected_ref=$(determine_file_ref "${current_branch}" "${head_ref}" "${pr_number}")
+
+            if [[ -n "${expected_ref}" ]]; then
                 # Same repo, different branch. Fetch the PR ref so agents can
                 # read files via `git show <ref>:<path>` without checkout.
-                local fetch_err
+                local fetch_err fetch_source
                 if [[ "${is_fork}" == "true" ]]; then
-                    local pr_ref="refs/review/pr-${pr_number}"
-                    if fetch_err=$(git fetch origin "+pull/${pr_number}/head:${pr_ref}" 2>&1); then
-                        file_ref="${pr_ref}"
-                    else
-                        warning "Failed to fetch PR ref for fork PR #${pr_number}: ${fetch_err}"
-                    fi
+                    fetch_source="+pull/${pr_number}/head:${expected_ref}"
                 else
-                    if fetch_err=$(git fetch origin "${head_ref}" 2>&1); then
-                        file_ref="origin/${head_ref}"
-                    else
-                        warning "Failed to fetch origin/${head_ref}: ${fetch_err}"
-                    fi
+                    fetch_source="+${head_ref}:${expected_ref}"
+                fi
+
+                if fetch_err=$(git fetch origin "${fetch_source}" 2>&1); then
+                    file_ref="${expected_ref}"
+                else
+                    warning "Failed to fetch ${fetch_source}: ${fetch_err}"
                 fi
 
                 # If fetch failed, null out working_dir so agents fall back to

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -917,7 +917,7 @@ handle_pr_review() {
                 local fetch_err
                 if [[ "${is_fork}" == "true" ]]; then
                     local pr_ref="refs/review/pr-${pr_number}"
-                    if fetch_err=$(git fetch origin "pull/${pr_number}/head:${pr_ref}" 2>&1); then
+                    if fetch_err=$(git fetch origin "+pull/${pr_number}/head:${pr_ref}" 2>&1); then
                         file_ref="${pr_ref}"
                     else
                         warning "Failed to fetch PR ref for fork PR #${pr_number}: ${fetch_err}"
@@ -928,6 +928,12 @@ handle_pr_review() {
                     else
                         warning "Failed to fetch origin/${head_ref}: ${fetch_err}"
                     fi
+                fi
+
+                # If fetch failed, null out working_dir so agents fall back to
+                # diff-only instead of reading the wrong branch's files.
+                if [[ -z "${file_ref}" ]]; then
+                    git_context=$(echo "${git_context}" | jq '.working_dir = null')
                 fi
             fi
         fi

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -900,12 +900,11 @@ handle_pr_review() {
     local pr_data
     pr_data=$("${SCRIPT_DIR}/pr-context.sh" "${pr_identifier}")
 
-    local pr_number org repo head_ref is_fork
+    local pr_number org repo head_ref
     pr_number=$(echo "${pr_data}" | jq -r '.number')
     org=$(echo "${pr_data}" | jq -r '.org')
     repo=$(echo "${pr_data}" | jq -r '.repo')
     head_ref=$(echo "${pr_data}" | jq -r '.head_ref')
-    is_fork=$(echo "${pr_data}" | jq -r '.is_fork // false')
 
     # Determine review mode based on local git state:
     # 1. Fast path: in the same repo AND on the PR's branch (agents use Read tool)
@@ -933,12 +932,10 @@ handle_pr_review() {
             if [[ -n "${expected_ref}" ]]; then
                 # Same repo, different branch. Fetch the PR ref so agents can
                 # read files via `git show <ref>:<path>` without checkout.
-                local fetch_err fetch_source
-                if [[ "${is_fork}" == "true" ]]; then
-                    fetch_source="+pull/${pr_number}/head:${expected_ref}"
-                else
-                    fetch_source="+${head_ref}:${expected_ref}"
-                fi
+                # Uses pull/N/head for all PRs (fork and non-fork) since it's
+                # maintained by GitHub and works even after branch deletion.
+                local fetch_err
+                local fetch_source="+pull/${pr_number}/head:${expected_ref}"
 
                 if fetch_err=$(git fetch origin "${fetch_source}" 2>&1); then
                     file_ref="${expected_ref}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -362,7 +362,7 @@ build_review_data() {
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
-        + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")))')
+        + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"
     debug_time "00-orchestrator" "end"
@@ -884,15 +884,19 @@ handle_pr_review() {
     local pr_data
     pr_data=$("${SCRIPT_DIR}/pr-context.sh" "${pr_identifier}")
 
-    local pr_number org repo head_ref
+    local pr_number org repo head_ref is_fork
     pr_number=$(echo "${pr_data}" | jq -r '.number')
     org=$(echo "${pr_data}" | jq -r '.org')
     repo=$(echo "${pr_data}" | jq -r '.repo')
     head_ref=$(echo "${pr_data}" | jq -r '.head_ref')
+    is_fork=$(echo "${pr_data}" | jq -r '.is_fork // false')
 
-    # Check if we're on the matching branch (enables richer local context)
-    # Conditions: in a git repo, repo matches PR's repo, branch matches PR's head branch
+    # Determine review mode based on local git state:
+    # 1. Fast path: in the same repo AND on the PR's branch (agents use Read tool)
+    # 2. Middle case: in the same repo but on a different branch (agents use git show)
+    # 3. Remote-only: not in the repo at all (agents work from diff only)
     local git_context=""
+    local file_ref=""
 
     if git rev-parse --git-dir > /dev/null 2>&1; then
         source "${SCRIPT_DIR}/helpers/git-helpers.sh"
@@ -904,16 +908,33 @@ handle_pr_review() {
         local current_branch
         current_branch=$(git branch --show-current 2> /dev/null || echo "")
 
-        # Normalize org names to lowercase for comparison
-        current_org=$(echo "${current_org}" | tr '[:upper:]' '[:lower:]')
-
-        if [[ "${current_org}" = "${org}" ]] && [[ "${current_repo}" = "${repo}" ]] && [[ "${current_branch}" = "${head_ref}" ]]; then
+        if [[ "${current_org}" = "${org}" ]] && [[ "${current_repo}" = "${repo}" ]]; then
             git_context=$("${SCRIPT_DIR}/git-context.sh")
+
+            if [[ "${current_branch}" != "${head_ref}" ]]; then
+                # Same repo, different branch. Fetch the PR ref so agents can
+                # read files via `git show <ref>:<path>` without checkout.
+                local fetch_err
+                if [[ "${is_fork}" == "true" ]]; then
+                    local pr_ref="refs/review/pr-${pr_number}"
+                    if fetch_err=$(git fetch origin "pull/${pr_number}/head:${pr_ref}" 2>&1); then
+                        file_ref="${pr_ref}"
+                    else
+                        warning "Failed to fetch PR ref for fork PR #${pr_number}: ${fetch_err}"
+                    fi
+                else
+                    if fetch_err=$(git fetch origin "${head_ref}" 2>&1); then
+                        file_ref="origin/${head_ref}"
+                    else
+                        warning "Failed to fetch origin/${head_ref}: ${fetch_err}"
+                    fi
+                fi
+            fi
         fi
     fi
 
-    # If not on fast path, construct a synthetic git_context with PR's org/repo
-    # Note: working_dir is null when not on fast path (no meaningful local directory)
+    # If not in the same repo, construct a synthetic git_context with PR's org/repo.
+    # working_dir is null since there's no meaningful local directory.
     if [[ -z "${git_context}" ]]; then
         git_context=$(jq -n \
             --arg org "${org}" \
@@ -934,7 +955,8 @@ handle_pr_review() {
     diff_content=$(echo "${pr_data}" | jq -r '.diff')
 
     build_review_data "pr" "${diff_content}" "${git_context}" "pr-${pr_number}" "${pr_data}" \
-        --arg mode_branch "${head_ref}"
+        --arg mode_branch "${head_ref}" \
+        --arg mode_file_ref "${file_ref}"
 }
 
 # Handle commit review

--- a/tests/unit/test-conditional-json-building.bats
+++ b/tests/unit/test-conditional-json-building.bats
@@ -238,6 +238,15 @@ setup_test_git_repo() {
     [[ ! "$org" =~ [A-Z] ]]
 }
 
+@test "get_git_org_repo: returns lowercase repo" {
+    run bash -c "cd '$PROJECT_ROOT' && source skills/review-code/scripts/helpers/git-helpers.sh && get_git_org_repo"
+    [ "$status" -eq 0 ]
+
+    repo="${output#*|}"
+    # Repo should be lowercase (no uppercase letters)
+    [[ ! "$repo" =~ [A-Z] ]]
+}
+
 # =============================================================================
 # display_summary Field Tests
 # =============================================================================

--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -129,6 +129,26 @@ setup() {
     [[ "$output" == *"|42" ]]
 }
 
+@test "pr-context.sh: normalizes repo to lowercase" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && parse_pr_identifier 'https://github.com/PostHog/PostHog/pull/789'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "posthog|posthog|789" ]
+}
+
+# =============================================================================
+# is_fork / isCrossRepository tests
+# =============================================================================
+
+@test "pr-context.sh: fetch_pr_metadata requests isCrossRepository field" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && declare -f fetch_pr_metadata | grep -q 'isCrossRepository'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: main outputs is_fork field in JSON" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && declare -f main | grep -q 'is_fork'"
+    [ "$status" -eq 0 ]
+}
+
 # =============================================================================
 # Input validation tests
 # =============================================================================

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -717,3 +717,22 @@ teardown() {
     has_file_ref=$(echo "$output" | jq 'has("file_ref")')
     [ "$has_file_ref" = "false" ]
 }
+
+@test "review-orchestrator.sh: non-empty file_ref included in build_review_data output" {
+    # The jq filter in build_review_data strips mode_ prefixes and filters
+    # empty values. A non-empty mode_file_ref should pass through as file_ref.
+    run jq -n \
+        --arg mode_branch "feature-branch" \
+        --arg mode_file_ref "refs/review/pr-42" \
+        '$ARGS.named
+         | with_entries(select(.key | startswith("mode_")))
+         | with_entries(.key |= sub("^mode_"; ""))
+         | with_entries(select(.value != ""))'
+    [ "$status" -eq 0 ]
+
+    file_ref=$(echo "$output" | jq -r '.file_ref')
+    [ "$file_ref" = "refs/review/pr-42" ]
+
+    branch=$(echo "$output" | jq -r '.branch')
+    [ "$branch" = "feature-branch" ]
+}

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -643,3 +643,111 @@ teardown() {
 
     [ "$is_own_pr" = "false" ]
 }
+
+# =============================================================================
+# Cross-branch PR review tests (file_ref / working_dir behavior)
+# =============================================================================
+
+@test "review-orchestrator.sh: file_ref is omitted on fast path (same branch)" {
+    # Simulate fast path: current branch matches PR head_ref
+    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+
+    local current_branch="feature-branch"
+    local head_ref="feature-branch"
+    local file_ref=""
+
+    # On the fast path, current_branch == head_ref, so file_ref stays empty
+    if [[ "${current_branch}" != "${head_ref}" ]]; then
+        file_ref="origin/${head_ref}"
+    fi
+
+    [ -z "$file_ref" ]
+}
+
+@test "review-orchestrator.sh: file_ref is set on cross-branch (different branch)" {
+    # Simulate middle case: same repo, different branch, fetch succeeds
+    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+
+    local current_branch="main"
+    local head_ref="feature-branch"
+    local is_fork="false"
+    local file_ref=""
+
+    if [[ "${current_branch}" != "${head_ref}" ]]; then
+        if [[ "${is_fork}" == "true" ]]; then
+            file_ref="refs/review/pr-42"
+        else
+            file_ref="origin/${head_ref}"
+        fi
+    fi
+
+    [ "$file_ref" = "origin/feature-branch" ]
+}
+
+@test "review-orchestrator.sh: file_ref uses PR ref for fork PRs" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+
+    local current_branch="main"
+    local head_ref="fork-feature"
+    local is_fork="true"
+    local pr_number="42"
+    local file_ref=""
+
+    if [[ "${current_branch}" != "${head_ref}" ]]; then
+        if [[ "${is_fork}" == "true" ]]; then
+            file_ref="refs/review/pr-${pr_number}"
+        else
+            file_ref="origin/${head_ref}"
+        fi
+    fi
+
+    [ "$file_ref" = "refs/review/pr-42" ]
+}
+
+@test "review-orchestrator.sh: working_dir nulled when fetch fails on cross-branch" {
+    # Simulate: same repo, different branch, fetch fails → file_ref empty
+    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+
+    local current_branch="main"
+    local head_ref="feature-branch"
+    local file_ref=""
+    local git_context='{"working_dir": "/some/path", "org": "testorg", "repo": "testrepo"}'
+
+    # Simulate fetch failure: file_ref stays empty
+    if [[ "${current_branch}" != "${head_ref}" && -z "${file_ref}" ]]; then
+        git_context=$(echo "${git_context}" | jq '.working_dir = null')
+    fi
+
+    working_dir=$(echo "${git_context}" | jq -r '.working_dir')
+    [ "$working_dir" = "null" ]
+}
+
+@test "review-orchestrator.sh: working_dir preserved when fetch succeeds on cross-branch" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+
+    local current_branch="main"
+    local head_ref="feature-branch"
+    local file_ref="origin/feature-branch"
+    local git_context='{"working_dir": "/some/path", "org": "testorg", "repo": "testrepo"}'
+
+    # Fetch succeeded: file_ref is set, so working_dir stays
+    if [[ "${current_branch}" != "${head_ref}" && -z "${file_ref}" ]]; then
+        git_context=$(echo "${git_context}" | jq '.working_dir = null')
+    fi
+
+    working_dir=$(echo "${git_context}" | jq -r '.working_dir')
+    [ "$working_dir" = "/some/path" ]
+}
+
+@test "review-orchestrator.sh: empty file_ref excluded from build_review_data output" {
+    # build_review_data filters out empty mode_ values, so file_ref shouldn't
+    # appear in the output when it's empty (fast path)
+    echo "change" > file.txt
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+    [ "$status" -eq 0 ]
+
+    # Local mode doesn't set file_ref, so it shouldn't be in output
+    has_file_ref=$(echo "$output" | jq 'has("file_ref")')
+    [ "$has_file_ref" = "false" ]
+}

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -648,93 +648,59 @@ teardown() {
 # Cross-branch PR review tests (file_ref / working_dir behavior)
 # =============================================================================
 
-@test "review-orchestrator.sh: file_ref is omitted on fast path (same branch)" {
-    # Simulate fast path: current branch matches PR head_ref
+@test "review-orchestrator.sh: determine_file_ref returns empty on fast path (same branch)" {
     source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
 
-    local current_branch="feature-branch"
-    local head_ref="feature-branch"
-    local file_ref=""
+    local result
+    result=$(determine_file_ref "feature-branch" "feature-branch" "42")
 
-    # On the fast path, current_branch == head_ref, so file_ref stays empty
-    if [[ "${current_branch}" != "${head_ref}" ]]; then
-        file_ref="origin/${head_ref}"
-    fi
-
-    [ -z "$file_ref" ]
+    [ -z "$result" ]
 }
 
-@test "review-orchestrator.sh: file_ref is set on cross-branch (different branch)" {
-    # Simulate middle case: same repo, different branch, fetch succeeds
+@test "review-orchestrator.sh: determine_file_ref returns review ref on cross-branch" {
     source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
 
-    local current_branch="main"
-    local head_ref="feature-branch"
-    local is_fork="false"
-    local file_ref=""
+    local result
+    result=$(determine_file_ref "main" "feature-branch" "42")
 
-    if [[ "${current_branch}" != "${head_ref}" ]]; then
-        if [[ "${is_fork}" == "true" ]]; then
-            file_ref="refs/review/pr-42"
-        else
-            file_ref="origin/${head_ref}"
-        fi
-    fi
-
-    [ "$file_ref" = "origin/feature-branch" ]
+    [ "$result" = "refs/review/pr-42" ]
 }
 
-@test "review-orchestrator.sh: file_ref uses PR ref for fork PRs" {
+@test "review-orchestrator.sh: determine_file_ref returns same ref format for fork PRs" {
     source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
 
-    local current_branch="main"
-    local head_ref="fork-feature"
-    local is_fork="true"
-    local pr_number="42"
-    local file_ref=""
+    local result
+    result=$(determine_file_ref "main" "fork-feature" "99")
 
-    if [[ "${current_branch}" != "${head_ref}" ]]; then
-        if [[ "${is_fork}" == "true" ]]; then
-            file_ref="refs/review/pr-${pr_number}"
-        else
-            file_ref="origin/${head_ref}"
-        fi
-    fi
-
-    [ "$file_ref" = "refs/review/pr-42" ]
+    [ "$result" = "refs/review/pr-99" ]
 }
 
-@test "review-orchestrator.sh: working_dir nulled when fetch fails on cross-branch" {
-    # Simulate: same repo, different branch, fetch fails → file_ref empty
-    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
-
-    local current_branch="main"
-    local head_ref="feature-branch"
+@test "review-orchestrator.sh: working_dir nulled when file_ref is empty on cross-branch" {
+    # Spec test: when fetch fails (file_ref empty) on a different branch,
+    # working_dir must be nulled to prevent agents reading the wrong branch.
     local file_ref=""
     local git_context='{"working_dir": "/some/path", "org": "testorg", "repo": "testrepo"}'
 
-    # Simulate fetch failure: file_ref stays empty
-    if [[ "${current_branch}" != "${head_ref}" && -z "${file_ref}" ]]; then
+    if [[ -z "${file_ref}" ]]; then
         git_context=$(echo "${git_context}" | jq '.working_dir = null')
     fi
 
+    local working_dir
     working_dir=$(echo "${git_context}" | jq -r '.working_dir')
     [ "$working_dir" = "null" ]
 }
 
-@test "review-orchestrator.sh: working_dir preserved when fetch succeeds on cross-branch" {
-    source "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
-
-    local current_branch="main"
-    local head_ref="feature-branch"
-    local file_ref="origin/feature-branch"
+@test "review-orchestrator.sh: working_dir preserved when file_ref is set" {
+    # Spec test: when fetch succeeds (file_ref set), working_dir stays so
+    # agents can use Grep/Glob for pattern discovery alongside git show.
+    local file_ref="refs/review/pr-42"
     local git_context='{"working_dir": "/some/path", "org": "testorg", "repo": "testrepo"}'
 
-    # Fetch succeeded: file_ref is set, so working_dir stays
-    if [[ "${current_branch}" != "${head_ref}" && -z "${file_ref}" ]]; then
+    if [[ -z "${file_ref}" ]]; then
         git_context=$(echo "${git_context}" | jq '.working_dir = null')
     fi
 
+    local working_dir
     working_dir=$(echo "${git_context}" | jq -r '.working_dir')
     [ "$working_dir" = "/some/path" ]
 }

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -705,17 +705,24 @@ teardown() {
     [ "$working_dir" = "/some/path" ]
 }
 
-@test "review-orchestrator.sh: empty file_ref excluded from build_review_data output" {
-    # build_review_data filters out empty mode_ values, so file_ref shouldn't
-    # appear in the output when it's empty (fast path)
-    echo "change" > file.txt
-
-    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+@test "review-orchestrator.sh: empty file_ref stripped by build_review_data jq filter" {
+    # When mode_file_ref is explicitly passed as empty (cross-branch fetch
+    # failure), the with_entries(select(.value != "")) filter should strip it.
+    run jq -n \
+        --arg mode_branch "feature-branch" \
+        --arg mode_file_ref "" \
+        '$ARGS.named
+         | with_entries(select(.key | startswith("mode_")))
+         | with_entries(.key |= sub("^mode_"; ""))
+         | with_entries(select(.value != ""))'
     [ "$status" -eq 0 ]
 
-    # Local mode doesn't set file_ref, so it shouldn't be in output
     has_file_ref=$(echo "$output" | jq 'has("file_ref")')
     [ "$has_file_ref" = "false" ]
+
+    # Non-empty mode values should still pass through
+    branch=$(echo "$output" | jq -r '.branch')
+    [ "$branch" = "feature-branch" ]
 }
 
 @test "review-orchestrator.sh: non-empty file_ref included in build_review_data output" {


### PR DESCRIPTION
## Summary

- Allow reviewing PRs without being on the PR's branch. When in the same repo but on a different branch, the orchestrator fetches the PR ref and passes a `file_ref` so agents can read files via `git show <ref>:<path>` without modifying the working tree. Handles both same-repo and fork PRs.
- Normalize repo names to lowercase alongside org names for case-insensitive comparison.
- Deduplicate file access instructions in SKILL.md into a single `$file_access_instructions` block referenced by both the context explorer and specialized agent prompts.
- Surface `git fetch` stderr in warning messages instead of swallowing it.

## Test plan

- [x] All 919 unit tests pass
- [x] All 12 integration tests pass
- [ ] Test reviewing a PR while on a different branch in the same repo
- [ ] Test reviewing a fork PR while on a different branch
- [ ] Test reviewing a PR while on the PR's branch (fast path still works)
- [ ] Test reviewing a PR from outside the repo (remote-only still works)