### PR TITLE
Centralize comment prefixes and exclude confidence percentages

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -320,10 +320,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Fundamental architectural problem (wrong approach, unnecessary complexity) — must fix before merge. Use sparingly.
-- **suggestion:** Better approach exists (reuse, simpler pattern, established library) — worth considering, but author's call.
-- **question:** Design intent or trade-off is unclear — asking for clarification.
-- **nit:** Minor idiom or simplification opportunity — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -316,17 +316,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Architectural Assessment**: Is the overall approach sound?

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -218,17 +218,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Compatibility Assessment**: Overall backwards compatibility status

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -222,10 +222,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Direct breaking change that will fail in production — must fix before merge. Use sparingly.
-- **suggestion:** Breaking change that affects a subset of users or edge cases — worth fixing, but author's call.
-- **question:** Unclear whether a change is intentional or breaks consumers — asking for clarification.
-- **nit:** Deprecation opportunity or minor compatibility concern — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -275,17 +275,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Intent Verification**: Does the code achieve what the PR claims?

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -279,10 +279,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Code will not work correctly at runtime — must fix before merge. Use sparingly.
-- **suggestion:** Code may fail in some scenarios or violates contracts — worth fixing, but author's call.
-- **question:** Something is unclear or surprising — asking for clarification, not necessarily a problem.
-- **nit:** Minor inconsistency or style issue — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -141,17 +141,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Frontend Health**: Brief assessment of component/state architecture

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -145,10 +145,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Bug or accessibility violation — must fix before merge. Use sparingly.
-- **suggestion:** Frontend issue worth fixing (performance, patterns, state management) — author's call.
-- **question:** Component behavior or design intent is unclear — asking for clarification.
-- **nit:** Minor optimization or pattern improvement — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -221,17 +221,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **What's Working Well**: Acknowledge good maintainability practices

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -225,10 +225,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Makes code confusing or dangerous to modify — must fix before merge. Use sparingly.
-- **suggestion:** Impacts long-term maintainability — worth fixing, but author's call.
-- **question:** Something about the design or intent is unclear — asking for clarification.
-- **nit:** Style, naming, or minor readability issue — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -93,10 +93,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Severe performance degradation (>100ms latency, >2x memory) — must fix before merge. Use sparingly.
-- **suggestion:** Noticeable performance impact — worth fixing, but author's call.
-- **question:** Performance implication is unclear — asking for clarification or measurement data.
-- **nit:** Micro-optimization or best practice — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -89,17 +89,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Performance Wins**: Acknowledge good performance practices first

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -91,10 +91,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Exploitable vulnerability — must fix before merge. Use sparingly.
-- **suggestion:** Security weakness that should be addressed — worth fixing, but author's call.
-- **question:** Something about the security model is unclear — asking for clarification.
-- **nit:** Defense-in-depth improvement — take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -87,17 +87,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 **Response Structure:**
 
 1. **Security Posture**: Brief assessment of overall security state

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -119,17 +119,6 @@ Before including any finding, argue against it:
 
 ## Feedback Format
 
-**Comment Prefixes:**
-
-Prefix every finding so the author knows what action is expected:
-
-- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
-- `nit:` A minor style or naming suggestion. Take it or leave it.
-- `suggestion:` A different approach worth considering, but the author's call.
-- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
-
-If a comment has no prefix, assume it's a suggestion.
-
 ### blocking: examples
 Tests that are fundamentally broken, missing for critical functionality, or create significant quality risks:
 - Missing tests for new features or bug fixes

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -123,10 +123,10 @@ Before including any finding, argue against it:
 
 Prefix every finding so the author knows what action is expected:
 
-- **blocking:** Must fix before merge. Use sparingly.
-- **suggestion:** Worth fixing, but author's call.
-- **question:** Asking for clarification, not necessarily a problem.
-- **nit:** Minor style or naming suggestion. Take it or leave it.
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
 
 If a comment has no prefix, assume it's a suggestion.
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -788,6 +788,7 @@ If `--draft` was specified and this is a PR review (not own PR), create a pendin
 - The full detailed review stays in the markdown file only
 - NEVER use `gh pr review` directly - always use `create-draft-review.sh`
 - NEVER post the full review summary to GitHub
+- NEVER include confidence percentages in GitHub comments — confidence is internal review metadata only
 
 **Check if draft mode is enabled:**
 
@@ -805,7 +806,7 @@ If any condition fails, skip draft review creation.
 1. **Extract suggested comments from the review**: Parse the "Suggested Comments" section to get:
    - File path
    - Line number
-   - Comment body (without metadata like agent name/confidence)
+   - Comment body — extract ONLY the text inside the ` ```text ``` ` code block
 
    Look for the pattern in the review file:
    ```
@@ -814,6 +815,8 @@ If any condition fails, skip draft review creation.
    <comment body>
    ```
    ```
+
+   **CRITICAL**: Do NOT include the `*From: <Agent Name> (<confidence>% confidence)*` metadata line in the comment body. Confidence percentages are internal review metadata only — they must never appear in public GitHub comments. Extract only what is inside the ` ```text ``` ` block.
 
 2. **Get the diff for position mapping**: Use the `diff` field from the session data (already read via Read tool).
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -531,6 +531,17 @@ For each finding you report:
 4. For bug claims: read surrounding code to confirm the behavior before reporting
 Do NOT report anything as a bug unless you've verified the behavior by reading the code.
 
+**Comment Prefixes:**
+
+Prefix every finding so the author knows what action is expected:
+
+- `blocking:` This must be fixed before merge. Use sparingly — reserve it for bugs, security issues, or things that will break.
+- `nit:` A minor style or naming suggestion. Take it or leave it.
+- `suggestion:` A different approach worth considering, but the author's call.
+- `question:` You don't understand something. Not necessarily a problem, but you'd like clarification.
+
+If a comment has no prefix, assume it's a suggestion.
+
 {If previous_review exists:}
 **Previous Review:**
 $previous_review


### PR DESCRIPTION
## Summary

- Exclude confidence percentages from draft PR comments to reduce noise
- Standardize comment prefix format (`blocking:`, `nit:`, `suggestion:`, `question:`) across all review agents
- Centralize comment prefix definitions into the SKILL.md prompt template, removing duplication from all 8 reviewer agent files

## Test plan

- [x] All 906 unit tests pass
- [x] All 12 integration tests pass
- [x] `bin/setup` installs cleanly
- [x] `bin/fmt` runs clean
- [x] Testing agent's domain-specific examples (blocking/suggestion/nit) preserved
- [x] Prefix definitions appear only in SKILL.md prompt template