### PR TITLE
Fix find mode extracting org/repo from PR URL

### DIFF
--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -65,9 +65,19 @@ main() {
 
     case "${mode}" in
         "pr")
-            # For PR mode, use helper function to parse identifier
+            # Use pr_url or pr_number from the parse result, not the raw arg.
+            # When invoked as "find <url>", arg is "find" which parse_pr_identifier
+            # can't extract org/repo from. The parse result has the actual PR ref.
+            local pr_identifier
+            pr_identifier=$(echo "${parse_result}" | jq -r '.pr_url // empty')
+            if [[ -z "${pr_identifier}" ]]; then
+                pr_identifier=$(echo "${parse_result}" | jq -r '.pr_number // empty')
+            fi
+            if [[ -z "${pr_identifier}" ]]; then
+                pr_identifier="${identifier}"
+            fi
             local pr_data
-            pr_data=$(parse_pr_identifier "${identifier}")
+            pr_data=$(parse_pr_identifier "${pr_identifier}")
             org="${pr_data%%|*}"
             repo=$(echo "${pr_data}" | cut -d'|' -f2)
             identifier="${pr_data##*|}"

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -484,6 +484,20 @@ teardown() {
     [[ "$display_target" == *"PR"* ]] || [[ "$display_target" == *"123"* ]]
 }
 
+@test "review-orchestrator.sh: find mode with PR URL extracts org/repo from URL" {
+    # When running "find <url>", org/repo should come from the URL, not the local repo.
+    # The local repo is testorg/testrepo, but the URL points to otherorg/otherrepo.
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh" find "https://github.com/otherorg/otherrepo/pull/456"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.status == "find"'
+
+    # file_info.file_path should contain the URL's org/repo, not the local repo's
+    file_path=$(echo "$output" | jq -r '.file_info.file_path')
+    [[ "$file_path" == *"otherorg/otherrepo"* ]]
+    # Must NOT contain the local repo's org/repo
+    [[ "$file_path" != *"testorg/testrepo"* ]]
+}
+
 @test "review-orchestrator.sh: find mode with branch" {
     # Create feature branch
     git checkout -b find-test-branch


### PR DESCRIPTION
## Summary

- When running `find <url>`, the orchestrator passed the raw first arg (`"find"`) to `parse_pr_identifier`, which couldn't extract org/repo and fell back to the local repo. Now uses `pr_url` or `pr_number` from the parse result instead.

## Test plan

- [x] New test verifies `find https://github.com/otherorg/otherrepo/pull/456` produces a file path with `otherorg/otherrepo`, not the local repo
- [x] All 916 existing tests pass