### PR TITLE
Add skill-scoped hook to block direct GitHub review operations

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -2,6 +2,12 @@
 description: Run specialized code review agents on code changes or pull requests
 argument-hint: [find|learn|pr|commit|branch|range|area]
 allowed-tools: Bash(~/.claude/skills/review-code/scripts/*:*), Read(~/.claude/**), Write(~/.claude/skills/review-code/learnings/*), Edit(~/.claude/skills/review-code/learnings/*)
+hooks:
+  PreToolUse:
+    - matcher: Bash
+      hooks:
+        - type: command
+          command: ~/.claude/skills/review-code/scripts/review-safety-hook.sh
 ---
 
 Run specialized code review agent(s) with comprehensive context on local changes or pull requests.

--- a/skills/review-code/scripts/review-safety-hook.sh
+++ b/skills/review-code/scripts/review-safety-hook.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# review-safety-hook.sh - PreToolUse hook that blocks direct GitHub review operations
+#
+# The review-code skill must use create-draft-review.sh for all GitHub review
+# operations. This hook enforces that by blocking direct gh CLI and API calls
+# that would bypass the script's safety guarantees (pending vs submitted state,
+# duplicate review detection, etc.).
+#
+# Blocked patterns:
+#   - gh pr review    (submits/creates reviews directly)
+#   - gh api with review endpoints (bypasses create-draft-review.sh)
+#
+# Input: JSON on stdin (Claude Code PreToolUse hook format)
+# Output: JSON with permissionDecision (deny or allow)
+
+set -euo pipefail
+
+input=$(cat)
+command=$(echo "$input" | jq -r '.tool_input.command // ""')
+
+# Allow empty commands (shouldn't happen, but be safe)
+if [[ -z "$command" ]]; then
+    exit 0
+fi
+
+# Block direct gh pr review commands
+if echo "$command" | grep -qE '\bgh\s+pr\s+review\b'; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: "Direct gh pr review is blocked during code review. Use create-draft-review.sh instead, which ensures reviews stay in PENDING state and handles duplicate detection."
+        }
+    }'
+    exit 0
+fi
+
+# Block direct gh api calls to review endpoints
+if echo "$command" | grep -qE '\bgh\s+api\b.*\brepos/[^/]+/[^/]+/pulls/[0-9]+/reviews\b'; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: "Direct GitHub API calls to review endpoints are blocked during code review. Use create-draft-review.sh instead."
+        }
+    }'
+    exit 0
+fi
+
+# Allow everything else
+exit 0

--- a/tests/unit/test-review-safety-hook.bats
+++ b/tests/unit/test-review-safety-hook.bats
@@ -1,0 +1,131 @@
+#!/usr/bin/env bats
+# Tests for review-safety-hook.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/review-safety-hook.sh"
+}
+
+# Helper to build hook input JSON for a given command
+make_input() {
+    local cmd="$1"
+    printf '{"tool_input":{"command":"%s"}}' "$cmd"
+}
+
+# =============================================================================
+# Blocked commands
+# =============================================================================
+
+@test "blocks gh pr review" {
+    result=$(make_input "gh pr review 123 --approve" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks gh pr review with flags" {
+    result=$(make_input "gh pr review 123 --comment --body 'looks good'" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks gh pr review with extra whitespace" {
+    result=$(make_input "gh  pr  review 456" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks gh api to review endpoint" {
+    result=$(make_input "gh api repos/posthog/posthog/pulls/123/reviews --method POST" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks gh api to review endpoint with different org/repo" {
+    result=$(make_input "gh api repos/myorg/myrepo/pulls/456/reviews" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "block reason mentions create-draft-review.sh for gh pr review" {
+    result=$(make_input "gh pr review 123" | bash "$SCRIPT")
+    reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    [[ "$reason" == *"create-draft-review.sh"* ]]
+}
+
+@test "block reason mentions create-draft-review.sh for gh api" {
+    result=$(make_input "gh api repos/org/repo/pulls/1/reviews" | bash "$SCRIPT")
+    reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    [[ "$reason" == *"create-draft-review.sh"* ]]
+}
+
+# =============================================================================
+# Allowed commands
+# =============================================================================
+
+@test "allows gh pr view" {
+    result=$(make_input "gh pr view 123" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows gh pr list" {
+    result=$(make_input "gh pr list --repo posthog/posthog" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows gh pr diff" {
+    result=$(make_input "gh pr diff 123" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows gh pr checks" {
+    result=$(make_input "gh pr checks 123" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows gh issue view" {
+    result=$(make_input "gh issue view 123" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows create-draft-review.sh" {
+    result=$(make_input "~/.claude/skills/review-code/scripts/create-draft-review.sh" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows other bash commands" {
+    result=$(make_input "git diff HEAD~1" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows gh api to non-review endpoints" {
+    result=$(make_input "gh api repos/org/repo/pulls/123/comments" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows empty command" {
+    result=$(echo '{"tool_input":{}}' | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+# =============================================================================
+# Edge cases
+# =============================================================================
+
+@test "does not block gh pr review in a comment or echo" {
+    # If someone echoes the text, grep will match it, but that's acceptable —
+    # better to over-block than under-block for safety-critical operations
+    result=$(make_input "echo 'do not run gh pr review'" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "exits 0 for allowed commands" {
+    make_input "ls -la" | bash "$SCRIPT"
+    [ $? -eq 0 ]
+}
+
+@test "exits 0 for blocked commands" {
+    make_input "gh pr review 123" | bash "$SCRIPT"
+    [ $? -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` hook in the SKILL.md frontmatter that blocks `gh pr review` and direct `gh api` calls to review endpoints
- The hook enforces programmatically what was previously instruction-only: all review operations must go through `create-draft-review.sh`
- Includes 19 bats tests covering blocked commands, allowed commands, and edge cases

## Motivation

The review-code skill has several critical safety guardrails (never use `gh pr review` directly, never bypass `create-draft-review.sh`) that relied on Claude following instructions. Skill-scoped hooks turn these from "please don't" into hard blocks that can't be bypassed.

## Test plan

- [x] All 935 unit tests pass
- [x] All 12 integration tests pass
- [x] New `test-review-safety-hook.bats` covers:
  - Blocking `gh pr review` (with various flags/whitespace)
  - Blocking `gh api repos/.../pulls/.../reviews`
  - Allowing `gh pr view`, `gh pr list`, `gh pr diff`, etc.
  - Allowing `create-draft-review.sh` itself
  - Allowing non-review `gh api` endpoints
  - Edge cases (empty commands, echoed text)