### PR TITLE
Enable extended thinking for review synthesis

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -272,6 +272,8 @@ Agents to invoke:
 
 ### Collect and Present Results
 
+Use ultrathink to synthesize findings from all agents into a coherent, deduplicated review.
+
 After all agents complete, combine their findings into a single review document.
 
 **Verify findings against the diff before including them in the final review.**


### PR DESCRIPTION
## Summary

- Adds the `ultrathink` keyword to the review handler's "Collect and Present Results" section
- This enables Claude's extended thinking mode during the most cognitively demanding part of the review: synthesizing findings from 7+ parallel agents into a coherent, deduplicated document

## Context

The review synthesis step requires Claude to:
1. Combine findings from up to 8 specialized agents
2. Validate each finding against the diff
3. Deduplicate overlapping findings across agents
4. Produce a coherent review document with proper categorization

Extended thinking gives Claude more "scratch space" for this synthesis, which should improve review quality.

## Test plan

- [x] All 916 unit tests pass
- [x] All 12 integration tests pass
- [ ] Manual testing: run a review and observe synthesis quality