### PR TITLE
Update tests README to reflect current coverage

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,11 +20,13 @@ bats -t tests/unit/*.bats
 ```
 tests/
 ├── unit/               # Unit tests for individual scripts
-│   ├── test-pre-review-context.bats
-│   └── test-code-language-detect.bats
-├── integration/        # Integration tests for workflows (TODO)
-├── fixtures/          # Test data and sample files (TODO)
-└── helpers/           # Shared test utilities (TODO)
+├── integration/        # End-to-end workflow tests
+├── fixtures/           # Test data (diffs, PR data, review files)
+│   ├── diffs/
+│   ├── files/
+│   ├── pr-data/
+│   └── reviews/
+└── helpers/            # Shared test utilities
 ```
 
 ## Writing Tests
@@ -50,18 +52,6 @@ Tests use BATS syntax:
 - Use `[ -x file ]` to check if file is executable
 - Use `skip "reason"` to skip tests temporarily
 
-## Test Coverage
-
-Current coverage:
-
-- ✅ `pre-review-context.sh` - 12 tests
-- ✅ `code-language-detect.sh` - 18 tests
-- ⏳ `incremental-diff.sh` - TODO
-- ⏳ `parse-review-arg.sh` - TODO (priority: high)
-- ⏳ `review-file-path.sh` - TODO (priority: high - security critical)
-- ⏳ `review-orchestrator.sh` - TODO
-- ⏳ Other lib scripts - TODO
-
 ## Installation
 
 Install BATS:
@@ -79,27 +69,14 @@ cd bats-core
 ./install.sh /usr/local
 ```
 
-## CI Integration
-
-Tests should be run automatically on every commit. Add to your git hooks:
-
-```bash
-# .git/hooks/pre-commit
-#!/bin/bash
-bin/test || exit 1
-```
-
-Or use GitHub Actions (see `.github/workflows/test.yml` if available).
-
 ## Known Issues
 
-- `code-language-detect.sh` matches framework imports in comments (test skipped, needs fix)
 - Empty diffs produce arrays with one empty string instead of empty arrays
 
 ## Contributing
 
 When adding new scripts:
+
 1. Create corresponding test file in `tests/unit/`
 2. Write tests for happy path, edge cases, and error conditions
 3. Ensure `bin/test` passes before committing
-4. Aim for 80%+ coverage on critical scripts


### PR DESCRIPTION
## Summary

- Removes stale "Test Coverage" section that listed most scripts as untested (they all have tests now)
- Updates directory tree to show actual structure (fixtures, helpers, integration tests)
- Removes known issue about comment matching (being fixed separately)
- Removes stale CI integration section

## Test plan

- [x] No code changes, documentation only