### PR TITLE
Fix framework detection matching imports inside comments

### DIFF
--- a/skills/review-code/scripts/code-language-detect.sh
+++ b/skills/review-code/scripts/code-language-detect.sh
@@ -123,8 +123,27 @@ while IFS= read -r framework; do
             ;;
     esac
 done < <(echo "${diff_content}" | awk '
-    # Skip lines where the code (after optional diff +/- prefix) is a comment
-    /^[+-]?[[:space:]]*(\/\/|\/\*|#|--|""")/ { next }
+    BEGIN { in_block = 0 }
+    {
+        # Strip optional diff +/- prefix to get actual code content
+        line = $0
+        sub(/^[+-]/, "", line)
+
+        # Inside a multi-line /* */ block comment, skip until closing */
+        if (in_block) {
+            if (line ~ /\*\//) in_block = 0
+            next
+        }
+
+        # Detect block comment opening (including JSDoc /**)
+        if (line ~ /^[[:space:]]*\/\*/) {
+            if (line !~ /\*\//) in_block = 1
+            next
+        }
+
+        # Skip single-line comments
+        if (line ~ /^[[:space:]]*(\/\/|#|--|""")/) next
+    }
     /import.*from ["'\'']react["'\'']|import React/ { print "react"; next }
     /import.*from ["'\'']kea["'\'']|useValues|useActions/ { print "kea"; next }
     /from django|import django/ { print "django"; next }

--- a/skills/review-code/scripts/code-language-detect.sh
+++ b/skills/review-code/scripts/code-language-detect.sh
@@ -123,6 +123,8 @@ while IFS= read -r framework; do
             ;;
     esac
 done < <(echo "${diff_content}" | awk '
+    # Skip lines where the code (after optional diff +/- prefix) is a comment
+    /^[+-]?[[:space:]]*(\/\/|\/\*|#|--|""")/ { next }
     /import.*from ["'\'']react["'\'']|import React/ { print "react"; next }
     /import.*from ["'\'']kea["'\'']|useValues|useActions/ { print "kea"; next }
     /from django|import django/ { print "django"; next }

--- a/skills/review-code/scripts/code-language-detect.sh
+++ b/skills/review-code/scripts/code-language-detect.sh
@@ -124,6 +124,8 @@ while IFS= read -r framework; do
     esac
 done < <(echo "${diff_content}" | awk '
     BEGIN { in_block = 0 }
+    # Reset block comment state at diff file boundaries
+    /^diff --git / { in_block = 0; next }
     {
         # Strip optional diff +/- prefix to get actual code content
         line = $0

--- a/tests/unit/test-code-language-detect.bats
+++ b/tests/unit/test-code-language-detect.bats
@@ -234,11 +234,7 @@ EOF
     echo "$result" | jq -e 'has("languages") and has("frameworks") and has("has_frontend") and has("file_extensions")'
 }
 
-@test "does not match commented imports" {
-    # This is a known issue - the current implementation matches commented imports
-    # This test documents the expected behavior once we fix it
-    skip "Known issue: matches commented imports"
-
+@test "does not match Python commented imports" {
     diff=$(cat <<'EOF'
 diff --git a/test.py b/test.py
 +++ b/test.py
@@ -250,6 +246,64 @@ EOF
 
     result=$(echo "$diff" | "$SCRIPT")
     echo "$result" | jq -e '.frameworks | contains(["django"]) | not'
+}
+
+@test "does not match JS single-line commented imports" {
+    diff=$(cat <<'EOF'
+diff --git a/test.tsx b/test.tsx
++++ b/test.tsx
+@@ -1,0 +1,2 @@
++// import React from 'react'
++const x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
+@test "does not match JS block-commented imports" {
+    diff=$(cat <<'EOF'
+diff --git a/test.tsx b/test.tsx
++++ b/test.tsx
+@@ -1,0 +1,2 @@
++/* import React from 'react' */
++const x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
+@test "does not match indented commented imports" {
+    diff=$(cat <<'EOF'
+diff --git a/test.py b/test.py
++++ b/test.py
+@@ -1,0 +1,2 @@
++    # from flask import Flask
++x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["flask"]) | not'
+}
+
+@test "still matches real imports alongside commented ones" {
+    diff=$(cat <<'EOF'
+diff --git a/test.py b/test.py
++++ b/test.py
+@@ -1,0 +1,3 @@
++# from flask import Flask
++from django.http import HttpResponse
++x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["django"])'
+    echo "$result" | jq -e '.frameworks | contains(["flask"]) | not'
 }
 
 @test "performance: single-pass framework detection" {

--- a/tests/unit/test-code-language-detect.bats
+++ b/tests/unit/test-code-language-detect.bats
@@ -356,6 +356,26 @@ EOF
     echo "$result" | jq -e '.frameworks | contains(["flask"]) | not'
 }
 
+@test "block comment state resets at diff file boundaries" {
+    diff=$(cat <<'EOF'
+diff --git a/first.tsx b/first.tsx
++++ b/first.tsx
+@@ -1,0 +1,2 @@
++/*
++import React from 'react'
+diff --git a/second.py b/second.py
++++ b/second.py
+@@ -1,0 +1,1 @@
++from django.http import HttpResponse
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    # The unclosed block comment in first.tsx should not suppress detection in second.py
+    echo "$result" | jq -e '.frameworks | contains(["django"])'
+    echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
 @test "performance: single-pass framework detection" {
     # Verify we're using single-pass awk, not multiple greps
     # This is a meta-test that checks the implementation

--- a/tests/unit/test-code-language-detect.bats
+++ b/tests/unit/test-code-language-detect.bats
@@ -262,7 +262,7 @@ EOF
     echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
 }
 
-@test "does not match JS block-commented imports" {
+@test "does not match single-line block-commented imports" {
     diff=$(cat <<'EOF'
 diff --git a/test.tsx b/test.tsx
 +++ b/test.tsx
@@ -274,6 +274,56 @@ EOF
 
     result=$(echo "$diff" | "$SCRIPT")
     echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
+@test "does not match multi-line block-commented imports" {
+    diff=$(cat <<'EOF'
+diff --git a/test.tsx b/test.tsx
++++ b/test.tsx
+@@ -1,0 +1,4 @@
++/*
++import React from 'react'
++*/
++const x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
+@test "does not match JSDoc block-commented imports" {
+    diff=$(cat <<'EOF'
+diff --git a/test.tsx b/test.tsx
++++ b/test.tsx
+@@ -1,0 +1,5 @@
++/**
++ * This component used to use React
++ * import React from 'react'
++ */
++const x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
+}
+
+@test "matches real imports after a multi-line block comment ends" {
+    diff=$(cat <<'EOF'
+diff --git a/test.tsx b/test.tsx
++++ b/test.tsx
+@@ -1,0 +1,5 @@
++/*
++ * old import, commented out
++ */
++import React from 'react'
++const x = 1
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.frameworks | contains(["react"])'
 }
 
 @test "does not match indented commented imports" {


### PR DESCRIPTION
## Summary

- Adds comment-skipping logic to the awk-based framework detector in `code-language-detect.sh`
- Single-line comments (`//`, `#`, `--`, `"""`) and block comments (`/* */`, `/** */`) are now ignored
- Multi-line block comments are handled with stateful tracking, skipping all lines between `/*` and `*/`
- Prevents commented-out imports from triggering false framework matches (e.g., the frontend review agent on non-frontend code)

## Problem

The framework detector scanned all diff lines for import patterns, including commented-out code. A line like `+# from django import models` would incorrectly detect Django, and `+// import React` would incorrectly detect React. Multi-line block comments like JSDoc blocks containing old imports would also trigger false matches.

## Changes

- **`code-language-detect.sh`**: Replaced the single-line comment regex with a stateful awk block that tracks `/* */` scope and skips single-line comments (`//`, `#`, `--`, `"""`)
- **`test-code-language-detect.bats`**: Added 8 test cases covering Python `#` comments, JS `//` comments, single-line `/* */` blocks, multi-line `/* */` blocks, JSDoc `/** */` blocks, indented comments, mixed real+commented imports, and real imports after a block comment ends

## Test plan

- [x] All 25 language detection unit tests pass
- [x] All 942 unit tests pass
- [x] All 12 integration tests pass