### PR TITLE
Improve review quality: concrete fixes, confidence filtering, caller context

### DIFF
--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -30,7 +30,7 @@ For each file in the diff:
 
 Find code related to the changes:
 - **Imports/Dependencies**: What does the modified code import or depend on?
-- **Usages**: Where is the modified code used? (grep for function/class names)
+- **Callers/Consumers**: For each modified function/method/class, grep for call sites. Prioritize: functions whose signature/return type/error behavior changed, public API functions over private helpers. Report top 3-5 most relevant callers per significantly modified function.
 - **Similar Patterns**: Search for similar code patterns in the codebase
 - **Related Tests**: Find test files that cover the modified code
 
@@ -65,7 +65,7 @@ Provide a structured summary that specialized agents can use:
 
 ### Related Code
 - **Dependencies**: List of key imports/modules the changes depend on
-- **Usages**: Where the modified functions/classes are used
+- **Callers**: Top 3-5 callers per significantly modified function/method
 - **Similar Patterns**: Locations of similar code in the codebase
 
 ### Architectural Context

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -231,7 +231,7 @@ Before including any finding, argue against it:
 - **Confidence Level**: Include confidence score (20-100%) based on certainty
 - **What Breaks**: Specific scenario that fails
 - **Impact**: Who/what is affected (API consumers, database, configs)
-- **Fix**: How to make it backwards compatible
+- **Fix**: Code snippet showing the backwards-compatible alternative
 - **Migration Path**: If breaking change is necessary, how to migrate
 
 **Confidence Scoring Guidelines:**

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -291,7 +291,7 @@ Before including any finding, argue against it:
 - **What's Wrong**: Specific description of the correctness issue
 - **Evidence**: How you determined this is wrong (traced to consumer, found similar code, etc.)
 - **Impact**: What will happen at runtime if not fixed
-- **Fix**: Specific recommendation
+- **Fix**: Concrete code snippet showing the correction (diff format or replacement block)
 
 **Confidence Scoring Guidelines:**
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -199,7 +199,7 @@ Flag as **Critical** [90-100% confidence] when you find:
 **Location**: `tests/file_test.py:45-48`
 **Issue**: [Specific problem with test]
 **Impact**: [Why this matters - false confidence, untested code, etc.]
-**Recommendation**: [Concrete fix]
+**Recommendation**: Concrete code example showing the test to add or change
 ```
 
 ---

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -223,7 +223,7 @@ Write comments the way a senior engineer talks in a PR review — direct, specif
 
 - No `**Issue**:` / `**Impact**:` / `**Recommendation**:` headers. Start with the prefix, then flow into natural prose.
 - Be specific: name the function, quote the value, cite the line.
-- Offer alternatives with code when possible. Use GitHub's `suggestion` syntax for single-line fixes.
+- For `blocking:` and `suggestion:` findings, always include a concrete code fix (see Accuracy Requirements above). For `question:` and `nit:`, offer code when it helps. Use GitHub's `suggestion` syntax for single-line fixes.
 - Defer to the author on judgment calls: "your call", "worth considering", "that said".
 - Express uncertainty honestly: "Unless I'm missing something", "If I'm reading this right". Give the author the benefit of the doubt.
 - Never restate what the code obviously does. The author wrote it — they know.

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -297,14 +297,14 @@ Use ultrathink to synthesize findings from all agents into a coherent, deduplica
 
 After all agents complete, combine their findings into a single review document.
 
-**Step 2b: Cross-agent corroboration.** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Apply these rules:
+**Filtering (cross-agent corroboration).** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Apply these rules:
 - **Corroborated (2+ agents):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
 - **Solo finding, confidence >= 40%:** Include as-is.
 - **Solo finding, confidence < 40%:** Drop silently.
 - **Questions and nits:** Exempt from filtering (no minimum confidence).
 - When consolidating corroborated findings, merge into a single entry crediting all contributing agents, using the highest confidence value.
 
-**Step 2c: Priority ordering.** Order findings in the final review by:
+**Priority ordering.** Order findings in the final review by:
 1. Corroborated blocking findings
 2. Solo blocking findings (>= 70% confidence)
 3. Corroborated suggestions

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -117,6 +117,8 @@ $file_access_instructions
 Explore the codebase to understand:
 - Full context of modified files
 - Related code and dependencies
+- Callers of modified functions — who calls the changed code and might be affected?
+  (grep for function/method names, report top 3-5 callers per significantly modified function)
 - Existing patterns for similar functionality
 - Reusable utilities or conventions
 
@@ -200,6 +202,8 @@ For each finding you report:
 2. Verify the line number by reading the actual file (see File Access above)
 3. Only flag code in the diff - do not flag pre-existing issues in unchanged code
 4. For bug claims: read surrounding code to confirm the behavior before reporting
+5. For every `blocking:` or `suggestion:` finding, include a **concrete code fix** — show the recommended change as a diff (`- old` / `+ new`) or replacement code block. If you cannot provide a concrete fix, demote the finding to `question:`.
+
 Do NOT report anything as a bug unless you've verified the behavior by reading the code.
 
 **Comment Prefixes:**
@@ -289,9 +293,23 @@ Use the Task tool with `subagent_type` from the table above. If an area is speci
 
 ### Collect and Present Results
 
-Use ultrathink to synthesize findings from all agents into a coherent, deduplicated review.
+Use ultrathink to synthesize findings from all agents into a coherent, deduplicated review. Apply confidence-based filtering and cross-agent corroboration before producing the final document.
 
 After all agents complete, combine their findings into a single review document.
+
+**Step 2b: Cross-agent corroboration.** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Apply these rules:
+- **Corroborated (2+ agents):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
+- **Solo finding, confidence >= 40%:** Include as-is.
+- **Solo finding, confidence < 40%:** Drop silently.
+- **Questions and nits:** Exempt from filtering (no minimum confidence).
+- When consolidating corroborated findings, merge into a single entry crediting all contributing agents, using the highest confidence value.
+
+**Step 2c: Priority ordering.** Order findings in the final review by:
+1. Corroborated blocking findings
+2. Solo blocking findings (>= 70% confidence)
+3. Corroborated suggestions
+4. Solo suggestions (>= 40% confidence)
+5. Questions and nits
 
 **Verify findings against the diff before including them in the final review.**
 


### PR DESCRIPTION
## Summary

- **Require concrete code fixes** in all blocking/suggestion findings. Every `blocking:` or `suggestion:` finding must include a code snippet showing the fix (diff or replacement block). Findings without a concrete fix are demoted to `question:`. Updated accuracy requirements in review.md and fix templates in the correctness, testing, and compatibility agents.

- **Confidence-based filtering and cross-agent corroboration.** Solo findings below 40% confidence are dropped silently. Corroborated findings (2+ agents flagging the same concern within 10 lines or the same function) are kept even at low confidence and merged into a single entry. Findings are priority-ordered: corroborated blocking > solo blocking (>= 70%) > corroborated suggestions > solo suggestions (>= 40%) > questions/nits.

- **Caller discovery in context exploration.** Replaced generic "Usages" exploration with targeted "Callers/Consumers" analysis. The context explorer now greps for call sites of modified functions, prioritizing functions whose signatures changed and public APIs over private helpers, reporting top 3-5 callers per significantly modified function.

## Test plan

- [ ] Existing tests pass
- [ ] Run `/review-code` on a known PR and verify findings include code fix snippets
- [ ] Verify low-confidence solo findings are filtered from synthesis
- [ ] Verify context explorer reports callers of modified functions