### PR TITLE
Enrich review context with linked issues

### DIFF
--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -32,6 +32,8 @@ Before reviewing code quality, verify the code does what the PR claims:
 2. **Verify each claim**: Is it actually implemented? In all code paths?
 3. **Flag gaps**: Where does implementation diverge from stated intent?
 
+When linked issues are provided, cross-reference: Does the implementation address all aspects of each linked issue? Are edge cases mentioned in the issue handled?
+
 **Red Flags:**
 - PR says "add logging for X" but X is captured and discarded (`_variable`)
 - PR says "switch to SystemY" but code still uses SystemX in some paths

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -144,6 +144,16 @@ You are reviewing Pull Request #$pr_number: "$pr_title"
 **PR Description:**
 $pr_body
 
+{If pr.linked_issues is not empty:}
+**Linked Issues:**
+{For each issue in pr.linked_issues:}
+### Issue #$issue.number: $issue.title
+**Labels:** $issue.labels (comma-separated names)
+**State:** $issue.state
+$issue.body
+---
+{End for}
+
 **Existing Review Comments:**
 $pr_comments
 

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -161,6 +161,60 @@ fetch_reviews() {
     "${gh_cmd[@]}" | jq '.reviews | [.[] | {id, author: .author.login, state, body, submitted_at: .submittedAt}]'
 }
 
+# Extract issue references from PR body and fetch their details.
+# Looks for patterns like "Fixes #123", "Closes #456", "Resolves #789".
+# Non-fatal: silently skips issues that fail to fetch.
+# Args: $1 = PR body text, $2 = repo_spec (owner/repo)
+# Output: JSON array of issue objects
+fetch_linked_issues() {
+    local body="$1"
+    local repo_spec="$2"
+
+    if [[ -z "${body}" ]] || [[ -z "${repo_spec}" ]]; then
+        echo "[]"
+        return
+    fi
+
+    # Extract issue numbers using grep (case-insensitive match for fix/close/resolve variants)
+    local issue_numbers
+    issue_numbers=$(echo "${body}" | grep -ioE '(fix(es|ed)?|close[sd]?|resolve[sd]?)\s+#[0-9]+' \
+        | grep -oE '#[0-9]+' \
+        | tr -d '#' \
+        | sort -u \
+        | head -5) || true
+
+    if [[ -z "${issue_numbers}" ]]; then
+        echo "[]"
+        return
+    fi
+
+    validate_repo_spec "${repo_spec}" || {
+        echo "[]"
+        return
+    }
+
+    local issues="[]"
+    while IFS= read -r issue_num; do
+        [[ -z "${issue_num}" ]] && continue
+
+        # Validate issue number is numeric
+        if [[ ! "${issue_num}" =~ ^[0-9]+$ ]]; then
+            continue
+        fi
+
+        local issue_data
+        issue_data=$(gh issue view "${issue_num}" --repo "${repo_spec}" \
+            --json number,title,body,labels,state 2> /dev/null) || continue
+
+        # Truncate body to 2000 chars to control token usage
+        issue_data=$(echo "${issue_data}" | jq '.body = (.body // "" | if length > 2000 then .[:2000] + "…" else . end)')
+
+        issues=$(echo "${issues}" | jq --argjson issue "${issue_data}" '. + [$issue]')
+    done <<< "${issue_numbers}"
+
+    echo "${issues}"
+}
+
 # Main logic
 main() {
     if [[ $# -eq 0 ]]; then
@@ -241,6 +295,10 @@ main() {
         repo_spec="${org}/${repo}"
     fi
 
+    # Extract and fetch linked issues from PR body
+    local linked_issues="[]"
+    linked_issues=$(fetch_linked_issues "${body}" "${repo_spec}")
+
     # Fetch all comment types (conversation, inline, reviews) with pagination
     local conversation_comments="[]"
     local inline_comments="[]"
@@ -286,6 +344,7 @@ main() {
     "state": "${state}",
     "is_fork": ${is_fork},
     "diff": ${diff},
+    "linked_issues": ${linked_issues},
     "comments": {
         "conversation": ${conversation_comments},
         "reviews": ${reviews},

--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -242,3 +242,89 @@ setup() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"Invalid repo specification"* ]]
 }
+
+# =============================================================================
+# fetch_linked_issues tests
+# =============================================================================
+
+@test "pr-context.sh: fetch_linked_issues returns empty array for empty body" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && fetch_linked_issues '' 'owner/repo'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "pr-context.sh: fetch_linked_issues returns empty array for empty repo_spec" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && fetch_linked_issues 'Fixes #123' ''"
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "pr-context.sh: fetch_linked_issues returns empty array when body has no issue references" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { return 1; }
+        fetch_linked_issues 'This is a normal PR body with no issue refs' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+
+@test "pr-context.sh: fetch_linked_issues extracts Fixes pattern" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { echo '{\"number\": 123, \"title\": \"Bug fix\", \"body\": \"description\", \"labels\": [], \"state\": \"OPEN\"}'; }
+        fetch_linked_issues 'Fixes #123' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].number == 123'
+}
+
+@test "pr-context.sh: fetch_linked_issues extracts Closes pattern" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { echo '{\"number\": 456, \"title\": \"Feature request\", \"body\": \"details\", \"labels\": [], \"state\": \"OPEN\"}'; }
+        fetch_linked_issues 'Closes #456' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].number == 456'
+}
+
+@test "pr-context.sh: fetch_linked_issues extracts Resolves pattern" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { echo '{\"number\": 789, \"title\": \"Issue\", \"body\": \"info\", \"labels\": [], \"state\": \"OPEN\"}'; }
+        fetch_linked_issues 'Resolves #789' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].number == 789'
+}
+
+@test "pr-context.sh: fetch_linked_issues is case insensitive" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { echo '{\"number\": 123, \"title\": \"Bug\", \"body\": \"desc\", \"labels\": [], \"state\": \"OPEN\"}'; }
+        fetch_linked_issues 'fixes #123' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].number == 123'
+}
+
+@test "pr-context.sh: fetch_linked_issues deduplicates issue numbers" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { echo '{\"number\": 123, \"title\": \"Bug\", \"body\": \"desc\", \"labels\": [], \"state\": \"OPEN\"}'; }
+        fetch_linked_issues 'Fixes #123 and also Closes #123' 'owner/repo'
+    "
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1'
+}
+
+@test "pr-context.sh: fetch_linked_issues returns empty array for invalid repo_spec" {
+    run bash -c "
+        source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh'
+        gh() { return 1; }
+        fetch_linked_issues 'Fixes #123' 'invalid;repo'
+    "
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | tail -1)" = "[]" ]
+}


### PR DESCRIPTION
## Summary

- Extract linked issues from PR body (`Fixes #N`, `Closes #N` patterns), fetch their details via `gh` CLI, and include them in agent context so reviewers can cross-reference implementation against requirements
- Add linked issues template section to review handler prompt
- Add correctness agent note to cross-reference linked issues

## Test plan

- [ ] Review a PR that has `Fixes #N` in the body — linked issues should appear in agent context
- [ ] Review a PR with no linked issues — no errors, no linked issues section