### PR TITLE
Workflow improvements: pre-review tone and auto-learn feedback

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -55,6 +55,13 @@ Examples:
 - `/review-code feature-branch "*.py"` - Review only Python files in branch
 - `/review-code 123 "src/**/*.ts"` - Review only TypeScript files in PR #123
 
+**Review modes:**
+
+- **Pre-review (collaborative):** Automatically detected for local changes, branches without PRs, and your own PRs. Uses collaborative framing ("you might want to", "consider:") instead of formal review tone.
+- **External review (standard):** For reviewing other people's PRs. Uses formal review prefixes (blocking, suggestion, nit, question).
+
+**Post-review learning:** After completing a PR review, you may be prompted to analyze recently merged PRs that have unanalyzed reviews. This improves future review quality by learning from outcomes. You can also run `/review-code learn` manually.
+
 **Usage examples:**
 
 - `/review-code` - Comprehensive review of local uncommitted changes (default)

--- a/skills/review-code/handlers/learn.md
+++ b/skills/review-code/handlers/learn.md
@@ -54,6 +54,29 @@ Also extract `learn_data` from `LEARN_RESULT` for subsequent steps.
 
 **Step 2: Process prompts for uncertain items**
 
+**Quick mode (when invoked from post-review prompt):**
+
+If this learn flow was triggered from the post-review learning opportunity (not from a direct `/review-code learn` invocation), use auto-categorization instead of interactive prompts:
+
+- Unaddressed findings with confidence < 85% → record as "low priority" (type: "deferred", user_feedback: "auto: low priority")
+- Unaddressed findings with confidence >= 85% → record as "deferred" (type: "deferred", user_feedback: "auto: high confidence deferred")
+- Missed findings where the file was modified after review → record as "add to patterns" (type: "missed_pattern", user_feedback: "auto: file was modified")
+- All other missed findings → skip
+
+Display a summary table instead of individual prompts:
+```
+Auto-categorized N findings:
+- X low priority (confidence < 85%)
+- Y deferred (confidence >= 85%)
+- Z patterns to learn from
+
+Use '/review-code learn <pr>' for interactive categorization.
+```
+
+Then proceed to Step 3 to record learnings and Step 4 to mark as analyzed.
+
+**Interactive mode (default):**
+
 For each item in `prompts_needed`, ask the user interactively:
 
 **For "unaddressed" findings (Claude found, not modified):**

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -192,6 +192,19 @@ For each finding you report:
 4. For bug claims: read surrounding code to confirm the behavior before reporting
 Do NOT report anything as a bug unless you've verified the behavior by reading the code.
 
+{If is_pre_review is true:}
+**Review Mode: Pre-Review (Author Self-Check)**
+Frame findings collaboratively — this is a self-check before submitting for external review:
+- Use "you might want to" instead of "this must be fixed"
+- Prioritize things that would embarrass the author if caught by a teammate
+- Use `fix before submitting:` instead of `blocking:`
+- Use `consider:` instead of `suggestion:`
+- `nit:` and `question:` remain unchanged
+- Still flag genuine bugs and security issues clearly
+
+If a comment has no prefix, assume it's a suggestion.
+
+{Otherwise:}
 **Comment Prefixes:**
 
 Prefix every finding so the author knows what action is expected:
@@ -303,9 +316,12 @@ Where the `targets` array contains `{"path": "<file>", "line": <number>}` object
 
 **Format the review based on mode:**
 
+{If is_pre_review is true, prefix all titles with "Pre-Review:" instead of the standard prefix:}
+
 **PR Review Title:**
 ```
-Pull Request Review: #$pr_number - $pr_title
+{If is_pre_review:} Pre-Review: #$pr_number - $pr_title
+{Otherwise:} Pull Request Review: #$pr_number - $pr_title
 ```
 
 **Commit Review Title:**
@@ -315,7 +331,8 @@ Commit Review: $commit
 
 **Branch Review Title:**
 ```
-Branch Review: $branch vs $base_branch
+{If is_pre_review:} Pre-Review: $branch vs $base_branch
+{Otherwise:} Branch Review: $branch vs $base_branch
 ```
 
 **Range Review Title:**
@@ -325,7 +342,8 @@ Range Review: $range
 
 **Local Review Title:**
 ```
-Code Review: (org/repo from git_context) - (branch) (uncommitted)
+{If is_pre_review:} Pre-Review: (org/repo from git_context) - (branch) (uncommitted)
+{Otherwise:} Code Review: (org/repo from git_context) - (branch) (uncommitted)
 ```
 
 **For comprehensive reviews**, include sections for each area:
@@ -338,6 +356,13 @@ Code Review: (org/repo from git_context) - (branch) (uncommitted)
 - Architecture Review
 
 **For area-specific reviews**, include only that area's findings.
+
+{If is_pre_review is true:}
+At the end of the review, add:
+```
+---
+**Next steps:** Address the items above, then submit for external review.
+```
 
 Save the complete review to `$review_file` and inform the user with a clickable file link:
 
@@ -593,6 +618,48 @@ If failed, show the error and suggest using the review file manually.
 - DO save detailed review to markdown file
 - DO use `create-draft-review.sh` with brief summary + inline comments only
 - DO stop and inform the user when errors occur - let them decide how to proceed
+
+### Post-Review: Learning Opportunity
+
+Skip this section if: this is a local/branch review (no PR), or this is an area-specific review.
+
+After saving the review, check for merged PRs with unanalyzed reviews:
+
+```bash
+~/.claude/skills/review-code/scripts/learn-batch.sh --limit 3 --days 30
+```
+
+If the output is a non-empty JSON array (length > 0):
+
+Use AskUserQuestion:
+- Question: "Found N merged PR(s) with unanalyzed reviews. Analyze them to improve future reviews?"
+- Options:
+  1. "Yes, analyze" - Analyze the merged PRs to learn from outcomes
+  2. "Not now" - Skip for now
+
+If "Yes, analyze": For each PR in the batch result, run the learn orchestrator:
+```bash
+~/.claude/skills/review-code/scripts/learn-orchestrator.sh single "<PR_NUMBER>" --org "<ORG>" --repo "<REPO>"
+```
+Then follow the "single" submode flow from the learn handler for each PR (with quick-mode auto-categorization: unaddressed findings with confidence < 85% are "low priority", confidence >= 85% are "deferred", missed findings where file was modified are "add to patterns"). Display a summary instead of interactive prompts.
+
+If "Not now": Display: "You can run `/review-code learn` anytime to analyze merged PRs."
+
+### Review Metadata
+
+When saving the review file, include a metadata header at the top:
+
+```html
+<!-- review-metadata
+reviewed_at: <current ISO 8601 timestamp>
+mode: <mode>
+pr_number: <pr_number if applicable>
+org: <org>
+repo: <repo>
+-->
+```
+
+This metadata is used by the learning system to determine when the review was created.
 
 ### Cleanup Session
 

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -130,11 +130,20 @@ main() {
         }]
     ' 2> /dev/null || echo "[]")
 
-    # Determine files changed after the review was created
-    # Use epoch seconds for reliable date comparison (ISO 8601 string comparison
-    # fails when GitHub API returns +00:00 vs Z suffix)
+    # Determine files changed after the review was created.
+    # Prefer reviewed_at from metadata header (written by review handler),
+    # fall back to file mtime for reviews created before metadata was added.
     local review_file_epoch
-    review_file_epoch=$(get_file_mtime "${review_file}")
+    local reviewed_at
+    reviewed_at=$(grep -A1 'review-metadata' "${review_file}" 2> /dev/null \
+        | grep 'reviewed_at:' \
+        | sed 's/.*reviewed_at: *//' \
+        | tr -d ' ' || true)
+    if [[ -n "${reviewed_at}" ]]; then
+        review_file_epoch=$(iso_to_epoch "${reviewed_at}")
+    else
+        review_file_epoch=$(get_file_mtime "${review_file}")
+    fi
 
     # Check if any commits are after the review file creation
     # Using the commits data already fetched in pr_data to avoid extra API calls

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -329,6 +329,17 @@ build_review_data() {
         fi
     fi
 
+    # Determine if this is a pre-review (author self-check) vs external review.
+    # Pre-review uses collaborative framing instead of formal review tone.
+    local is_pre_review="false"
+    if [[ "${mode}" == "local" ]]; then
+        is_pre_review="true"
+    elif [[ "${mode}" == "branch" ]] && [[ -z "${pr_context}" ]]; then
+        is_pre_review="true"
+    elif [[ "${mode}" == "pr" ]] && [[ "${is_own_pr}" == "true" ]]; then
+        is_pre_review="true"
+    fi
+
     local -a jq_args=(
         -n
         --arg mode "${mode}"
@@ -343,6 +354,7 @@ build_review_data() {
         --argjson pr "${pr_json}"
         --arg reviewer_username "${reviewer_username}"
         --arg is_own_pr "${is_own_pr}"
+        --arg is_pre_review "${is_pre_review}"
     )
 
     # Add mode-specific arguments
@@ -372,6 +384,7 @@ build_review_data() {
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
+        + (if $is_pre_review == "true" then {is_pre_review: true} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"


### PR DESCRIPTION
## Summary

Research shows AI is "most valuable as a pre-review aid" and that continuous feedback loops are essential for improvement. This PR adds automatic pre-review mode detection and a post-review learning prompt.

**Changes:**

- **Pre-review mode (3A):** Automatically detected based on context — local changes, branches without PRs, and reviewing your own PR all trigger collaborative framing. Uses "you might want to" instead of "this must be fixed", "fix before submitting:" instead of "blocking:", and "consider:" instead of "suggestion:". Pre-review titles are prefixed with "Pre-Review:" and a "Next steps" footer guides the author to address findings before submitting for external review.

- **Auto-learn feedback loop (3B):** After completing a PR review, the system checks for recently merged PRs with unanalyzed reviews (via `learn-batch.sh --limit 3 --days 30`). If found, it prompts the user to analyze them. Uses quick-mode auto-categorization: unaddressed findings below 85% confidence are "low priority", above 85% are "deferred", and missed findings where the file was modified become patterns to learn. Review files now include a metadata header with `reviewed_at` timestamp, which `learn-from-pr.sh` prefers over file mtime for more reliable date comparison.

## Test plan

- [x] All 935 existing tests pass
- [ ] Run `/review-code` on local changes — verify collaborative tone and pre-review title
- [ ] Run `/review-code` on your own PR — verify pre-review mode activates
- [ ] Run `/review-code` on someone else's PR — verify standard review mode
- [ ] Complete a PR review — verify learning prompt appears if merged PRs exist
- [ ] Verify review files contain `<!-- review-metadata -->` header