### PR TITLE
Add review submission from Claude Code

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -608,6 +608,53 @@ If failed, show the error and suggest using the review file manually.
 - DO use `create-draft-review.sh` with brief summary + inline comments only
 - DO stop and inform the user when errors occur - let them decide how to proceed
 
+### Offer to Submit Review
+
+After creating the draft review successfully, offer to submit it from within Claude Code.
+
+**Only proceed if the draft review was created successfully** (the `create-draft-review.sh` output has `success: true` and a valid `review_id`).
+
+Use `AskUserQuestion` with these options:
+
+1. "Submit as Comment" — neutral feedback, no approval or rejection
+2. "Submit as Approve" — approve the PR
+3. "Submit as Request Changes" — request changes before merge
+4. "Keep as draft" — don't submit now; visit GitHub to review and submit manually
+
+**If the user selects one of the submit options:**
+
+Map the selection to an event value:
+- "Submit as Comment" → `COMMENT`
+- "Submit as Approve" → `APPROVE`
+- "Submit as Request Changes" → `REQUEST_CHANGES`
+
+Call `submit-review.sh` with the review ID from the draft creation output:
+
+```bash
+~/.claude/skills/review-code/scripts/submit-review.sh <<'EOF'
+{"owner": "<owner>", "repo": "<repo>", "pr_number": <number>, "review_id": <review_id>, "event": "<EVENT>"}
+EOF
+```
+
+**Display the result:**
+
+If successful:
+```
+Review submitted!
+
+Review: <review_url>
+Event: <event> (State: <state>)
+```
+
+If failed, show the error and tell the user they can submit manually on GitHub.
+
+**If the user selects "Keep as draft":**
+
+```
+Review kept as draft. Visit GitHub to review and submit:
+<review_url>
+```
+
 ### Cleanup Session
 
 After the review is complete, cleanup the session (replace `<SESSION_ID>` with the actual session ID):

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -44,19 +44,6 @@ source "${SCRIPT_DIR}/helpers/json-helpers.sh"
 # shellcheck source=lib/helpers/gh-wrapper.sh
 source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 
-# Validate a required field
-# Args: $1 = value, $2 = field name
-# Output: JSON error if invalid, returns 1 if invalid
-require_field() {
-    local value="$1"
-    local name="$2"
-
-    if [[ -z "${value}" ]] || [[ "${value}" == "null" ]]; then
-        jq -n --arg name "${name}" '{success: false, error: ("Missing " + $name)}'
-        return 1
-    fi
-}
-
 # Fetch existing pending review and its comments
 # Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = reviewer_username
 # Output: JSON with review_id and comments, or null if no pending review

--- a/skills/review-code/scripts/helpers/json-helpers.sh
+++ b/skills/review-code/scripts/helpers/json-helpers.sh
@@ -12,3 +12,17 @@ validate_json() {
         return 1
     fi
 }
+
+# Validate a required field extracted from JSON input.
+# Outputs a JSON error object to stdout and returns 1 if the value is empty or
+# the literal string "null" (which is what jq -r produces for missing keys).
+# Args: $1 = value, $2 = field name
+require_field() {
+    local value="$1"
+    local name="$2"
+
+    if [[ -z "${value}" ]] || [[ "${value}" == "null" ]]; then
+        jq -n --arg name "${name}" '{success: false, error: ("Missing " + $name)}'
+        return 1
+    fi
+}

--- a/skills/review-code/scripts/submit-review.sh
+++ b/skills/review-code/scripts/submit-review.sh
@@ -38,19 +38,6 @@ source "${SCRIPT_DIR}/helpers/json-helpers.sh"
 # shellcheck source=helpers/gh-wrapper.sh
 source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 
-# Validate a required field
-# Args: $1 = value, $2 = field name
-# Output: JSON error if invalid, returns 1 if invalid
-require_field() {
-    local value="$1"
-    local name="$2"
-
-    if [[ -z "${value}" ]] || [[ "${value}" == "null" ]]; then
-        jq -n --arg name "${name}" '{success: false, error: ("Missing " + $name)}'
-        return 1
-    fi
-}
-
 # Validate the event is one of the allowed values
 # Args: $1 = event
 # Output: JSON error if invalid, returns 1 if invalid

--- a/skills/review-code/scripts/submit-review.sh
+++ b/skills/review-code/scripts/submit-review.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# submit-review.sh - Submit a pending GitHub PR review
+#
+# Submits an existing pending (draft) review on GitHub with a specified event
+# type. Verifies the review is in PENDING state before submitting to prevent
+# double-submission.
+#
+# Usage:
+#   echo '<json_input>' | submit-review.sh
+#
+# Input JSON:
+#   {
+#     "owner": "org",
+#     "repo": "repo",
+#     "pr_number": 123,
+#     "review_id": 12345,
+#     "event": "COMMENT"
+#   }
+#
+# Event accepts: APPROVE, REQUEST_CHANGES, COMMENT
+#
+# Output JSON:
+#   {
+#     "success": true,
+#     "review_id": 12345,
+#     "review_url": "https://github.com/org/repo/pull/123#pullrequestreview-12345",
+#     "event": "COMMENT",
+#     "state": "COMMENTED"
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=helpers/json-helpers.sh
+source "${SCRIPT_DIR}/helpers/json-helpers.sh"
+# shellcheck source=helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
+# Validate a required field
+# Args: $1 = value, $2 = field name
+# Output: JSON error if invalid, returns 1 if invalid
+require_field() {
+    local value="$1"
+    local name="$2"
+
+    if [[ -z "${value}" ]] || [[ "${value}" == "null" ]]; then
+        jq -n --arg name "${name}" '{success: false, error: ("Missing " + $name)}'
+        return 1
+    fi
+}
+
+# Validate the event is one of the allowed values
+# Args: $1 = event
+# Output: JSON error if invalid, returns 1 if invalid
+validate_event() {
+    local event="$1"
+
+    case "${event}" in
+        APPROVE | REQUEST_CHANGES | COMMENT) return 0 ;;
+        *)
+            jq -n --arg event "${event}" \
+                '{success: false, error: ("Invalid event: " + $event + ". Must be APPROVE, REQUEST_CHANGES, or COMMENT")}'
+            return 1
+            ;;
+    esac
+}
+
+# Verify the review is in PENDING state
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = review_id
+# Output: JSON error if not pending, returns 1 if not pending
+verify_pending_state() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local review_id="$4"
+
+    local review
+    review=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null) || {
+        jq -n --arg id "${review_id}" \
+            '{success: false, error: ("Failed to fetch review " + $id)}'
+        return 1
+    }
+
+    local state
+    state=$(echo "${review}" | jq -r '.state')
+
+    if [[ "${state}" != "PENDING" ]]; then
+        jq -n --arg id "${review_id}" --arg state "${state}" \
+            '{success: false, error: ("Review " + $id + " is in " + $state + " state, not PENDING. It may have already been submitted.")}'
+        return 1
+    fi
+}
+
+# Submit the review
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = review_id, $5 = event
+# Output: API response JSON
+submit_review() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local review_id="$4"
+    local event="$5"
+
+    local request_body
+    request_body=$(jq -n --arg event "${event}" '{event: $event}')
+
+    local result
+    result=$(echo "${request_body}" | gh api --method POST \
+        "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/events" \
+        --input - 2>/dev/null) || {
+        echo "Failed to submit review" >&2
+        return 1
+    }
+
+    echo "${result}"
+}
+
+main() {
+    # Read input JSON from stdin
+    local input
+    input=$(cat)
+
+    # Validate input
+    validate_json "${input}" || exit 1
+
+    # Extract fields
+    local owner repo pr_number review_id event
+    owner=$(echo "${input}" | jq -r '.owner')
+    repo=$(echo "${input}" | jq -r '.repo')
+    pr_number=$(echo "${input}" | jq -r '.pr_number')
+    review_id=$(echo "${input}" | jq -r '.review_id')
+    event=$(echo "${input}" | jq -r '.event')
+
+    # Validate required fields
+    require_field "${owner}" "owner" || exit 1
+    require_field "${repo}" "repo" || exit 1
+    require_field "${pr_number}" "pr_number" || exit 1
+    require_field "${review_id}" "review_id" || exit 1
+    require_field "${event}" "event" || exit 1
+
+    # Validate event value
+    validate_event "${event}" || exit 1
+
+    # Verify the review is in PENDING state
+    verify_pending_state "${owner}" "${repo}" "${pr_number}" "${review_id}" || exit 1
+
+    # Submit the review
+    local submit_result
+    submit_result=$(submit_review "${owner}" "${repo}" "${pr_number}" "${review_id}" "${event}") || {
+        jq -n \
+            --arg error "Failed to submit review: ${submit_result}" \
+            '{success: false, error: $error}'
+        exit 1
+    }
+
+    # Extract state from API response
+    local state
+    state=$(echo "${submit_result}" | jq -r '.state')
+
+    # Build review URL
+    local review_url="https://github.com/${owner}/${repo}/pull/${pr_number}#pullrequestreview-${review_id}"
+
+    # Return success result
+    jq -n \
+        --argjson success true \
+        --argjson review_id "${review_id}" \
+        --arg review_url "${review_url}" \
+        --arg event "${event}" \
+        --arg state "${state}" \
+        '{
+            success: $success,
+            review_id: $review_id,
+            review_url: $review_url,
+            event: $event,
+            state: $state
+        }'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -51,8 +51,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "create-draft-review: has require_field function" {
-    run bash -c "grep -q '^require_field()' '$SCRIPT'"
+@test "create-draft-review: has require_field function (via json-helpers)" {
+    run bash -c "source '$SCRIPT' && declare -f require_field > /dev/null"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/unit/test-review-safety-hook.bats
+++ b/tests/unit/test-review-safety-hook.bats
@@ -93,6 +93,11 @@ make_input() {
     [ -z "$result" ]
 }
 
+@test "allows submit-review.sh" {
+    result=$(make_input "~/.claude/skills/review-code/scripts/submit-review.sh" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
 @test "allows other bash commands" {
     result=$(make_input "git diff HEAD~1" | bash "$SCRIPT")
     [ -z "$result" ]

--- a/tests/unit/test-submit-review.bats
+++ b/tests/unit/test-submit-review.bats
@@ -1,0 +1,359 @@
+#!/usr/bin/env bats
+# Tests for submit-review.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/submit-review.sh"
+
+    # Create temp directory for mock scripts
+    MOCK_DIR=$(mktemp -d)
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+# Helper to create a mock gh command
+create_mock_gh() {
+    local response="$1"
+    cat > "$MOCK_DIR/gh" << EOF
+#!/bin/bash
+echo '$response'
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# Helper to create a mock gh that fails
+create_failing_mock_gh() {
+    local error_msg="$1"
+    cat > "$MOCK_DIR/gh" << EOF
+#!/bin/bash
+echo '$error_msg' >&2
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "submit-review: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: uses set -euo pipefail" {
+    run bash -c "head -40 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: has require_field function" {
+    run bash -c "grep -q '^require_field()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: has validate_event function" {
+    run bash -c "grep -q '^validate_event()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: has verify_pending_state function" {
+    run bash -c "grep -q '^verify_pending_state()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: has submit_review function" {
+    run bash -c "grep -q '^submit_review()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: has main function" {
+    run bash -c "grep -q '^main()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "submit-review: rejects invalid JSON input" {
+    run bash -c "echo 'not json' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid JSON"* ]]
+}
+
+@test "submit-review: rejects missing owner" {
+    local input='{"repo": "test", "pr_number": 1, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing owner"* ]]
+}
+
+@test "submit-review: rejects missing repo" {
+    local input='{"owner": "org", "pr_number": 1, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing repo"* ]]
+}
+
+@test "submit-review: rejects missing pr_number" {
+    local input='{"owner": "org", "repo": "test", "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing pr_number"* ]]
+}
+
+@test "submit-review: rejects missing review_id" {
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing review_id"* ]]
+}
+
+@test "submit-review: rejects missing event" {
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 123}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing event"* ]]
+}
+
+# =============================================================================
+# Event validation tests
+# =============================================================================
+
+@test "submit-review: validate_event accepts APPROVE" {
+    run bash -c "source '$SCRIPT' && validate_event 'APPROVE'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: validate_event accepts REQUEST_CHANGES" {
+    run bash -c "source '$SCRIPT' && validate_event 'REQUEST_CHANGES'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: validate_event accepts COMMENT" {
+    run bash -c "source '$SCRIPT' && validate_event 'COMMENT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: validate_event rejects invalid event" {
+    run bash -c "source '$SCRIPT' && validate_event 'DISMISS'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid event"* ]]
+    [[ "$output" == *"DISMISS"* ]]
+}
+
+@test "submit-review: validate_event rejects lowercase event" {
+    run bash -c "source '$SCRIPT' && validate_event 'comment'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid event"* ]]
+}
+
+@test "submit-review: rejects invalid event in full flow" {
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 123, "event": "INVALID"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid event"* ]]
+}
+
+# =============================================================================
+# PENDING state guard tests
+# =============================================================================
+
+@test "submit-review: rejects already-submitted review (APPROVED state)" {
+    create_mock_gh '{"id": 123, "state": "APPROVED"}'
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"APPROVED"* ]]
+    [[ "$output" == *"not PENDING"* ]]
+}
+
+@test "submit-review: rejects already-submitted review (COMMENTED state)" {
+    create_mock_gh '{"id": 123, "state": "COMMENTED"}'
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"COMMENTED"* ]]
+    [[ "$output" == *"not PENDING"* ]]
+}
+
+@test "submit-review: rejects already-submitted review (CHANGES_REQUESTED state)" {
+    create_mock_gh '{"id": 123, "state": "CHANGES_REQUESTED"}'
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"CHANGES_REQUESTED"* ]]
+    [[ "$output" == *"not PENDING"* ]]
+}
+
+@test "submit-review: handles review fetch failure" {
+    create_failing_mock_gh "Not Found"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 99999, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to fetch review"* ]]
+}
+
+# =============================================================================
+# Main flow tests with mocks
+# =============================================================================
+
+@test "submit-review: submits COMMENT successfully" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 123, "state": "COMMENTED"}'
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"event": "COMMENT"'* ]]
+    [[ "$output" == *'"state": "COMMENTED"'* ]]
+}
+
+@test "submit-review: submits APPROVE successfully" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 123, "state": "APPROVED"}'
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "APPROVE"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"event": "APPROVE"'* ]]
+    [[ "$output" == *'"state": "APPROVED"'* ]]
+}
+
+@test "submit-review: submits REQUEST_CHANGES successfully" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 123, "state": "CHANGES_REQUESTED"}'
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "REQUEST_CHANGES"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"event": "REQUEST_CHANGES"'* ]]
+    [[ "$output" == *'"state": "CHANGES_REQUESTED"'* ]]
+}
+
+@test "submit-review: handles API failure on submit" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo "Unprocessable Entity" >&2
+    exit 1
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *'"success": false'* ]]
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "submit-review: outputs valid JSON on success" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 123, "state": "COMMENTED"}'
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT' | jq empty"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: includes review_url in output" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 123, "state": "COMMENTED"}'
+else
+    echo '{"id": 123, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 42, "review_id": 123, "event": "COMMENT"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"review_url": "https://github.com/org/test/pull/42#pullrequestreview-123"'* ]]
+}
+
+@test "submit-review: includes review_id in output" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/events"* ]]; then
+    echo '{"id": 456, "state": "APPROVED"}'
+else
+    echo '{"id": 456, "state": "PENDING"}'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "review_id": 456, "event": "APPROVE"}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"review_id": 456'* ]]
+}
+
+# =============================================================================
+# require_field tests
+# =============================================================================
+
+@test "submit-review: require_field accepts valid value" {
+    run bash -c "source '$SCRIPT' && require_field 'test_value' 'field_name'"
+    [ "$status" -eq 0 ]
+}
+
+@test "submit-review: require_field rejects empty value" {
+    run bash -c "source '$SCRIPT' && require_field '' 'field_name'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"success": false'* ]]
+    [[ "$output" == *'"error": "Missing field_name"'* ]]
+}
+
+@test "submit-review: require_field rejects null value" {
+    run bash -c "source '$SCRIPT' && require_field 'null' 'field_name'"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *'"success": false'* ]]
+    [[ "$output" == *'"error": "Missing field_name"'* ]]
+}

--- a/tests/unit/test-submit-review.bats
+++ b/tests/unit/test-submit-review.bats
@@ -50,8 +50,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "submit-review: has require_field function" {
-    run bash -c "grep -q '^require_field()' '$SCRIPT'"
+@test "submit-review: has require_field function (via json-helpers)" {
+    run bash -c "source '$SCRIPT' && declare -f require_field > /dev/null"
     [ "$status" -eq 0 ]
 }
 
@@ -162,6 +162,14 @@ EOF
 # =============================================================================
 # PENDING state guard tests
 # =============================================================================
+
+@test "submit-review: verify_pending_state accepts PENDING review" {
+    create_mock_gh '{"id": 123, "state": "PENDING"}'
+
+    run bash -c "source '$SCRIPT' && verify_pending_state 'org' 'test' '1' '123'"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
 
 @test "submit-review: rejects already-submitted review (APPROVED state)" {
     create_mock_gh '{"id": 123, "state": "APPROVED"}'


### PR DESCRIPTION
## Summary

- Create `submit-review.sh` script that submits pending GitHub PR reviews via the API, with PENDING state verification to prevent double-submission
- Add a submission prompt to the review handler (`AskUserQuestion` with Comment/Approve/Request Changes/Keep as draft options) so users can submit directly from Claude Code
- Add 33 unit tests for the new script and 1 safety hook test confirming the script isn't blocked

## Test plan

- [x] `bin/fmt` passes
- [x] `bin/test` passes (all 969 unit + 12 integration tests)
- [x] `bin/setup` installs successfully
- [ ] Manual: run `/review-code <pr> --draft` and verify the submission prompt appears after draft creation