### PR TITLE
Add false-positive suppression for review agents

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -194,6 +194,12 @@ $review_context
 
 $file_access_instructions
 
+{If false_positives is not empty:}
+**Known False Positive Patterns:**
+$false_positives
+
+Do NOT flag patterns listed above. These have been confirmed as false positives from prior reviews of this codebase. If you encounter one of these patterns, skip it silently.
+
 **Accuracy Requirements:**
 For each finding you report:
 1. Quote the exact code you're referencing

--- a/skills/review-code/scripts/load-false-positives.sh
+++ b/skills/review-code/scripts/load-false-positives.sh
@@ -6,7 +6,7 @@
 #
 # Description:
 #   Reads learnings/index.jsonl, filters for type=="false_positive",
-#   groups by agent and language/framework, and outputs a markdown summary
+#   groups by agent, and outputs a markdown summary
 #   that agents can use to suppress known false positive patterns.
 #
 # Output (JSON):
@@ -49,7 +49,6 @@ jq -rs '
             patterns: [.[] | {
                 file: .finding.file,
                 description: .finding.description,
-                language: (.context.language // "unknown"),
                 pr: .pr_number
             }]
         }) |

--- a/skills/review-code/scripts/load-false-positives.sh
+++ b/skills/review-code/scripts/load-false-positives.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# load-false-positives.sh - Load false positive patterns from learnings index
+#
+# Usage:
+#   load-false-positives.sh
+#
+# Description:
+#   Reads learnings/index.jsonl, filters for type=="false_positive",
+#   groups by agent and language/framework, and outputs a markdown summary
+#   that agents can use to suppress known false positive patterns.
+#
+# Output (JSON):
+#   {"content": "<markdown>", "count": N}
+#
+#   content: Markdown-formatted false positive patterns grouped by agent
+#   count: Number of false positive patterns found
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=helpers/config-helpers.sh
+source "${SCRIPT_DIR}/helpers/config-helpers.sh"
+
+# Get learnings directory from config - allow override via LEARNINGS_PATH for tests
+LEARNINGS_DIR="${LEARNINGS_PATH:-$(get_learnings_dir)}"
+
+INDEX_FILE="${LEARNINGS_DIR}/index.jsonl"
+
+# Early exit if no learnings file or empty
+if [[ ! -f "${INDEX_FILE}" ]] || [[ ! -s "${INDEX_FILE}" ]]; then
+    jq -n '{content: "", count: 0}'
+    exit 0
+fi
+
+# Filter for false_positive entries and group by agent + context
+# Uses a single jq invocation to avoid multiple passes over the file
+jq -rs '
+    # Filter to false_positive entries only
+    [.[] | select(.type == "false_positive")] |
+    if length == 0 then
+        {content: "", count: 0}
+    else
+        . as $fps |
+        # Group by agent
+        group_by(.agent // "unknown") |
+        map({
+            agent: (.[0].agent // "unknown"),
+            patterns: [.[] | {
+                file: .finding.file,
+                description: .finding.description,
+                language: (.context.language // "unknown"),
+                pr: .pr_number
+            }]
+        }) |
+        # Build markdown content
+        (map(
+            "### \(.agent)\n" +
+            (.patterns | map("- \(.description) (`\(.file)`, PR #\(.pr))") | join("\n"))
+        ) | join("\n\n")) as $md |
+        {
+            content: $md,
+            count: ($fps | length)
+        }
+    end
+' "${INDEX_FILE}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -289,6 +289,12 @@ build_review_data() {
     review_context=$(echo "${review_context_json}" | jq -r '.content')
     loaded_context_files=$(echo "${review_context_json}" | jq -r '.loaded_files')
 
+    # Load false positive patterns from learnings
+    local false_positives_json false_positives false_positives_count
+    false_positives_json=$("${SCRIPT_DIR}/load-false-positives.sh" 2> /dev/null || echo '{"content":"","count":0}')
+    false_positives=$(echo "${false_positives_json}" | jq -r '.content')
+    false_positives_count=$(echo "${false_positives_json}" | jq -r '.count')
+
     # Build summary for user confirmation
     # Extract mode-specific fields to avoid passing large args to jq
     local mode_fields
@@ -343,6 +349,8 @@ build_review_data() {
         --argjson pr "${pr_json}"
         --arg reviewer_username "${reviewer_username}"
         --arg is_own_pr "${is_own_pr}"
+        --arg false_positives "${false_positives}"
+        --arg false_positives_count "${false_positives_count}"
     )
 
     # Add mode-specific arguments
@@ -372,6 +380,7 @@ build_review_data() {
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
+        + (if ($false_positives_count | tonumber) > 0 then {false_positives: $false_positives} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"

--- a/tests/unit/test-load-false-positives.bats
+++ b/tests/unit/test-load-false-positives.bats
@@ -1,0 +1,133 @@
+#!/usr/bin/env bats
+# Tests for load-false-positives.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create temp learnings directory for testing
+    TEST_LEARNINGS_DIR=$(mktemp -d)
+    export LEARNINGS_PATH="$TEST_LEARNINGS_DIR"
+}
+
+teardown() {
+    rm -rf "$TEST_LEARNINGS_DIR"
+}
+
+# =============================================================================
+# Empty/missing file tests
+# =============================================================================
+
+@test "load-false-positives.sh: returns empty when no index file exists" {
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    content=$(echo "$output" | jq -r '.content')
+    count=$(echo "$output" | jq -r '.count')
+    [ -z "$content" ]
+    [ "$count" -eq 0 ]
+}
+
+@test "load-false-positives.sh: returns empty when index file is empty" {
+    touch "$TEST_LEARNINGS_DIR/index.jsonl"
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    content=$(echo "$output" | jq -r '.content')
+    count=$(echo "$output" | jq -r '.count')
+    [ -z "$content" ]
+    [ "$count" -eq 0 ]
+}
+
+# =============================================================================
+# Filtering tests
+# =============================================================================
+
+@test "load-false-positives.sh: filters for false_positive type only" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"false_positive","agent":"security","finding":{"file":"auth.py","description":"SQL injection false alarm"},"context":{"language":"python"},"pr_number":100}
+{"type":"missed_pattern","agent":"testing","finding":{"file":"test.py","description":"Missing edge case"},"context":{"language":"python"},"pr_number":101}
+{"type":"valid_catch","agent":"correctness","finding":{"file":"api.py","description":"Bug found"},"context":{"language":"python"},"pr_number":102}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq -r '.count')
+    [ "$count" -eq 1 ]
+    content=$(echo "$output" | jq -r '.content')
+    [[ "$content" == *"SQL injection false alarm"* ]]
+    [[ "$content" != *"Missing edge case"* ]]
+    [[ "$content" != *"Bug found"* ]]
+}
+
+@test "load-false-positives.sh: returns empty when no false positives exist" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"missed_pattern","agent":"testing","finding":{"file":"test.py","description":"Missing edge case"},"context":{"language":"python"},"pr_number":101}
+{"type":"valid_catch","agent":"correctness","finding":{"file":"api.py","description":"Bug found"},"context":{"language":"python"},"pr_number":102}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    content=$(echo "$output" | jq -r '.content')
+    count=$(echo "$output" | jq -r '.count')
+    [ -z "$content" ]
+    [ "$count" -eq 0 ]
+}
+
+# =============================================================================
+# Grouping tests
+# =============================================================================
+
+@test "load-false-positives.sh: groups by agent" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"false_positive","agent":"security","finding":{"file":"auth.py","description":"SQL injection false alarm"},"context":{"language":"python"},"pr_number":100}
+{"type":"false_positive","agent":"security","finding":{"file":"api.py","description":"XSS false alarm"},"context":{"language":"python"},"pr_number":101}
+{"type":"false_positive","agent":"performance","finding":{"file":"cache.py","description":"N+1 false alarm"},"context":{"language":"python"},"pr_number":102}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq -r '.count')
+    [ "$count" -eq 3 ]
+    content=$(echo "$output" | jq -r '.content')
+    # Both agents should appear as headings
+    [[ "$content" == *"### security"* ]]
+    [[ "$content" == *"### performance"* ]]
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "load-false-positives.sh: outputs valid JSON" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"false_positive","agent":"security","finding":{"file":"auth.py","description":"False alarm"},"context":{"language":"python"},"pr_number":100}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq empty
+}
+
+@test "load-false-positives.sh: includes file path and PR number in output" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"false_positive","agent":"security","finding":{"file":"auth.py","description":"False alarm"},"context":{"language":"python"},"pr_number":100}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    content=$(echo "$output" | jq -r '.content')
+    [[ "$content" == *"auth.py"* ]]
+    [[ "$content" == *"PR #100"* ]]
+}
+
+@test "load-false-positives.sh: handles missing agent field gracefully" {
+    cat > "$TEST_LEARNINGS_DIR/index.jsonl" << 'JSONL'
+{"type":"false_positive","finding":{"file":"auth.py","description":"False alarm"},"context":{"language":"python"},"pr_number":100}
+JSONL
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/load-false-positives.sh"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq -r '.count')
+    [ "$count" -eq 1 ]
+    content=$(echo "$output" | jq -r '.content')
+    [[ "$content" == *"### unknown"* ]]
+}


### PR DESCRIPTION
## Summary

- Add `load-false-positives.sh` to read `learnings/index.jsonl`, filter for confirmed false positives, group by agent, and output markdown that agents use to suppress known false-positive patterns
- Integrate false-positive loading into `review-orchestrator.sh` session data
- Add false-positive suppression instructions to review handler prompt
- Add 8 unit tests for `load-false-positives.sh`

## Test plan

- [ ] Run `bin/test` — all 8 new tests pass
- [ ] Review a repo with false positives in `learnings/index.jsonl` — suppression patterns appear in agent context
- [ ] Review a repo with no learnings — no errors, no false positives section