### PR TITLE
Add Python dict access rule and fix learn matching

### DIFF
--- a/skills/review-code/context/languages/python.md
+++ b/skills/review-code/context/languages/python.md
@@ -82,6 +82,22 @@ def view(request: HttpRequest, user_id: Optional[int] = None) -> HttpResponse:
     ...
 ```
 
+## Dictionary Access Patterns
+
+**Direct access vs `.get()` for required fields:**
+
+- Use `dict["key"]` for fields that must be present (primary keys, identifiers, required schema fields). This fails fast with a clear `KeyError` if the data is unexpectedly malformed, rather than silently propagating `None` downstream where it causes confusing errors.
+- Use `dict.get("key")` only for genuinely optional fields where absence is a valid state.
+- When building lookup dicts from lists (e.g., `{item["id"]: item for item in items}`), use direct access for the key field — if the field is missing, the data is corrupt and you want to know immediately.
+
+```python
+# Good - fails fast if "id" is missing
+flags_by_id = {flag["id"]: flag for flag in flags}
+
+# Bad - silently maps None as a key, causing subtle bugs later
+flags_by_id = {flag.get("id"): flag for flag in flags}
+```
+
 ## Error Handling
 
 **Django-specific:**

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -182,8 +182,18 @@ main() {
             # Compute addressed status
             . as $c |
             (if ($changed | index($c.path)) != null then "likely" else "not_modified" end) as $addressed |
-            # Check if Claude caught this (same file, within 10 lines)
-            ([$claude[] | select(.file == $c.path and ((.line - $c.line) | fabs) <= 10)] | length > 0) as $caught |
+            # Match by line proximity or, when lines are missing, by content overlap
+            (($c.body // "" | ascii_downcase | .[0:80]) as $cbody |
+            [$claude[] |
+                ((.description // "") | ascii_downcase | .[0:80]) as $cdesc |
+                select(
+                    .file == $c.path and (
+                        ((.line // 0) > 0 and ($c.line // 0) > 0 and (((.line // 0) - ($c.line // 0)) | fabs) <= 10)
+                        or
+                        ((.line // 0) == 0 or ($c.line // 0) == 0) and (($cdesc | contains($cbody)) or ($cbody | contains($cdesc)))
+                    )
+                )
+            ] | length > 0) as $caught |
             {
                 file: $c.path,
                 line: ($c.line // 0),


### PR DESCRIPTION
## Summary

- Add a Python context rule for using direct dict access (`dict["key"]`) instead of `.get()` on required fields like primary keys — teaches reviewers to flag silent `None` propagation
- Fix learn-from-pr.sh crash when GitHub review comments have null line numbers, and add content-based fallback matching so file-level suggestions still correlate with Claude's line-specific findings

## Test plan

- [x] All 979 unit tests pass
- [x] All 12 integration tests pass
- [x] Verified content fallback on real PRs: #49111 (3 false misses → 0), #49114 (1 false miss → 0)
- [x] `bin/fmt` clean
- [x] `bash -n` syntax check passes