### PR TITLE
Add inline comment voice and tone guidance

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -213,6 +213,51 @@ Prefix every finding so the author knows what action is expected. The prefix mus
 
 If a comment has no prefix, assume it's a suggestion.
 
+**Inline Comment Voice:**
+
+Write comments the way a senior engineer talks in a PR review — direct, specific, and conversational. No filler, no formality, no structured headers.
+
+Rules:
+- Start with the backtick prefix, then flow into natural prose. No `**Issue**:`, `**Impact**:`, `**Recommendation**:` headers.
+- Lead with what's wrong (or what to consider), then explain why. Combine them naturally — don't separate into sections.
+- Be specific: name the function, quote the value, cite the line. Vague observations aren't helpful.
+- Offer alternatives with code when possible. Use GitHub's `suggestion` syntax for single-line fixes.
+- Defer to the author on judgment calls: "your call", "worth considering", "that said".
+- Express uncertainty honestly. When you're not 100% sure, say so — "Unless I'm missing something", "I might be wrong, but", "If I'm reading this right". Give the author the benefit of the doubt rather than asserting something you can't fully verify.
+- Keep it short. If the comment needs more than two short paragraphs, you're probably combining multiple findings — split them.
+- Use natural transitions ("More broadly...", "Also worth noting...", "That said...") instead of bullet lists.
+- Never restate what the code obviously does. The author wrote it — they know.
+
+Good:
+```
+`suggestion`: The `except` clause doesn't catch `OverflowError`, which `dateutil.parser.parse()` raises for very large numeric strings like `"9999999999"`. This causes a 500 instead of a clean 400.
+
+More broadly, consider using the existing `determine_parsed_date_for_property_matching` from `posthog/queries/base.py` instead of reimplementing the same two-step parsing here. It already catches broader exceptions and is the established pattern in the feature flag API.
+```
+
+```
+`question`: The feature flag API only validates `is_date_before` and `is_date_after` — notably excluding `is_date_exact`. Is `is_date_exact` fully supported in cohorts, or could validating its value here give users a false sense that it works?
+```
+
+```
+`suggestion`: Consider adding an inline comment documenting the thread pool sizing model. The PR description has great reasoning that won't be easily discoverable later. That said, these values change frequently during tuning so comments can go stale — your call.
+```
+
+```
+`suggestion`: Unless I'm missing something, this change means `process_batch` will now retry on *all* errors, not just transient ones. That could mask permanent failures and delay error reporting to the caller.
+```
+
+Bad:
+```
+**Issue**: The `except` clause doesn't catch `OverflowError`.
+**Impact**: This causes a 500 Internal Server Error for large numeric strings.
+**Recommendation**: Add `OverflowError` to the except tuple.
+```
+
+```
+`suggestion`: This code would benefit from improved error handling. The current implementation does not account for all possible exception types that may be raised during date parsing operations. Consider expanding the exception handling to include `OverflowError`.
+```
+
 {If previous_review exists:}
 **Previous Review:**
 $previous_review
@@ -367,7 +412,7 @@ For each finding that needs a new comment:
 #### `<file_path>:<line_number>`
 
 ```text
-<suggested comment text - clear, constructive, and actionable>
+<comment text — direct, specific, conversational (see Inline Comment Voice above)>
 ```
 
 *From: <Agent Name> (<confidence>% confidence)*

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -55,7 +55,7 @@ get_existing_pending_review() {
 
     # Get all reviews for this PR
     local reviews
-    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2>/dev/null || echo "[]")
+    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2> /dev/null || echo "[]")
 
     # Find pending review from this user
     local pending_review
@@ -72,7 +72,7 @@ get_existing_pending_review() {
 
     # Fetch comments for this pending review
     local comments
-    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2>/dev/null || echo "[]")
+    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2> /dev/null || echo "[]")
 
     # Return review info with comments
     jq -n \
@@ -99,7 +99,7 @@ delete_pending_review() {
     local pr_number="$3"
     local review_id="$4"
 
-    gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null || {
+    gh api --method DELETE "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2> /dev/null || {
         warning "Failed to delete existing pending review ${review_id}"
         return 1
     }
@@ -131,8 +131,8 @@ create_pending_review() {
 
     if ! result=$(echo "${request_body}" | gh api --method POST \
         "repos/${owner}/${repo}/pulls/${pr_number}/reviews" \
-        --input - 2>"${tmpfile}"); then
-        error_output=$(<"${tmpfile}")
+        --input - 2> "${tmpfile}"); then
+        error_output=$(< "${tmpfile}")
         echo "API error: ${error_output}" >&2
         echo "Request body sent:" >&2
         echo "${request_body}" | jq -c '.' >&2

--- a/skills/review-code/scripts/helpers/date-helpers.sh
+++ b/skills/review-code/scripts/helpers/date-helpers.sh
@@ -10,9 +10,9 @@ get_file_mtime() {
     local file_path="$1"
 
     if [[ "${OSTYPE}" == "darwin"* ]]; then
-        stat -f '%m' "${file_path}" 2>/dev/null
+        stat -f '%m' "${file_path}" 2> /dev/null
     else
-        stat -c '%Y' "${file_path}" 2>/dev/null
+        stat -c '%Y' "${file_path}" 2> /dev/null
     fi
 }
 
@@ -29,15 +29,15 @@ iso_to_epoch() {
         # - "2026-02-02T10:30:00+00:00" (offset format)
         # BSD date's %z expects +HHMM not +HH:MM
         if [[ "${iso_date}" == *Z ]]; then
-            date -j -f "%Y-%m-%dT%H:%M:%SZ" "${iso_date}" +%s 2>/dev/null || echo "0"
+            date -j -f "%Y-%m-%dT%H:%M:%SZ" "${iso_date}" +%s 2> /dev/null || echo "0"
         else
             # Normalize +HH:MM or -HH:MM to +HHMM/-HHMM for BSD date
             local normalized_date
             normalized_date=$(echo "${iso_date}" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
-            date -j -f "%Y-%m-%dT%H:%M:%S%z" "${normalized_date}" +%s 2>/dev/null || echo "0"
+            date -j -f "%Y-%m-%dT%H:%M:%S%z" "${normalized_date}" +%s 2> /dev/null || echo "0"
         fi
     else
-        date -d "${iso_date}" +%s 2>/dev/null || echo "0"
+        date -d "${iso_date}" +%s 2> /dev/null || echo "0"
     fi
 }
 

--- a/skills/review-code/scripts/helpers/json-helpers.sh
+++ b/skills/review-code/scripts/helpers/json-helpers.sh
@@ -7,7 +7,7 @@
 # Returns: 0 if valid, 1 if invalid (with error message to stderr)
 validate_json() {
     local input="$1"
-    if ! echo "${input}" | jq empty 2>/dev/null; then
+    if ! echo "${input}" | jq empty 2> /dev/null; then
         error "Invalid JSON input"
         return 1
     fi

--- a/skills/review-code/scripts/inject-handler.sh
+++ b/skills/review-code/scripts/inject-handler.sh
@@ -12,26 +12,26 @@ SKILL_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Discard stderr so that warnings (branch divergence, multiple PRs) don't
 # corrupt the JSON on stdout. Errors are detected via exit code instead.
 parse_exit=0
-parse_result=$("${SCRIPT_DIR}/parse-review-arg.sh" "$@" 2>/dev/null) || parse_exit=$?
+parse_result=$("${SCRIPT_DIR}/parse-review-arg.sh" "$@" 2> /dev/null) || parse_exit=$?
 
 # Determine which handler to load based on the parsed mode.
 # Error mode (non-zero exit) gets no handler since SKILL.md handles errors via PARSE_RESULT.
 handler=""
 if [[ $parse_exit -ne 0 ]]; then
-	echo "<!-- No handler loaded: argument parsing returned an error. See PARSE_RESULT above. -->"
-	exit 0
+    echo "<!-- No handler loaded: argument parsing returned an error. See PARSE_RESULT above. -->"
+    exit 0
 elif echo "${parse_result}" | jq -e '.mode == "learn"' > /dev/null 2>&1; then
-	handler="${SKILL_DIR}/handlers/learn.md"
+    handler="${SKILL_DIR}/handlers/learn.md"
 elif echo "${parse_result}" | jq -e '.find_mode == "true"' > /dev/null 2>&1; then
-	handler="${SKILL_DIR}/handlers/find.md"
+    handler="${SKILL_DIR}/handlers/find.md"
 else
-	handler="${SKILL_DIR}/handlers/review.md"
+    handler="${SKILL_DIR}/handlers/review.md"
 fi
 
 # Output the handler content
 if [[ -f "${handler}" ]]; then
-	cat "${handler}"
+    cat "${handler}"
 else
-	echo "ERROR: Handler file not found: ${handler}" >&2
-	exit 1
+    echo "ERROR: Handler file not found: ${handler}" >&2
+    exit 1
 fi

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -75,7 +75,7 @@ main() {
 
     # Read all learnings using jq slurp (O(n) instead of O(n²) bash loop)
     local learnings
-    learnings=$(jq -s '[.[] | select(. != null)]' "${learnings_file}" 2>/dev/null || echo "[]")
+    learnings=$(jq -s '[.[] | select(. != null)]' "${learnings_file}" 2> /dev/null || echo "[]")
 
     local total_learnings
     total_learnings=$(echo "${learnings}" | jq 'length')

--- a/skills/review-code/scripts/submit-review.sh
+++ b/skills/review-code/scripts/submit-review.sh
@@ -64,7 +64,7 @@ verify_pending_state() {
     local review_id="$4"
 
     local review
-    review=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2>/dev/null) || {
+    review=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}" 2> /dev/null) || {
         jq -n --arg id "${review_id}" \
             '{success: false, error: ("Failed to fetch review " + $id)}'
         return 1
@@ -96,7 +96,7 @@ submit_review() {
     local result
     result=$(echo "${request_body}" | gh api --method POST \
         "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/events" \
-        --input - 2>/dev/null) || {
+        --input - 2> /dev/null) || {
         echo "Failed to submit review" >&2
         return 1
     }


### PR DESCRIPTION
## Summary

- Add explicit voice/tone guidance for inline PR comments so the tool produces direct, conversational prose instead of robotic structured headers (`**Issue**:`/`**Impact**:`/`**Recommendation**:`)
- Update the suggested comment template placeholder to reference the new guidance
- Apply shfmt formatting to shell scripts

## Test plan

- [x] `bin/fmt` passes
- [x] `bin/test` passes (all 987 tests)
- [x] `bin/setup` installs successfully
- [ ] Test with `/review-code --draft <PR>` on a real PR and verify inline comments match the voice guidance