### PR TITLE
Prefer reviewed_at metadata over file mtime for learn timestamps

### DIFF
--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -130,11 +130,20 @@ main() {
         }]
     ' 2> /dev/null || echo "[]")
 
-    # Determine files changed after the review was created
-    # Use epoch seconds for reliable date comparison (ISO 8601 string comparison
-    # fails when GitHub API returns +00:00 vs Z suffix)
+    # Determine files changed after the review was created.
+    # Prefer reviewed_at from metadata header (written by review handler),
+    # fall back to file mtime for reviews created before metadata was added.
     local review_file_epoch
-    review_file_epoch=$(get_file_mtime "${review_file}")
+    local reviewed_at
+    reviewed_at=$(grep -A1 'review-metadata' "${review_file}" 2> /dev/null \
+        | grep 'reviewed_at:' \
+        | sed 's/.*reviewed_at: *//' \
+        | tr -d ' ' || true)
+    if [[ -n "${reviewed_at}" ]]; then
+        review_file_epoch=$(iso_to_epoch "${reviewed_at}")
+    else
+        review_file_epoch=$(get_file_mtime "${review_file}")
+    fi
 
     # Check if any commits are after the review file creation
     # Using the commits data already fetched in pr_data to avoid extra API calls

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -135,10 +135,8 @@ main() {
     # fall back to file mtime for reviews created before metadata was added.
     local review_file_epoch
     local reviewed_at
-    reviewed_at=$(grep -A1 'review-metadata' "${review_file}" 2> /dev/null \
-        | grep 'reviewed_at:' \
-        | sed 's/.*reviewed_at: *//' \
-        | tr -d ' ' || true)
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "${review_file}" 2> /dev/null || true)
     if [[ -n "${reviewed_at}" ]]; then
         review_file_epoch=$(iso_to_epoch "${reviewed_at}")
     else

--- a/tests/unit/test-learn-from-pr.bats
+++ b/tests/unit/test-learn-from-pr.bats
@@ -279,6 +279,96 @@ teardown() {
 # Date comparison tests
 # =============================================================================
 
+# =============================================================================
+# reviewed_at metadata extraction tests
+# =============================================================================
+
+@test "learn-from-pr.sh: extracts reviewed_at from metadata block" {
+    local review_file="$TEST_DIR/review-with-metadata.md"
+    cat > "$review_file" <<'EOF'
+<!-- review-metadata
+reviewed_at: 2024-06-15T14:30:00Z
+mode: pr
+pr_number: 42
+org: testorg
+repo: testrepo
+-->
+
+# Review for PR #42
+Some review content here.
+EOF
+
+    local reviewed_at
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "$review_file" 2>/dev/null || true)
+
+    [ "$reviewed_at" = "2024-06-15T14:30:00Z" ]
+}
+
+@test "learn-from-pr.sh: extracts reviewed_at with offset timezone" {
+    local review_file="$TEST_DIR/review-offset-tz.md"
+    cat > "$review_file" <<'EOF'
+<!-- review-metadata
+reviewed_at: 2024-06-15T14:30:00+05:30
+mode: pr
+-->
+EOF
+
+    local reviewed_at
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "$review_file" 2>/dev/null || true)
+
+    [ "$reviewed_at" = "2024-06-15T14:30:00+05:30" ]
+}
+
+@test "learn-from-pr.sh: returns empty when no metadata block exists" {
+    local review_file="$TEST_DIR/review-no-metadata.md"
+    cat > "$review_file" <<'EOF'
+# Review for PR #42
+Some review content without metadata.
+EOF
+
+    local reviewed_at
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "$review_file" 2>/dev/null || true)
+
+    [ -z "$reviewed_at" ]
+}
+
+@test "learn-from-pr.sh: ignores reviewed_at outside metadata block" {
+    local review_file="$TEST_DIR/review-stray-field.md"
+    cat > "$review_file" <<'EOF'
+# Review for PR #42
+reviewed_at: 2024-01-01T00:00:00Z
+Some review content.
+EOF
+
+    local reviewed_at
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "$review_file" 2>/dev/null || true)
+
+    [ -z "$reviewed_at" ]
+}
+
+@test "learn-from-pr.sh: extracts reviewed_at regardless of field order" {
+    local review_file="$TEST_DIR/review-reordered.md"
+    cat > "$review_file" <<'EOF'
+<!-- review-metadata
+mode: pr
+pr_number: 42
+reviewed_at: 2024-06-15T14:30:00Z
+org: testorg
+repo: testrepo
+-->
+EOF
+
+    local reviewed_at
+    reviewed_at=$(sed -n '/review-metadata/,/-->/{ /reviewed_at:/{ s/.*reviewed_at: *//; s/ *$//; p; q; }; }' \
+        "$review_file" 2>/dev/null || true)
+
+    [ "$reviewed_at" = "2024-06-15T14:30:00Z" ]
+}
+
 @test "learn-from-pr.sh: epoch comparison works for dates" {
     local review_file_epoch=1704067200  # Jan 1, 2024 00:00:00 UTC
     local commit_epoch=1704153600       # Jan 2, 2024 00:00:00 UTC


### PR DESCRIPTION
## Summary

- Use the `reviewed_at` field from the review file's metadata header when determining review timing in the learn flow
- Fall back to file mtime for reviews created before metadata was added

This avoids incorrect timestamps when review files are copied or touched after the original review.

## Test plan

- [ ] Run `/review-code learn` on a PR with `reviewed_at` metadata — verify correct timestamp used
- [ ] Run `/review-code learn` on an older review without metadata — verify mtime fallback works