### PR TITLE
Add frozen diff support for PR benchmarks

### DIFF
--- a/evals/benchmarks/posthog/group-types-cache/answer-key.json
+++ b/evals/benchmarks/posthog/group-types-cache/answer-key.json
@@ -1,0 +1,49 @@
+{
+  "version": 1,
+  "expected_findings": [
+    {
+      "id": "negative-cache-overwrites-stale-data",
+      "description": "When the 5-minute cache TTL expires during a prolonged DB outage, get_safe_cache returns None, the DB query fails with DatabaseError, and the except branch unconditionally caches [] for 30 seconds. This means users lose group types visibility in 30-second windows throughout the outage, contradicting the docstring's claim of returning cached data. A stale-while-revalidate pattern (separate long-lived cache key or cache.add/NX semantics) would preserve the last known good data instead of clobbering it with an empty list.",
+      "area": "correctness",
+      "severity": "blocking",
+      "weight": 9,
+      "file": "posthog/models/group_type_mapping.py",
+      "line_start": 110,
+      "line_end": 113,
+      "keywords": ["negative cache", "stale", "TTL", "expires", "empty list", "overwrite", "clobber", "outage", "prolonged", "data loss", "stale-while-revalidate", "fallback", "cache.add", "NX", "last known good"]
+    },
+    {
+      "id": "missing-exception-context-in-cache-helpers",
+      "description": "safe_cache_set and safe_cache_delete catch Exception but drop the exception object entirely, logging only the cache key. During incidents this makes it impossible to distinguish connection errors from serialization failures. The existing get_safe_cache in the same file and the DatabaseError handler in get_group_types_for_project both log with exc_info=True, so this is inconsistent.",
+      "area": "maintainability",
+      "severity": "suggestion",
+      "weight": 6,
+      "file": "posthog/utils.py",
+      "line_start": 1221,
+      "line_end": 1231,
+      "keywords": ["exception", "exc_info", "traceback", "context", "swallow", "warning", "cache", "debug", "incident", "safe_cache_set", "safe_cache_delete", "logging"]
+    },
+    {
+      "id": "double-cache-lookup-per-request",
+      "description": "get_has_group_types delegates to self.get_group_types() which calls get_group_types_for_project(). Since DRF calls both get_has_group_types and get_group_types as independent SerializerMethodField methods when rendering a response, get_group_types_for_project is invoked twice per request. The second call is a Redis cache hit so the cost is low, but the round-trip is unnecessary. Calling get_group_types_for_project directly with bool() avoids the indirection.",
+      "area": "performance",
+      "severity": "suggestion",
+      "weight": 5,
+      "file": "posthog/api/team.py",
+      "line_start": 398,
+      "line_end": 398,
+      "keywords": ["double", "twice", "redundant", "duplicate", "lookup", "cache hit", "round-trip", "SerializerMethodField", "get_has_group_types", "get_group_types", "indirection"]
+    }
+  ],
+  "false_positive_traps": [
+    {
+      "id": "cache-invalidation-coverage",
+      "description": "All four mutation endpoints (update_metadata, create_detail_dashboard, destroy, set_default_columns) plus the dashboard deletion path correctly call invalidate_group_types_cache. This is thorough and complete coverage. A reviewer might be tempted to flag missing invalidation paths, but all are covered.",
+      "file": "ee/clickhouse/views/groups.py",
+      "line_start": 115,
+      "line_end": 155,
+      "trap_keywords": ["missing invalidation", "cache stale", "forgot to invalidate", "inconsistent"]
+    }
+  ],
+  "clean_areas": ["security", "compatibility"]
+}

--- a/evals/benchmarks/posthog/group-types-cache/diff.patch
+++ b/evals/benchmarks/posthog/group-types-cache/diff.patch
@@ -1,0 +1,412 @@
+diff --git a/ee/clickhouse/views/groups.py b/ee/clickhouse/views/groups.py
+index 129cb107df44..4c6ff787227b 100644
+--- a/ee/clickhouse/views/groups.py
++++ b/ee/clickhouse/views/groups.py
+@@ -30,7 +30,11 @@
+ from posthog.models.filters.utils import GroupTypeIndex
+ from posthog.models.group import Group
+ from posthog.models.group.util import create_group, raw_create_group_ch
+-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
++from posthog.models.group_type_mapping import (
++    GROUP_TYPE_MAPPING_SERIALIZER_FIELDS,
++    GroupTypeMapping,
++    invalidate_group_types_cache,
++)
+ from posthog.models.user import User
+ 
+ from products.event_definitions.backend.models.property_definition import PropertyType
+@@ -111,6 +115,7 @@ def update_metadata(self, request: request.Request, *args, **kwargs):
+             serializer.is_valid(raise_exception=True)
+             serializer.save()
+ 
++        invalidate_group_types_cache(self.team.project_id)
+         return self.list(request, *args, **kwargs)
+ 
+     @action(methods=["PUT"], detail=False)
+@@ -131,8 +136,13 @@ def create_detail_dashboard(self, request: request.Request, **kw):
+         dashboard = create_group_type_mapping_detail_dashboard(group_type_mapping, request.user)
+         group_type_mapping.detail_dashboard_id = dashboard.id
+         group_type_mapping.save()
++        invalidate_group_types_cache(self.team.project_id)
+         return response.Response(self.get_serializer(group_type_mapping).data)
+ 
++    def perform_destroy(self, instance):
++        super().perform_destroy(instance)
++        invalidate_group_types_cache(self.team.project_id)
++
+     @action(methods=["PUT"], detail=False)
+     def set_default_columns(self, request: request.Request, **kw):
+         try:
+@@ -144,6 +154,7 @@ def set_default_columns(self, request: request.Request, **kw):
+ 
+         group_type_mapping.default_columns = request.data["default_columns"]
+         group_type_mapping.save()
++        invalidate_group_types_cache(self.team.project_id)
+         return response.Response(self.get_serializer(group_type_mapping).data)
+ 
+ 
+diff --git a/ee/clickhouse/views/test/test_clickhouse_groups.py b/ee/clickhouse/views/test/test_clickhouse_groups.py
+index 681a0d553b49..4658c4506d6a 100644
+--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
++++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
+@@ -7,6 +7,7 @@
+ from unittest import mock
+ from unittest.mock import patch
+ 
++from django.core.cache import cache
+ from django.db import IntegrityError
+ 
+ from orjson import orjson
+@@ -20,6 +21,7 @@
+ from posthog.models import GroupTypeMapping, GroupUsageMetric, Person, PropertyDefinition
+ from posthog.models.filters.utils import GroupTypeIndex
+ from posthog.models.group.util import create_group
++from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
+ from posthog.models.organization import Organization
+ from posthog.models.sharing_configuration import SharingConfiguration
+ from posthog.models.team.team import Team
+@@ -1518,6 +1520,62 @@ def test_create_detail_dashboard(self):
+         self.assertEqual(data["group_type_index"], 0)
+         self.assertIsNotNone(data["detail_dashboard"])
+ 
++    def _seed_cache(self):
++        """Populate the group types cache so we can verify invalidation."""
++        cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}"
++        cache.set(cache_key, [{"stale": True}], 300)
++        return cache_key
++
++    def test_update_metadata_invalidates_cache(self):
++        GroupTypeMapping.objects.create(
++            team=self.team, project=self.project, group_type="organization", group_type_index=0
++        )
++        cache_key = self._seed_cache()
++
++        response = self.client.patch(
++            self.url + "/update_metadata",
++            [{"group_type_index": 0, "name_singular": "org"}],
++        )
++
++        self.assertEqual(response.status_code, status.HTTP_200_OK)
++        self.assertIsNone(cache.get(cache_key))
++
++    def test_destroy_invalidates_cache(self):
++        GroupTypeMapping.objects.create(
++            team=self.team, project=self.project, group_type="organization", group_type_index=0
++        )
++        cache_key = self._seed_cache()
++
++        response = self.client.delete(self.url + "/0")
++
++        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
++        self.assertIsNone(cache.get(cache_key))
++
++    def test_create_detail_dashboard_invalidates_cache(self):
++        GroupTypeMapping.objects.create(
++            team=self.team, project=self.project, group_type="organization", group_type_index=0
++        )
++        cache_key = self._seed_cache()
++
++        response = self.client.put(self.url + "/create_detail_dashboard", {"group_type_index": 0})
++
++        self.assertEqual(response.status_code, status.HTTP_200_OK)
++        self.assertIsNone(cache.get(cache_key))
++
++    def test_set_default_columns_invalidates_cache(self):
++        GroupTypeMapping.objects.create(
++            team=self.team, project=self.project, group_type="organization", group_type_index=0
++        )
++        cache_key = self._seed_cache()
++
++        response = self.client.put(
++            self.url + "/set_default_columns",
++            {"group_type_index": 0, "default_columns": ["name", "email"]},
++        )
++
++        self.assertEqual(response.status_code, status.HTTP_200_OK)
++        self.assertIsNone(cache.get(cache_key))
++
+ 
+ class GroupUsageMetricViewSetTestCase(APIBaseTest):
+     def setUp(self):
+diff --git a/posthog/api/dashboards/dashboard.py b/posthog/api/dashboards/dashboard.py
+index e2c5f9ad30a8..97d5732de5c4 100644
+--- a/posthog/api/dashboards/dashboard.py
++++ b/posthog/api/dashboards/dashboard.py
+@@ -49,7 +49,7 @@
+ from posthog.models.activity_logging.activity_log import Detail, changes_between, log_activity
+ from posthog.models.alert import AlertConfiguration
+ from posthog.models.dashboard_templates import DashboardTemplate
+-from posthog.models.group_type_mapping import GroupTypeMapping
++from posthog.models.group_type_mapping import GroupTypeMapping, invalidate_group_types_cache
+ from posthog.models.insight_variable import InsightVariable
+ from posthog.models.signals import model_activity_signal, mutable_receiver
+ from posthog.models.tagged_item import TaggedItem
+@@ -463,6 +463,7 @@ def update(self, instance: Dashboard, validated_data: dict, *args: Any, **kwargs
+             if group_type_mapping:
+                 group_type_mapping.detail_dashboard_id = None
+                 group_type_mapping.save()
++                invalidate_group_types_cache(instance.team.project_id)
+ 
+         request_filters = initial_data.get("filters")
+         if request_filters:
+diff --git a/posthog/api/project.py b/posthog/api/project.py
+index 5e837a94a3ac..a91190c6ae5d 100644
+--- a/posthog/api/project.py
++++ b/posthog/api/project.py
+@@ -38,7 +38,7 @@
+     log_activity,
+ )
+ from posthog.models.activity_logging.activity_page import activity_page_response
+-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
++from posthog.models.group_type_mapping import get_group_types_for_project
+ from posthog.models.organization import Organization, OrganizationMembership
+ from posthog.models.product_intent.product_intent import (
+     ProductIntent,
+@@ -264,12 +264,10 @@ def get_effective_membership_level(self, project: Project) -> Optional[Organizat
+         return self.user_permissions.team(team).effective_membership_level
+ 
+     def get_has_group_types(self, project: Project) -> bool:
+-        return GroupTypeMapping.objects.filter(project_id=project.id).exists()
++        return len(self.get_group_types(project)) > 0
+ 
+     def get_group_types(self, project: Project) -> list[dict[str, Any]]:
+-        return list(
+-            GroupTypeMapping.objects.filter(project_id=project.id).values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
+-        )
++        return get_group_types_for_project(project.id)
+ 
+     def get_live_events_token(self, project: Project) -> Optional[str]:
+         team = project.teams.get(pk=project.pk)
+diff --git a/posthog/api/team.py b/posthog/api/team.py
+index a6c617383229..594d4556804f 100644
+--- a/posthog/api/team.py
++++ b/posthog/api/team.py
+@@ -38,7 +38,7 @@
+ from posthog.models.data_color_theme import DataColorTheme
+ from posthog.models.event_ingestion_restriction_config import EventIngestionRestrictionConfig
+ from posthog.models.feature_flag import TeamDefaultEvaluationTag
+-from posthog.models.group_type_mapping import GROUP_TYPE_MAPPING_SERIALIZER_FIELDS, GroupTypeMapping
++from posthog.models.group_type_mapping import get_group_types_for_project
+ from posthog.models.organization import OrganizationMembership
+ from posthog.models.product_intent.product_intent import ProductIntentSerializer, calculate_product_activation
+ from posthog.models.project import Project
+@@ -395,14 +395,10 @@ def get_effective_membership_level(self, team: Team) -> OrganizationMembership.L
+         return self.user_permissions.team(team).effective_membership_level
+ 
+     def get_has_group_types(self, team: Team) -> bool:
+-        return GroupTypeMapping.objects.filter(project_id=team.project_id).exists()
++        return len(self.get_group_types(team)) > 0
+ 
+     def get_group_types(self, team: Team) -> list[dict[str, Any]]:
+-        return list(
+-            GroupTypeMapping.objects.filter(project_id=team.project_id)
+-            .order_by("group_type_index")
+-            .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
+-        )
++        return get_group_types_for_project(team.project_id)
+ 
+     def get_live_events_token(self, team: Team) -> str | None:
+         return encode_jwt(
+diff --git a/posthog/api/test/dashboards/test_dashboard.py b/posthog/api/test/dashboards/test_dashboard.py
+index 3a9bbb37d943..119ba44f5b5e 100644
+--- a/posthog/api/test/dashboards/test_dashboard.py
++++ b/posthog/api/test/dashboards/test_dashboard.py
+@@ -6,6 +6,7 @@
+ from unittest import mock
+ from unittest.mock import ANY, MagicMock, patch
+ 
++from django.core.cache import cache
+ from django.test import override_settings
+ from django.utils.timezone import now
+ 
+@@ -22,6 +23,7 @@
+ from posthog.models.activity_logging.activity_log import ActivityLog
+ from posthog.models.dashboard_tile import Text
+ from posthog.models.file_system.file_system_view_log import FileSystemViewLog
++from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
+ from posthog.models.insight_variable import InsightVariable
+ from posthog.models.organization import Organization
+ from posthog.models.project import Project
+@@ -628,9 +630,13 @@ def test_delete_dashboard_resets_group_type_detail_dashboard_if_needed(self):
+         group_type.detail_dashboard_id = dashboard.id
+         group_type.save()
+ 
++        cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}"
++        cache.set(cache_key, [{"stale": True}], 300)
++
+         self.dashboard_api.soft_delete(dashboard.id, "dashboards", {"delete_insights": True})
+         group_type.refresh_from_db()
+         self.assertIsNone(group_type.detail_dashboard_id)
++        self.assertIsNone(cache.get(cache_key))
+ 
+     def test_dashboard_items(self):
+         dashboard_id, _ = self.dashboard_api.create_dashboard({"filters": {"date_from": "-14d"}})
+diff --git a/posthog/api/test/test_team.py b/posthog/api/test/test_team.py
+index 6c5966d94747..5686346d5fe8 100644
+--- a/posthog/api/test/test_team.py
++++ b/posthog/api/test/test_team.py
+@@ -9,6 +9,7 @@
+ 
+ from django.conf import settings
+ from django.core.cache import cache
++from django.db import OperationalError
+ from django.http import HttpResponse
+ from django.test import override_settings
+ from django.utils import timezone
+@@ -22,6 +23,7 @@
+ from posthog.constants import AvailableFeature
+ from posthog.models import ActivityLog
+ from posthog.models.dashboard import Dashboard
++from posthog.models.group_type_mapping import GROUP_TYPES_CACHE_KEY_PREFIX
+ from posthog.models.instance_setting import get_instance_setting
+ from posthog.models.oauth import OAuthAccessToken, OAuthApplication
+ from posthog.models.organization import Organization, OrganizationMembership
+@@ -119,6 +121,9 @@ def test_retrieve_team_has_group_types(self):
+                 project=self.project, team=other_team, group_type="place", group_type_index=1
+             )
+ 
++            # Clear the cache so the next request fetches from DB
++            cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
++
+             response = self.client.get("/api/environments/@current/")
+             response_data = response.json()
+ 
+@@ -157,6 +162,50 @@ def test_retrieve_team_has_group_types(self):
+                 ],
+             )
+ 
++        def test_group_types_graceful_degradation_on_db_failure(self):
++            """When the persons DB is unreachable, the endpoint still returns 200
++            with empty group types rather than a 500."""
++            with patch("posthog.models.group_type_mapping.GroupTypeMapping.objects") as mock_objects:
++                mock_objects.filter.return_value.order_by.return_value.values.side_effect = OperationalError(
++                    "could not connect to server"
++                )
++                cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
++
++                response = self.client.get("/api/environments/@current/")
++                response_data = response.json()
++
++                self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
++                self.assertEqual(response_data["has_group_types"], False)
++                self.assertEqual(response_data["group_types"], [])
++
++        def test_group_types_cache_survives_db_failure(self):
++            """After a successful load populates the cache, a subsequent DB failure
++            still returns the cached data."""
++            other_team = Team.objects.create(organization=self.organization, project=self.project)
++            create_group_type_mapping_without_created_at(
++                project=self.project, team=other_team, group_type="company", group_type_index=0
++            )
++
++            # First request populates the cache
++            cache.delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{self.team.project_id}")
++            response = self.client.get("/api/environments/@current/")
++            self.assertEqual(response.status_code, status.HTTP_200_OK)
++            self.assertEqual(response.json()["has_group_types"], True)
++            self.assertEqual(len(response.json()["group_types"]), 1)
++
++            # Second request with DB failure still returns cached data
++            with patch("posthog.models.group_type_mapping.GroupTypeMapping.objects") as mock_objects:
++                mock_objects.filter.return_value.order_by.return_value.values.side_effect = OperationalError(
++                    "could not connect to server"
++                )
++
++                response = self.client.get("/api/environments/@current/")
++                response_data = response.json()
++
++                self.assertEqual(response.status_code, status.HTTP_200_OK, response_data)
++                self.assertEqual(response_data["has_group_types"], True)
++                self.assertEqual(response_data["group_types"][0]["group_type"], "company")
++
+         def test_cant_retrieve_team_from_another_org(self):
+             org = Organization.objects.create(name="New Org")
+             team = Team.objects.create(organization=org, name="Default project")
+diff --git a/posthog/models/group_type_mapping.py b/posthog/models/group_type_mapping.py
+index 546a4a53c05e..a7d45e8a36bf 100644
+--- a/posthog/models/group_type_mapping.py
++++ b/posthog/models/group_type_mapping.py
+@@ -1,8 +1,19 @@
++from typing import Any
++
+ from django.contrib.postgres.fields import ArrayField
+-from django.db import models
++from django.db import DatabaseError, models
+ from django.utils import timezone
+ 
++import structlog
++
+ from posthog.models.utils import RootTeamMixin
++from posthog.utils import get_safe_cache, safe_cache_delete, safe_cache_set
++
++logger = structlog.get_logger(__name__)
++
++GROUP_TYPES_CACHE_TTL = 60 * 5  # 5 minutes
++GROUP_TYPES_NEGATIVE_CACHE_TTL = 30  # seconds — short so we detect DB recovery quickly
++GROUP_TYPES_CACHE_KEY_PREFIX = "group_types_for_project_"
+ 
+ # Defined here for reuse between OS and EE
+ GROUP_TYPE_MAPPING_SERIALIZER_FIELDS = [
+@@ -74,3 +85,33 @@ def save(self, *args, **kwargs):
+         if self._state.adding and self.created_at is None:
+             self.created_at = timezone.now()
+         super().save(*args, **kwargs)
++
++
++def invalidate_group_types_cache(project_id: int) -> None:
++    safe_cache_delete(f"{GROUP_TYPES_CACHE_KEY_PREFIX}{project_id}")
++
++
++def get_group_types_for_project(project_id: int) -> list[dict[str, Any]]:
++    """Fetch group types from cache, falling back to DB, then to empty list.
++
++    Group types live in the persons DB. If that DB is unreachable, we return
++    cached data (if available) or an empty list rather than failing the request.
++    """
++    cache_key = f"{GROUP_TYPES_CACHE_KEY_PREFIX}{project_id}"
++
++    cached = get_safe_cache(cache_key)
++    if cached is not None:
++        return cached
++
++    try:
++        result = list(
++            GroupTypeMapping.objects.filter(project_id=project_id)
++            .order_by("group_type_index")
++            .values(*GROUP_TYPE_MAPPING_SERIALIZER_FIELDS)
++        )
++        safe_cache_set(cache_key, result, GROUP_TYPES_CACHE_TTL)
++        return result
++    except DatabaseError:
++        logger.warning("persons_db_group_types_failure", project_id=project_id, exc_info=True)
++        safe_cache_set(cache_key, [], GROUP_TYPES_NEGATIVE_CACHE_TTL)
++        return []
+diff --git a/posthog/utils.py b/posthog/utils.py
+index 94d9470052e1..f72593b7cf52 100644
+--- a/posthog/utils.py
++++ b/posthog/utils.py
+@@ -1213,6 +1213,24 @@ def get_safe_cache(cache_key: str):
+     return None
+ 
+ 
++def safe_cache_set(cache_key: str, value: Any, timeout: int | None = None) -> None:
++    """Best-effort cache write. Logs a warning on failure so Redis blips
++    are visible during incidents without breaking the calling request."""
++    try:
++        cache.set(cache_key, value, timeout)
++    except Exception:
++        logger.warning("safe_cache_set_failure", cache_key=cache_key)
++
++
++def safe_cache_delete(cache_key: str) -> None:
++    """Best-effort cache delete. Logs a warning on failure so Redis blips
++    are visible during incidents without breaking the calling request."""
++    try:
++        cache.delete(cache_key)
++    except Exception:
++        logger.warning("safe_cache_delete_failure", cache_key=cache_key)
++
++
+ def is_anonymous_id(distinct_id: str) -> bool:
+     # Our anonymous ids are _not_ uuids, but a random collection of strings
+     return bool(re.match(ANONYMOUS_REGEX, distinct_id))

--- a/evals/benchmarks/posthog/group-types-cache/metadata.json
+++ b/evals/benchmarks/posthog/group-types-cache/metadata.json
@@ -1,0 +1,14 @@
+{
+  "id": "group-types-cache",
+  "name": "Redis Cache for Group Types During DB Outage",
+  "description": "Python caching layer with negative-cache data loss, missing exception context, and redundant lookups",
+  "source": "posthog/posthog#49597",
+  "source_url": "https://github.com/PostHog/posthog/pull/49597",
+  "languages": ["python"],
+  "frameworks": ["django"],
+  "areas": ["correctness", "maintainability", "performance"],
+  "difficulty": "medium",
+  "expected_finding_count": 3,
+  "false_positive_trap_count": 1,
+  "frozen_diff": true
+}

--- a/evals/benchmarks/registry.json
+++ b/evals/benchmarks/registry.json
@@ -77,6 +77,16 @@
       "languages": ["rust"],
       "areas": ["correctness", "testing", "maintainability"],
       "difficulty": "hard"
+    },
+    {
+      "id": "group-types-cache",
+      "category": "posthog",
+      "name": "Redis Cache for Group Types During DB Outage",
+      "description": "Python caching layer with negative-cache data loss, missing exception context, and redundant lookups",
+      "source": "posthog/posthog#49597",
+      "languages": ["python"],
+      "areas": ["correctness", "maintainability", "performance"],
+      "difficulty": "medium"
     }
   ]
 }

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -85,11 +85,23 @@ run_pr_benchmark() {
 
     echo "  Reviewing PR ${pr_url}…"
 
+    # If the benchmark has a frozen diff, tell the reviewer to use it instead of
+    # fetching the latest diff from GitHub. This lets us evaluate against the
+    # original (pre-fix) code even after the PR author pushes corrections.
+    local frozen_diff
+    frozen_diff=$(jq -r '.frozen_diff // false' "${bench_dir}/metadata.json" 2> /dev/null)
+
+    local frozen_env=()
+    if [[ "${frozen_diff}" == "true" ]] && [[ -f "${bench_dir}/diff.patch" ]]; then
+        frozen_env=(REVIEW_CODE_FROZEN_DIFF="${bench_dir}/diff.patch")
+        echo "  Using frozen diff from ${bench_dir}/diff.patch"
+    fi
+
     # Run the review via claude -p using the PR URL.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
     echo "  Budget: \$${budget}"
     local claude_exit=0
-    env -u CLAUDECODE claude -p "/review-code ${pr_url} --force" \
+    env -u CLAUDECODE "${frozen_env[@]}" claude -p "/review-code ${pr_url} --force" \
         --dangerously-skip-permissions \
         --max-budget-usd "${budget}" \
         > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -92,9 +92,14 @@ run_pr_benchmark() {
     frozen_diff=$(jq -r '.frozen_diff // false' "${bench_dir}/metadata.json" 2> /dev/null)
 
     local frozen_env=()
-    if [[ "${frozen_diff}" == "true" ]] && [[ -f "${bench_dir}/diff.patch" ]]; then
-        frozen_env=(REVIEW_CODE_FROZEN_DIFF="${bench_dir}/diff.patch")
-        echo "  Using frozen diff from ${bench_dir}/diff.patch"
+    if [[ "${frozen_diff}" == "true" ]]; then
+        if [[ -f "${bench_dir}/diff.patch" ]]; then
+            frozen_env=(REVIEW_CODE_FROZEN_DIFF="${bench_dir}/diff.patch")
+            echo "  Using frozen diff from ${bench_dir}/diff.patch"
+        else
+            echo "  Error: frozen_diff is true but ${bench_dir}/diff.patch not found" >&2
+            return 1
+        fi
     fi
 
     # Run the review via claude -p using the PR URL.

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -979,9 +979,13 @@ handle_pr_review() {
             }')
     fi
 
-    # Extract diff content from PR data
+    # Extract diff: use frozen diff if available, otherwise from PR data
     local diff_content
-    diff_content=$(echo "${pr_data}" | jq -r '.diff')
+    if [[ -n "${REVIEW_CODE_FROZEN_DIFF:-}" ]] && [[ -f "${REVIEW_CODE_FROZEN_DIFF}" ]]; then
+        diff_content=$(cat "${REVIEW_CODE_FROZEN_DIFF}")
+    else
+        diff_content=$(echo "${pr_data}" | jq -r '.diff')
+    fi
 
     build_review_data "pr" "${diff_content}" "${git_context}" "pr-${pr_number}" "${pr_data}" \
         --arg mode_branch "${head_ref}" \


### PR DESCRIPTION
## Summary

- When a PR author fixes issues after reviewers flag them, benchmarks can't test whether our reviewer would have caught the original bugs. This adds a "frozen diff" mode for PR benchmarks.
- When `metadata.json` has `"frozen_diff": true` and a `diff.patch` exists, the eval runner passes the path via `REVIEW_CODE_FROZEN_DIFF` env var. The orchestrator uses that file instead of fetching the latest diff from GitHub, while still fetching PR metadata (title, body, comments) live for context.
- Enables frozen diff for the `group-types-cache` benchmark, which previously scored 0% recall because it was reviewing the already-fixed PR.

## Test plan

- [x] `bin/fmt` passes
- [x] `bin/test` passes (1002 unit + 12 integration tests)
- [ ] Run `evals/scripts/run-eval.sh --benchmark group-types-cache` and verify `claude-output.txt` shows the original buggy diff
- [ ] Run `evals/scripts/score-eval.sh <run-id> group-types-cache --no-llm` and verify improved recall