### PR TITLE
Add diff chunking for large PR reviews

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -302,9 +302,9 @@ Use the Task tool with `subagent_type` from the table above. If an area is speci
 
 **Chunked review dispatch:**
 
-If `is_chunked` is true, process chunks sequentially (one chunk at a time, all agents in parallel per chunk):
+If `is_chunked` is true, process all chunks in parallel (all agents x all chunks dispatched at once):
 
-1. For each chunk in the `chunks` array:
+1. For each chunk in the `chunks` array, for each applicable agent:
    - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
    - Add a chunk context header to each agent prompt:
      ```
@@ -315,10 +315,9 @@ If `is_chunked` is true, process chunks sequentially (one chunk at a time, all a
      If you notice issues that may interact with code in other chunks, flag them as questions.
      ```
    - Keep all other context the same: full `file_metadata`, full `architectural_context`, full `review_context`, all PR metadata
-   - Invoke all applicable agents in parallel for this chunk
-   - Collect all findings from this chunk before moving to the next
+   - Dispatch all (chunk x agent) combinations in parallel via the Task tool
 
-2. After all chunks are processed, merge all findings into a single pool for synthesis.
+2. After all tasks complete, merge all findings into a single pool for synthesis.
 
 If `is_chunked` is false (or `chunk_metadata` is absent), behavior is identical to the non-chunked path above.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -68,6 +68,14 @@ From the session file JSON, extract these fields:
 - `languages` — detected languages
 - `file_info.file_path` — where to save the review
 - `file_ref` — (optional) git ref for reading PR files when on a different branch
+- `chunks` — (optional) array of chunk objects when the diff was split
+- `chunk_metadata` — (optional) object with `chunked`, `reason`, `chunk_count`
+
+**Check for chunked diff:**
+
+If `chunk_metadata` exists and `chunk_metadata.chunked` is `true`, set `is_chunked = true`. Extract `chunk_count` from `chunk_metadata.chunk_count` and the `chunks` array. Display to the user:
+
+"This is a large PR ({chunk_metadata.reason}). Splitting into {chunk_count} chunks for focused review."
 
 **Extract mode-specific fields:**
 
@@ -292,14 +300,36 @@ Comment structure: `conversation` (discussion), `reviews` (approve/changes), `in
 
 Use the Task tool with `subagent_type` from the table above. If an area is specified, invoke only that agent. Otherwise, invoke all 7 core agents in parallel (+ frontend if `languages.has_frontend` is true). Pass the FULL context (PR info, diff, architectural context, guidelines) to each agent as the prompt.
 
+**Chunked review dispatch:**
+
+If `is_chunked` is true, process chunks sequentially (one chunk at a time, all agents in parallel per chunk):
+
+1. For each chunk in the `chunks` array:
+   - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
+   - Add a chunk context header to each agent prompt:
+     ```
+     **Chunk Context:**
+     You are reviewing chunk $chunk.id of $chunk_count: $chunk.label
+     Files in this chunk: $chunk.files (comma-separated list)
+     Other chunks cover: (list labels of other chunks)
+     If you notice issues that may interact with code in other chunks, flag them as questions.
+     ```
+   - Keep all other context the same: full `file_metadata`, full `architectural_context`, full `review_context`, all PR metadata
+   - Invoke all applicable agents in parallel for this chunk
+   - Collect all findings from this chunk before moving to the next
+
+2. After all chunks are processed, merge all findings into a single pool for synthesis.
+
+If `is_chunked` is false (or `chunk_metadata` is absent), behavior is identical to the non-chunked path above.
+
 ### Collect and Present Results
 
 Use ultrathink to synthesize findings from all agents into a coherent, deduplicated review. Apply confidence-based filtering and cross-agent corroboration before producing the final document.
 
 After all agents complete, combine their findings into a single review document.
 
-**Filtering (cross-agent corroboration).** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Apply these rules:
-- **Corroborated (2+ agents):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
+**Filtering (cross-agent and cross-chunk corroboration).** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. This applies both across agents within the same chunk and across chunks that touch related code. Apply these rules:
+- **Corroborated (2+ agents or chunks):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
 - **Solo finding, confidence >= 40%:** Include as-is.
 - **Solo finding, confidence < 40%:** Drop silently.
 - **Questions and nits:** Exempt from filtering (no minimum confidence).
@@ -312,9 +342,13 @@ After all agents complete, combine their findings into a single review document.
 4. Solo suggestions (>= 40% confidence)
 5. Questions and nits
 
+**Important:** The final review document does NOT separate findings by chunk. Present a unified review organized by the priority ordering above, the same as for non-chunked reviews.
+
 **Verify findings against the diff before including them in the final review.**
 
-After collecting findings from agents, validate that each finding references code actually in the diff. This catches wrong line numbers, findings about unrelated files, and stale references.
+After collecting findings from all agents (across all chunks if chunked), validate that each finding references code actually in the diff. This catches wrong line numbers, findings about unrelated files, and stale references.
+
+**Important:** Always use the FULL diff from the session data (not chunk diffs) for position mapping. The position mapper needs the complete diff to map findings to correct GitHub inline comment positions.
 
 **Step 1: Extract and validate.** For each agent's findings that reference a specific file and line, build a targets array and run it through the position mapper:
 
@@ -357,6 +391,12 @@ Where the `targets` array contains `{"path": "<file>", "line": <number>}` object
 - Architecture Review
 
 **For area-specific reviews**, include only that area's findings.
+
+If `is_chunked` is true, add a "Review Scope" note at the top of the review document (after the metadata header):
+
+```markdown
+> **Review Scope:** This review covered $chunk_count chunks ($total_file_count files total).
+```
 
 Save the complete review to `$review_file` and inform the user with a clickable file link:
 

--- a/skills/review-code/scripts/chunk-diff.sh
+++ b/skills/review-code/scripts/chunk-diff.sh
@@ -43,21 +43,22 @@ parse_diff_segments() {
     # Each record captures the file path (from the "diff --git a/... b/..." line)
     # and the full diff text for that file.
     awk '
+    function emit() {
+        sz = length(buf)
+        gsub(/\\/, "\\\\", buf)
+        gsub(/"/, "\\\"", buf)
+        gsub(/\n/, "\\n", buf)
+        gsub(/\t/, "\\t", buf)
+        gsub(/\r/, "\\r", buf)
+        gsub(/\\/, "\\\\", path)
+        gsub(/"/, "\\\"", path)
+        printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, sz
+    }
+
     BEGIN { path = ""; buf = "" }
 
     /^diff --git / {
-        # Emit previous segment if we have one
-        if (path != "") {
-            # JSON-escape the buffer: backslashes, quotes, newlines, tabs, carriage returns
-            gsub(/\\/, "\\\\", buf)
-            gsub(/"/, "\\\"", buf)
-            gsub(/\n/, "\\n", buf)
-            gsub(/\t/, "\\t", buf)
-            gsub(/\r/, "\\r", buf)
-            gsub(/\\/, "\\\\", path)
-            gsub(/"/, "\\\"", path)
-            printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
-        }
+        if (path != "") emit()
 
         # Extract path from "diff --git a/X b/X" - take the b/ side.
         # Match on " b/" (with leading space) to avoid false matches on directory
@@ -75,16 +76,7 @@ parse_diff_segments() {
     { buf = buf $0 "\n" }
 
     END {
-        if (path != "") {
-            gsub(/\\/, "\\\\", buf)
-            gsub(/"/, "\\\"", buf)
-            gsub(/\n/, "\\n", buf)
-            gsub(/\t/, "\\t", buf)
-            gsub(/\r/, "\\r", buf)
-            gsub(/\\/, "\\\\", path)
-            gsub(/"/, "\\\"", path)
-            printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
-        }
+        if (path != "") emit()
     }
     ' "${diff_file}"
 }
@@ -158,7 +150,8 @@ main() {
     # Step 1: Pair test files with their implementation files.
     # Build a mapping of impl_path -> [test_paths] and track which files are paired.
     # When file_metadata is available (passed from the orchestrator via pre-review-context.sh),
-    # use its is_test and likely_test_path fields instead of reimplementing test detection.
+    # use its likely_test_path for forward mapping and is_test to skip known non-test files.
+    # Fall back to filename pattern matching when metadata is absent.
     local file_metadata_json
     file_metadata_json=$(jq -c '.file_metadata // null' <<< "${input}")
 
@@ -201,27 +194,48 @@ main() {
             reduce $meta.modified_files[] as $m ({}; . + {($m.path): $m})
         else {} end) as $meta_lookup |
 
-        # For each file, check if it is a test file
+        # Step 1a: Use likely_test_path forward mapping when metadata is available.
+        # For each non-test file with a likely_test_path, check if that test file
+        # is in the diff and pair them.
+        (if ($meta_lookup | length) > 0 then
+            reduce ($meta_lookup | to_entries[]) as $entry (
+                {"pairs": {}, "paired_set": {}};
+                $entry.key as $file_path |
+                $entry.value as $m |
+                if $m.is_test != true and
+                   ($m.likely_test_path // "") != "" and
+                   ($all_paths | index($m.likely_test_path) != null) then
+                    .pairs[$file_path] = ((.pairs[$file_path] // []) + [$m.likely_test_path]) |
+                    .paired_set[$file_path] = true |
+                    .paired_set[$m.likely_test_path] = true
+                else . end
+            )
+        else null end) as $meta_pairs |
+
+        # Step 1b: Fall back to pattern matching for files not paired by metadata.
         reduce .[] as $seg (
-            {"pairs": {}, "paired_set": {}};
+            ($meta_pairs // {"pairs": {}, "paired_set": {}});
 
-            ($seg.path | split("/") | last) as $basename |
-            ($seg.path | split("/")[:-1] | join("/")) as $dirpart |
-
-            # Use metadata to skip pattern matching for known non-test files.
-            # Otherwise, derive the impl path from the test file name.
-            (if ($meta_lookup | has($seg.path)) and $meta_lookup[$seg.path].is_test != true then
-                null
+            # Skip files already paired via metadata
+            if .paired_set[$seg.path] == true then .
             else
-                impl_path_for_test($basename; $dirpart)
-            end) as $impl_path |
+                ($seg.path | split("/") | last) as $basename |
+                ($seg.path | split("/")[:-1] | join("/")) as $dirpart |
 
-            if $impl_path != null and ($all_paths | index($impl_path) != null) then
-                .pairs[$impl_path] = ((.pairs[$impl_path] // []) + [$seg.path]) |
-                .paired_set[$seg.path] = true |
-                .paired_set[$impl_path] = true
-            else
-                .
+                # Use metadata to skip pattern matching for known non-test files.
+                (if ($meta_lookup | has($seg.path)) and $meta_lookup[$seg.path].is_test != true then
+                    null
+                else
+                    impl_path_for_test($basename; $dirpart)
+                end) as $impl_path |
+
+                if $impl_path != null and ($all_paths | index($impl_path) != null) then
+                    .pairs[$impl_path] = ((.pairs[$impl_path] // []) + [$seg.path]) |
+                    .paired_set[$seg.path] = true |
+                    .paired_set[$impl_path] = true
+                else
+                    .
+                end
             end
         )
     ')
@@ -242,16 +256,17 @@ main() {
         ($pair_groups + $single_groups) | sort_by(.[0])
     ')
 
-    # Step 3: Bin-pack groups into chunks respecting size and file count limits
-    local chunks_json
-    chunks_json=$(echo "${segments_json}" | jq --argjson groups "${grouping_units}" \
+    # Steps 3+4: Bin-pack groups into chunks, then build final output with diffs and labels.
+    # Combined into a single jq invocation to avoid rebuilding the segment lookup twice.
+    local final_output
+    final_output=$(echo "${segments_json}" | jq --argjson groups "${grouping_units}" \
         --argjson max_size "${max_chunk_size_bytes}" \
         --argjson max_files "${max_files_per_chunk}" '
         # Build a lookup from path to segment
         (reduce .[] as $seg ({}; . + {($seg.path): $seg})) as $seg_lookup |
 
         # Bin-pack groups into chunks
-        reduce $groups[] as $group (
+        (reduce $groups[] as $group (
             {"chunks": [], "current": {"files": [], "size": 0}};
 
             # Calculate group size and file count
@@ -278,57 +293,47 @@ main() {
         else
             .
         end |
-        .chunks
-    ')
+        .chunks) as $chunks |
 
-    local chunk_count
-    chunk_count=$(echo "${chunks_json}" | jq 'length')
+        # If only one chunk, no point in chunking
+        if ($chunks | length) <= 1 then
+            {"chunked": false, "reason":
+                ("all files fit in a single chunk (" +
+                 (reduce .[] as $s (0; . + $s.size_bytes) | . / 1024 | floor | tostring) +
+                 "KB, " + (length | tostring) + " files)")}
+        else
+            {
+                "chunked": true,
+                "reason": ("diff exceeds threshold (" +
+                    (reduce .[] as $s (0; . + $s.size_bytes) | . / 1024 | floor | tostring) +
+                    "KB, " + (length | tostring) + " files)"),
+                "chunk_count": ($chunks | length),
+                "chunks": [
+                    $chunks | to_entries[] |
+                    .key as $idx |
+                    .value as $chunk |
 
-    # If only one chunk, no point in chunking
-    if [[ "${chunk_count}" -le 1 ]]; then
-        jq -n \
-            --arg reason "all files fit in a single chunk (${diff_size_kb}KB, ${file_count} files)" \
-            '{"chunked": false, "reason": $reason}'
-        return
-    fi
+                    # Concatenate diffs for files in this chunk
+                    (reduce $chunk.files[] as $f ("";
+                        . + ($seg_lookup[$f].diff // "")
+                    )) as $chunk_diff |
 
-    # Step 4: Build final output with chunk diffs and labels
-    local final_output
-    final_output=$(echo "${segments_json}" | jq --argjson chunks "${chunks_json}" '
-        # Build path -> segment lookup
-        (reduce .[] as $seg ({}; . + {($seg.path): $seg})) as $seg_lookup |
+                    # Calculate chunk size
+                    ($chunk_diff | length / 1024 | floor) as $size_kb |
 
-        {
-            "chunked": true,
-            "reason": ("diff exceeds threshold (" +
-                (reduce .[] as $s (0; . + $s.size_bytes) | . / 1024 | floor | tostring) +
-                "KB, " + (length | tostring) + " files)"),
-            "chunk_count": ($chunks | length),
-            "chunks": [
-                $chunks | to_entries[] |
-                .key as $idx |
-                .value as $chunk |
+                    # Generate label from most common top-level directory
+                    ([$chunk.files[] | split("/")[0]] | group_by(.) | sort_by(-length) | .[0][0] // "root") as $top_dir |
 
-                # Concatenate diffs for files in this chunk
-                (reduce $chunk.files[] as $f ("";
-                    . + ($seg_lookup[$f].diff // "")
-                )) as $chunk_diff |
-
-                # Calculate chunk size
-                ($chunk_diff | length / 1024 | floor) as $size_kb |
-
-                # Generate label from most common top-level directory
-                ([$chunk.files[] | split("/")[0]] | group_by(.) | sort_by(-length) | .[0][0] // "root") as $top_dir |
-
-                {
-                    "id": ($idx + 1),
-                    "label": ($top_dir + " (" + ($chunk.files | length | tostring) + " files)"),
-                    "files": $chunk.files,
-                    "diff": $chunk_diff,
-                    "size_kb": $size_kb
-                }
-            ]
-        }
+                    {
+                        "id": ($idx + 1),
+                        "label": ($top_dir + " (" + ($chunk.files | length | tostring) + " files)"),
+                        "files": $chunk.files,
+                        "diff": $chunk_diff,
+                        "size_kb": $size_kb
+                    }
+                ]
+            }
+        end
     ')
 
     echo "${final_output}"

--- a/skills/review-code/scripts/chunk-diff.sh
+++ b/skills/review-code/scripts/chunk-diff.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# chunk-diff.sh - Split large diffs into logical chunks for focused review
+#
+# Usage:
+#   echo '{"diff": "...", "config": {...}}' | chunk-diff.sh
+#
+# Input (stdin): JSON object with:
+#   - diff: unified diff text (required)
+#   - file_metadata: array of {path, type, language, is_test, likely_test_path} (optional)
+#   - config: {max_chunk_size_kb, max_files_per_chunk, min_chunk_threshold_kb,
+#              min_chunk_threshold_files} (optional, all have defaults)
+#
+# Output (stdout): JSON object:
+#   - chunked: boolean
+#   - reason: string
+#   - chunk_count: number (only when chunked)
+#   - chunks: array of {id, label, files, diff, size_kb} (only when chunked)
+#
+# When below threshold, outputs: {"chunked": false, "reason": "..."}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=helpers/json-helpers.sh
+source "${SCRIPT_DIR}/helpers/json-helpers.sh"
+
+set -euo pipefail
+
+# Default configuration
+DEFAULT_MAX_CHUNK_SIZE_KB=200
+DEFAULT_MAX_FILES_PER_CHUNK=30
+DEFAULT_MIN_CHUNK_THRESHOLD_KB=200
+DEFAULT_MIN_CHUNK_THRESHOLD_FILES=50
+
+# Parse the diff text into per-file segments.
+# Reads the diff from the file at path $1 and writes a JSON array to stdout where
+# each element is {"path": "...", "diff": "...", "size_bytes": N}.
+parse_diff_segments() {
+    local diff_file="$1"
+
+    # Use awk to split on "diff --git" boundaries and emit NDJSON.
+    # Each record captures the file path (from the "diff --git a/... b/..." line)
+    # and the full diff text for that file.
+    awk '
+    BEGIN { path = ""; buf = "" }
+
+    /^diff --git / {
+        # Emit previous segment if we have one
+        if (path != "") {
+            # JSON-escape the buffer: backslashes, quotes, newlines, tabs, carriage returns
+            gsub(/\\/, "\\\\", buf)
+            gsub(/"/, "\\\"", buf)
+            gsub(/\n/, "\\n", buf)
+            gsub(/\t/, "\\t", buf)
+            gsub(/\r/, "\\r", buf)
+            printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
+        }
+
+        # Extract path from "diff --git a/X b/X" - take the b/ side
+        match($0, /b\/(.+)$/)
+        if (RSTART > 0) {
+            path = substr($0, RSTART + 2)
+        } else {
+            path = "unknown"
+        }
+        buf = $0 "\n"
+        next
+    }
+
+    { buf = buf $0 "\n" }
+
+    END {
+        if (path != "") {
+            gsub(/\\/, "\\\\", buf)
+            gsub(/"/, "\\\"", buf)
+            gsub(/\n/, "\\n", buf)
+            gsub(/\t/, "\\t", buf)
+            gsub(/\r/, "\\r", buf)
+            printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
+        }
+    }
+    ' "${diff_file}"
+}
+
+# Determine the implementation file that a test file corresponds to.
+# Returns the likely implementation path, or empty string if not a test file.
+get_impl_for_test() {
+    local file_path="$1"
+    local basename
+    basename=$(basename "${file_path}")
+    local dirname
+    dirname=$(dirname "${file_path}")
+
+    # Python: test_foo.py -> foo.py
+    if [[ "${basename}" =~ ^test_ ]]; then
+        echo "${dirname}/${basename#test_}"
+        return
+    fi
+
+    # Go: foo_test.go -> foo.go
+    if [[ "${basename}" =~ _test\.go$ ]]; then
+        echo "${dirname}/${basename%_test.go}.go"
+        return
+    fi
+
+    # Generic: foo_test.ext -> foo.ext
+    if [[ "${basename}" =~ _test\. ]]; then
+        echo "${dirname}/${basename/_test./\.}"
+        return
+    fi
+
+    # JS/TS: foo.test.ext or foo.spec.ext -> foo.ext
+    if [[ "${basename}" =~ \.test\. ]]; then
+        local name="${basename%.test.*}"
+        local ext="${basename##*.}"
+        echo "${dirname}/${name}.${ext}"
+        return
+    fi
+    if [[ "${basename}" =~ \.spec\. ]]; then
+        local name="${basename%.spec.*}"
+        local ext="${basename##*.}"
+        echo "${dirname}/${name}.${ext}"
+        return
+    fi
+
+    # __tests__/foo.ext -> ../foo.ext
+    if [[ "${dirname}" =~ /__tests__$ ]]; then
+        local parent
+        parent=$(dirname "${dirname}")
+        echo "${parent}/${basename}"
+        return
+    fi
+
+    echo ""
+}
+
+# Check whether a file path looks like a test file.
+is_test_file() {
+    local file_path="$1"
+    local basename
+    basename=$(basename "${file_path}")
+    local dirname
+    dirname=$(dirname "${file_path}")
+
+    [[ "${basename}" =~ ^test_ ]] \
+        || [[ "${basename}" =~ _test\. ]] \
+        || [[ "${basename}" =~ \.test\. ]] \
+        || [[ "${basename}" =~ \.spec\. ]] \
+        || [[ "${basename}" =~ _spec\. ]] \
+        || [[ "${dirname}" =~ /__tests__$ ]] \
+        || [[ "${dirname}" =~ /tests?$ ]] \
+        || [[ "${dirname}" =~ /specs?$ ]]
+}
+
+# Generate a human-readable label for a chunk by finding the most common
+# directory prefix among the chunk's files.
+generate_chunk_label() {
+    local files_json="$1"
+    local file_count
+    file_count=$(echo "${files_json}" | jq -r 'length')
+
+    if [[ "${file_count}" -eq 0 ]]; then
+        echo "empty"
+        return
+    fi
+
+    if [[ "${file_count}" -eq 1 ]]; then
+        echo "${files_json}" | jq -r '.[0]'
+        return
+    fi
+
+    # Find the most common top-level directory
+    local top_dir
+    top_dir=$(echo "${files_json}" | jq -r '.[]' | while IFS= read -r f; do
+        dirname "${f}" | cut -d'/' -f1
+    done | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
+
+    echo "${top_dir} (${file_count} files)"
+}
+
+main() {
+    # Read input from stdin
+    local input
+    input=$(cat)
+
+    # Validate JSON
+    if ! echo "${input}" | jq empty 2> /dev/null; then
+        error "Invalid JSON input"
+        exit 1
+    fi
+
+    # Extract diff to a temp file to avoid argument length limits
+    # Use a global for the trap so cleanup works even after the function returns
+    _CHUNK_DIFF_TMPFILE=$(mktemp)
+    local diff_file="${_CHUNK_DIFF_TMPFILE}"
+    trap 'rm -f "${_CHUNK_DIFF_TMPFILE}"' EXIT
+
+    echo "${input}" | jq -r '.diff // ""' > "${diff_file}"
+
+    # Check for empty diff (the file will have at least a trailing newline from echo)
+    local diff_content_check
+    diff_content_check=$(jq -r '.diff // ""' <<< "${input}")
+    if [[ -z "${diff_content_check}" ]]; then
+        jq -n '{"chunked": false, "reason": "empty diff"}'
+        return
+    fi
+
+    # Extract config with defaults
+    local max_chunk_size_kb max_files_per_chunk min_threshold_kb min_threshold_files
+    max_chunk_size_kb=$(echo "${input}" | jq -r ".config.max_chunk_size_kb // ${DEFAULT_MAX_CHUNK_SIZE_KB}")
+    max_files_per_chunk=$(echo "${input}" | jq -r ".config.max_files_per_chunk // ${DEFAULT_MAX_FILES_PER_CHUNK}")
+    min_threshold_kb=$(echo "${input}" | jq -r ".config.min_chunk_threshold_kb // ${DEFAULT_MIN_CHUNK_THRESHOLD_KB}")
+    min_threshold_files=$(echo "${input}" | jq -r ".config.min_chunk_threshold_files // ${DEFAULT_MIN_CHUNK_THRESHOLD_FILES}")
+
+    local max_chunk_size_bytes=$((max_chunk_size_kb * 1024))
+
+    # Calculate diff size and file count
+    local diff_size_bytes
+    diff_size_bytes=$(wc -c < "${diff_file}")
+    diff_size_bytes="${diff_size_bytes// /}" # Strip whitespace (macOS wc pads with spaces)
+    local diff_size_kb=$((diff_size_bytes / 1024))
+
+    # Parse diff into per-file segments
+    local segments_ndjson
+    segments_ndjson=$(parse_diff_segments "${diff_file}")
+
+    # Count files. grep -c returns 1 on no match, so use a default.
+    local file_count
+    file_count=$(printf '%s\n' "${segments_ndjson}" | grep -c '^{' || true)
+    file_count="${file_count:-0}"
+
+    # Check if below threshold
+    local threshold_kb_bytes=$((min_threshold_kb * 1024))
+    if [[ "${diff_size_bytes}" -lt "${threshold_kb_bytes}" ]] && [[ "${file_count}" -lt "${min_threshold_files}" ]]; then
+        jq -n \
+            --arg reason "below threshold (${diff_size_kb}KB, ${file_count} files)" \
+            '{"chunked": false, "reason": $reason}'
+        return
+    fi
+
+    # Build the segments array as JSON
+    local segments_json
+    segments_json=$(echo "${segments_ndjson}" | jq -s '.')
+
+    # Step 1: Pair test files with their implementation files.
+    # Build a mapping of impl_path -> [test_paths] and track which files are paired.
+    local paired_groups
+    paired_groups=$(echo "${segments_json}" | jq -r '
+        # Build a list of all file paths
+        [.[].path] as $all_paths |
+
+        # For each file, check if it is a test file
+        reduce .[] as $seg (
+            {"pairs": {}, "paired_set": {}};
+
+            # Check test file patterns
+            ($seg.path | split("/") | last) as $basename |
+            ($seg.path | split("/")[:-1] | join("/")) as $dirpart |
+            (
+                if ($basename | test("^test_")) then
+                    # Python-style: test_foo.py -> foo.py
+                    ($dirpart + "/" + ($basename | sub("^test_"; "")))
+                elif ($basename | test("_test\\.go$")) then
+                    # Go-style: foo_test.go -> foo.go
+                    ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
+                elif ($basename | test("_test\\.")) then
+                    # Generic: foo_test.ext -> foo.ext
+                    ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
+                elif ($basename | test("\\.test\\.")) then
+                    # JS/TS: foo.test.ext -> foo.ext
+                    ($basename | split(".test.")) as $parts |
+                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
+                elif ($basename | test("\\.spec\\.")) then
+                    # JS/TS: foo.spec.ext -> foo.ext
+                    ($basename | split(".spec.")) as $parts |
+                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
+                elif ($dirpart | test("/__tests__$")) then
+                    # __tests__/foo.ext -> ../foo.ext
+                    (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
+                else
+                    null
+                end
+            ) as $impl_path |
+
+            if $impl_path != null and ($all_paths | index($impl_path) != null) then
+                .pairs[$impl_path] = ((.pairs[$impl_path] // []) + [$seg.path]) |
+                .paired_set[$seg.path] = true |
+                .paired_set[$impl_path] = true
+            else
+                .
+            end
+        )
+    ')
+
+    # Step 2: Build grouping units (paired groups + unpaired files), sorted by directory
+    local grouping_units
+    grouping_units=$(echo "${segments_json}" | jq --argjson pairs "${paired_groups}" '
+        # Get all paired files
+        ($pairs.paired_set | keys) as $paired_files |
+
+        # Build paired groups: each group is [impl_file, test_files...]
+        [($pairs.pairs | to_entries[] | [.key] + .value)] as $pair_groups |
+
+        # Build unpaired singles: each group is [file]
+        [.[] | select(.path as $p | $paired_files | index($p) | not) | [.path]] as $single_groups |
+
+        # Combine and sort by first file path (directory proximity)
+        ($pair_groups + $single_groups) | sort_by(.[0])
+    ')
+
+    # Step 3: Bin-pack groups into chunks respecting size and file count limits
+    local chunks_json
+    chunks_json=$(echo "${segments_json}" | jq --argjson groups "${grouping_units}" \
+        --argjson max_size "${max_chunk_size_bytes}" \
+        --argjson max_files "${max_files_per_chunk}" '
+        # Build a lookup from path to segment
+        (reduce .[] as $seg ({}; . + {($seg.path): $seg})) as $seg_lookup |
+
+        # Bin-pack groups into chunks
+        reduce $groups[] as $group (
+            {"chunks": [], "current": {"files": [], "size": 0}};
+
+            # Calculate group size and file count
+            (reduce $group[] as $f (0; . + ($seg_lookup[$f].size_bytes // 0))) as $group_size |
+            ($group | length) as $group_file_count |
+
+            # Check if adding this group would exceed limits
+            if (.current.files | length) > 0 and
+               ((.current.size + $group_size > $max_size) or
+                ((.current.files | length) + $group_file_count > $max_files))
+            then
+                # Start a new chunk
+                .chunks += [.current] |
+                .current = {"files": $group, "size": $group_size}
+            else
+                # Add to current chunk
+                .current.files += $group |
+                .current.size += $group_size
+            end
+        ) |
+        # Flush the last chunk
+        if (.current.files | length) > 0 then
+            .chunks += [.current]
+        else
+            .
+        end |
+        .chunks
+    ')
+
+    local chunk_count
+    chunk_count=$(echo "${chunks_json}" | jq 'length')
+
+    # If only one chunk, no point in chunking
+    if [[ "${chunk_count}" -le 1 ]]; then
+        jq -n \
+            --arg reason "all files fit in a single chunk (${diff_size_kb}KB, ${file_count} files)" \
+            '{"chunked": false, "reason": $reason}'
+        return
+    fi
+
+    # Step 4: Build final output with chunk diffs and labels
+    local final_output
+    final_output=$(echo "${segments_json}" | jq --argjson chunks "${chunks_json}" '
+        # Build path -> segment lookup
+        (reduce .[] as $seg ({}; . + {($seg.path): $seg})) as $seg_lookup |
+
+        {
+            "chunked": true,
+            "reason": ("diff exceeds threshold (" +
+                (reduce .[] as $s (0; . + $s.size_bytes) | . / 1024 | floor | tostring) +
+                "KB, " + (length | tostring) + " files)"),
+            "chunk_count": ($chunks | length),
+            "chunks": [
+                $chunks | to_entries[] |
+                .key as $idx |
+                .value as $chunk |
+
+                # Concatenate diffs for files in this chunk
+                (reduce $chunk.files[] as $f ("";
+                    . + ($seg_lookup[$f].diff // "")
+                )) as $chunk_diff |
+
+                # Calculate chunk size
+                ($chunk_diff | length / 1024 | floor) as $size_kb |
+
+                # Generate label from most common top-level directory
+                ([$chunk.files[] | split("/")[0]] | group_by(.) | sort_by(-length) | .[0][0] // "root") as $top_dir |
+
+                {
+                    "id": ($idx + 1),
+                    "label": ($top_dir + " (" + ($chunk.files | length | tostring) + " files)"),
+                    "files": $chunk.files,
+                    "diff": $chunk_diff,
+                    "size_kb": $size_kb
+                }
+            ]
+        }
+    ')
+
+    echo "${final_output}"
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/chunk-diff.sh
+++ b/skills/review-code/scripts/chunk-diff.sh
@@ -6,7 +6,8 @@
 #
 # Input (stdin): JSON object with:
 #   - diff: unified diff text (required)
-#   - file_metadata: array of {path, type, language, is_test, likely_test_path} (optional)
+#   - file_metadata: object with modified_files array of {path, type, language, is_test,
+#                   likely_test_path} (optional, from pre-review-context.sh)
 #   - config: {max_chunk_size_kb, max_files_per_chunk, min_chunk_threshold_kb,
 #              min_chunk_threshold_files} (optional, all have defaults)
 #
@@ -29,7 +30,7 @@ set -euo pipefail
 # Default configuration
 DEFAULT_MAX_CHUNK_SIZE_KB=200
 DEFAULT_MAX_FILES_PER_CHUNK=30
-DEFAULT_MIN_CHUNK_THRESHOLD_KB=200
+DEFAULT_MIN_CHUNK_THRESHOLD_KB=400
 DEFAULT_MIN_CHUNK_THRESHOLD_FILES=50
 
 # Parse the diff text into per-file segments.
@@ -53,13 +54,17 @@ parse_diff_segments() {
             gsub(/\n/, "\\n", buf)
             gsub(/\t/, "\\t", buf)
             gsub(/\r/, "\\r", buf)
+            gsub(/\\/, "\\\\", path)
+            gsub(/"/, "\\\"", path)
             printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
         }
 
-        # Extract path from "diff --git a/X b/X" - take the b/ side
-        match($0, /b\/(.+)$/)
+        # Extract path from "diff --git a/X b/X" - take the b/ side.
+        # Match on " b/" (with leading space) to avoid false matches on directory
+        # names containing "b" (e.g., lib/, web/, pub/, sub/, contrib/, db/).
+        match($0, / b\/(.+)$/)
         if (RSTART > 0) {
-            path = substr($0, RSTART + 2)
+            path = substr($0, RSTART + 3)
         } else {
             path = "unknown"
         }
@@ -76,106 +81,12 @@ parse_diff_segments() {
             gsub(/\n/, "\\n", buf)
             gsub(/\t/, "\\t", buf)
             gsub(/\r/, "\\r", buf)
+            gsub(/\\/, "\\\\", path)
+            gsub(/"/, "\\\"", path)
             printf "{\"path\":\"%s\",\"diff\":\"%s\",\"size_bytes\":%d}\n", path, buf, length(buf)
         }
     }
     ' "${diff_file}"
-}
-
-# Determine the implementation file that a test file corresponds to.
-# Returns the likely implementation path, or empty string if not a test file.
-get_impl_for_test() {
-    local file_path="$1"
-    local basename
-    basename=$(basename "${file_path}")
-    local dirname
-    dirname=$(dirname "${file_path}")
-
-    # Python: test_foo.py -> foo.py
-    if [[ "${basename}" =~ ^test_ ]]; then
-        echo "${dirname}/${basename#test_}"
-        return
-    fi
-
-    # Go: foo_test.go -> foo.go
-    if [[ "${basename}" =~ _test\.go$ ]]; then
-        echo "${dirname}/${basename%_test.go}.go"
-        return
-    fi
-
-    # Generic: foo_test.ext -> foo.ext
-    if [[ "${basename}" =~ _test\. ]]; then
-        echo "${dirname}/${basename/_test./\.}"
-        return
-    fi
-
-    # JS/TS: foo.test.ext or foo.spec.ext -> foo.ext
-    if [[ "${basename}" =~ \.test\. ]]; then
-        local name="${basename%.test.*}"
-        local ext="${basename##*.}"
-        echo "${dirname}/${name}.${ext}"
-        return
-    fi
-    if [[ "${basename}" =~ \.spec\. ]]; then
-        local name="${basename%.spec.*}"
-        local ext="${basename##*.}"
-        echo "${dirname}/${name}.${ext}"
-        return
-    fi
-
-    # __tests__/foo.ext -> ../foo.ext
-    if [[ "${dirname}" =~ /__tests__$ ]]; then
-        local parent
-        parent=$(dirname "${dirname}")
-        echo "${parent}/${basename}"
-        return
-    fi
-
-    echo ""
-}
-
-# Check whether a file path looks like a test file.
-is_test_file() {
-    local file_path="$1"
-    local basename
-    basename=$(basename "${file_path}")
-    local dirname
-    dirname=$(dirname "${file_path}")
-
-    [[ "${basename}" =~ ^test_ ]] \
-        || [[ "${basename}" =~ _test\. ]] \
-        || [[ "${basename}" =~ \.test\. ]] \
-        || [[ "${basename}" =~ \.spec\. ]] \
-        || [[ "${basename}" =~ _spec\. ]] \
-        || [[ "${dirname}" =~ /__tests__$ ]] \
-        || [[ "${dirname}" =~ /tests?$ ]] \
-        || [[ "${dirname}" =~ /specs?$ ]]
-}
-
-# Generate a human-readable label for a chunk by finding the most common
-# directory prefix among the chunk's files.
-generate_chunk_label() {
-    local files_json="$1"
-    local file_count
-    file_count=$(echo "${files_json}" | jq -r 'length')
-
-    if [[ "${file_count}" -eq 0 ]]; then
-        echo "empty"
-        return
-    fi
-
-    if [[ "${file_count}" -eq 1 ]]; then
-        echo "${files_json}" | jq -r '.[0]'
-        return
-    fi
-
-    # Find the most common top-level directory
-    local top_dir
-    top_dir=$(echo "${files_json}" | jq -r '.[]' | while IFS= read -r f; do
-        dirname "${f}" | cut -d'/' -f1
-    done | sort | uniq -c | sort -rn | head -1 | awk '{print $2}')
-
-    echo "${top_dir} (${file_count} files)"
 }
 
 main() {
@@ -195,22 +106,24 @@ main() {
     local diff_file="${_CHUNK_DIFF_TMPFILE}"
     trap 'rm -f "${_CHUNK_DIFF_TMPFILE}"' EXIT
 
-    echo "${input}" | jq -r '.diff // ""' > "${diff_file}"
+    # Use jq -j (no trailing newline) so an empty diff produces a truly empty file
+    echo "${input}" | jq -j '.diff // ""' > "${diff_file}"
 
-    # Check for empty diff (the file will have at least a trailing newline from echo)
-    local diff_content_check
-    diff_content_check=$(jq -r '.diff // ""' <<< "${input}")
-    if [[ -z "${diff_content_check}" ]]; then
+    # Check for empty diff using the file that was already written
+    if [[ ! -s "${diff_file}" ]]; then
         jq -n '{"chunked": false, "reason": "empty diff"}'
         return
     fi
 
-    # Extract config with defaults
-    local max_chunk_size_kb max_files_per_chunk min_threshold_kb min_threshold_files
-    max_chunk_size_kb=$(echo "${input}" | jq -r ".config.max_chunk_size_kb // ${DEFAULT_MAX_CHUNK_SIZE_KB}")
-    max_files_per_chunk=$(echo "${input}" | jq -r ".config.max_files_per_chunk // ${DEFAULT_MAX_FILES_PER_CHUNK}")
-    min_threshold_kb=$(echo "${input}" | jq -r ".config.min_chunk_threshold_kb // ${DEFAULT_MIN_CHUNK_THRESHOLD_KB}")
-    min_threshold_files=$(echo "${input}" | jq -r ".config.min_chunk_threshold_files // ${DEFAULT_MIN_CHUNK_THRESHOLD_FILES}")
+    # Extract config with defaults (single jq call instead of four)
+    local config_values max_chunk_size_kb max_files_per_chunk min_threshold_kb min_threshold_files
+    config_values=$(jq -r "[
+        .config.max_chunk_size_kb // ${DEFAULT_MAX_CHUNK_SIZE_KB},
+        .config.max_files_per_chunk // ${DEFAULT_MAX_FILES_PER_CHUNK},
+        .config.min_chunk_threshold_kb // ${DEFAULT_MIN_CHUNK_THRESHOLD_KB},
+        .config.min_chunk_threshold_files // ${DEFAULT_MIN_CHUNK_THRESHOLD_FILES}
+    ] | @tsv" <<< "${input}")
+    read -r max_chunk_size_kb max_files_per_chunk min_threshold_kb min_threshold_files <<< "${config_values}"
 
     local max_chunk_size_bytes=$((max_chunk_size_kb * 1024))
 
@@ -244,43 +157,77 @@ main() {
 
     # Step 1: Pair test files with their implementation files.
     # Build a mapping of impl_path -> [test_paths] and track which files are paired.
+    # When file_metadata is available (passed from the orchestrator via pre-review-context.sh),
+    # use its is_test and likely_test_path fields instead of reimplementing test detection.
+    local file_metadata_json
+    file_metadata_json=$(jq -c '.file_metadata // null' <<< "${input}")
+
     local paired_groups
-    paired_groups=$(echo "${segments_json}" | jq -r '
+    paired_groups=$(echo "${segments_json}" | jq -r --argjson meta "${file_metadata_json}" '
         # Build a list of all file paths
         [.[].path] as $all_paths |
+
+        # Build a lookup from path to metadata (when available).
+        # file_metadata is an object with a modified_files array of
+        # {path, type, language, is_test, likely_test_path} entries.
+        (if $meta != null and ($meta | has("modified_files")) then
+            reduce $meta.modified_files[] as $m ({}; . + {($m.path): $m})
+        else {} end) as $meta_lookup |
 
         # For each file, check if it is a test file
         reduce .[] as $seg (
             {"pairs": {}, "paired_set": {}};
 
-            # Check test file patterns
             ($seg.path | split("/") | last) as $basename |
             ($seg.path | split("/")[:-1] | join("/")) as $dirpart |
-            (
+
+            # Use metadata when available, fall back to pattern matching
+            (if $meta_lookup[$seg.path].is_test == true then
+                # Metadata says this is a test file. The likely_test_path field on
+                # source files points test->impl, but for test files we need to
+                # derive the impl path. Use the same pattern-matching logic as
+                # the fallback, since metadata marks test files but does not
+                # provide the reverse mapping.
                 if ($basename | test("^test_")) then
-                    # Python-style: test_foo.py -> foo.py
                     ($dirpart + "/" + ($basename | sub("^test_"; "")))
                 elif ($basename | test("_test\\.go$")) then
-                    # Go-style: foo_test.go -> foo.go
                     ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
                 elif ($basename | test("_test\\.")) then
-                    # Generic: foo_test.ext -> foo.ext
                     ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
                 elif ($basename | test("\\.test\\.")) then
-                    # JS/TS: foo.test.ext -> foo.ext
                     ($basename | split(".test.")) as $parts |
                     ($dirpart + "/" + $parts[0] + "." + $parts[1])
                 elif ($basename | test("\\.spec\\.")) then
-                    # JS/TS: foo.spec.ext -> foo.ext
                     ($basename | split(".spec.")) as $parts |
                     ($dirpart + "/" + $parts[0] + "." + $parts[1])
                 elif ($dirpart | test("/__tests__$")) then
-                    # __tests__/foo.ext -> ../foo.ext
                     (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
                 else
                     null
                 end
-            ) as $impl_path |
+            elif $meta_lookup | has($seg.path) then
+                # Metadata exists but is_test is false, so not a test file
+                null
+            else
+                # No metadata available, fall back to pattern matching
+                if ($basename | test("^test_")) then
+                    ($dirpart + "/" + ($basename | sub("^test_"; "")))
+                elif ($basename | test("_test\\.go$")) then
+                    ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
+                elif ($basename | test("_test\\.")) then
+                    ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
+                elif ($basename | test("\\.test\\.")) then
+                    ($basename | split(".test.")) as $parts |
+                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
+                elif ($basename | test("\\.spec\\.")) then
+                    ($basename | split(".spec.")) as $parts |
+                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
+                elif ($dirpart | test("/__tests__$")) then
+                    (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
+                else
+                    null
+                end
+            end) as $impl_path |
 
             if $impl_path != null and ($all_paths | index($impl_path) != null) then
                 .pairs[$impl_path] = ((.pairs[$impl_path] // []) + [$seg.path]) |

--- a/skills/review-code/scripts/chunk-diff.sh
+++ b/skills/review-code/scripts/chunk-diff.sh
@@ -164,6 +164,33 @@ main() {
 
     local paired_groups
     paired_groups=$(echo "${segments_json}" | jq -r --argjson meta "${file_metadata_json}" '
+        # Derive the implementation file path from a test file name.
+        # Returns null if the file does not match any known test pattern.
+        def impl_path_for_test($basename; $dirpart):
+            if ($basename | test("^test_")) then
+                ($dirpart + "/" + ($basename | sub("^test_"; "")))
+            elif ($basename | test("_test\\.go$")) then
+                ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
+            elif ($basename | test("_test\\.")) then
+                ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
+            elif ($basename | test("_spec\\.")) then
+                ($dirpart + "/" + ($basename | sub("_spec\\."; ".")))
+            elif ($basename | test("\\.test\\.")) then
+                ($basename | split(".test.")) as $parts |
+                ($dirpart + "/" + $parts[0] + "." + $parts[1])
+            elif ($basename | test("\\.spec\\.")) then
+                ($basename | split(".spec.")) as $parts |
+                ($dirpart + "/" + $parts[0] + "." + $parts[1])
+            elif ($dirpart | test("/__tests__$")) then
+                (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
+            elif ($dirpart | test("/tests?$")) then
+                (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
+            elif ($dirpart | test("/specs?$")) then
+                (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
+            else
+                null
+            end;
+
         # Build a list of all file paths
         [.[].path] as $all_paths |
 
@@ -181,52 +208,12 @@ main() {
             ($seg.path | split("/") | last) as $basename |
             ($seg.path | split("/")[:-1] | join("/")) as $dirpart |
 
-            # Use metadata when available, fall back to pattern matching
-            (if $meta_lookup[$seg.path].is_test == true then
-                # Metadata says this is a test file. The likely_test_path field on
-                # source files points test->impl, but for test files we need to
-                # derive the impl path. Use the same pattern-matching logic as
-                # the fallback, since metadata marks test files but does not
-                # provide the reverse mapping.
-                if ($basename | test("^test_")) then
-                    ($dirpart + "/" + ($basename | sub("^test_"; "")))
-                elif ($basename | test("_test\\.go$")) then
-                    ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
-                elif ($basename | test("_test\\.")) then
-                    ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
-                elif ($basename | test("\\.test\\.")) then
-                    ($basename | split(".test.")) as $parts |
-                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
-                elif ($basename | test("\\.spec\\.")) then
-                    ($basename | split(".spec.")) as $parts |
-                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
-                elif ($dirpart | test("/__tests__$")) then
-                    (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
-                else
-                    null
-                end
-            elif $meta_lookup | has($seg.path) then
-                # Metadata exists but is_test is false, so not a test file
+            # Use metadata to skip pattern matching for known non-test files.
+            # Otherwise, derive the impl path from the test file name.
+            (if ($meta_lookup | has($seg.path)) and $meta_lookup[$seg.path].is_test != true then
                 null
             else
-                # No metadata available, fall back to pattern matching
-                if ($basename | test("^test_")) then
-                    ($dirpart + "/" + ($basename | sub("^test_"; "")))
-                elif ($basename | test("_test\\.go$")) then
-                    ($dirpart + "/" + ($basename | sub("_test\\.go$"; ".go")))
-                elif ($basename | test("_test\\.")) then
-                    ($dirpart + "/" + ($basename | sub("_test\\."; ".")))
-                elif ($basename | test("\\.test\\.")) then
-                    ($basename | split(".test.")) as $parts |
-                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
-                elif ($basename | test("\\.spec\\.")) then
-                    ($basename | split(".spec.")) as $parts |
-                    ($dirpart + "/" + $parts[0] + "." + $parts[1])
-                elif ($dirpart | test("/__tests__$")) then
-                    (($dirpart | split("/")[:-1] | join("/")) + "/" + $basename)
-                else
-                    null
-                end
+                impl_path_for_test($basename; $dirpart)
             end) as $impl_path |
 
             if $impl_path != null and ($all_paths | index($impl_path) != null) then

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -289,6 +289,33 @@ build_review_data() {
     review_context=$(echo "${review_context_json}" | jq -r '.content')
     loaded_context_files=$(echo "${review_context_json}" | jq -r '.loaded_files')
 
+    # Run diff chunking to determine if the diff should be split
+    debug_time "05-chunking" "start"
+    local chunk_result=""
+    local chunk_max_size_kb="${REVIEW_CODE_CHUNK_MAX_SIZE_KB:-200}"
+    local chunk_max_files="${REVIEW_CODE_CHUNK_MAX_FILES:-30}"
+    local chunk_threshold_kb="${REVIEW_CODE_CHUNK_THRESHOLD_KB:-200}"
+    local chunk_threshold_files="${REVIEW_CODE_CHUNK_THRESHOLD_FILES:-50}"
+
+    chunk_result=$(jq -n \
+        --arg diff "${diff_content}" \
+        --argjson max_size "${chunk_max_size_kb}" \
+        --argjson max_files "${chunk_max_files}" \
+        --argjson threshold_kb "${chunk_threshold_kb}" \
+        --argjson threshold_files "${chunk_threshold_files}" \
+        '{
+            diff: $diff,
+            config: {
+                max_chunk_size_kb: $max_size,
+                max_files_per_chunk: $max_files,
+                min_chunk_threshold_kb: $threshold_kb,
+                min_chunk_threshold_files: $threshold_files
+            }
+        }' | "${SCRIPT_DIR}/chunk-diff.sh" 2> /dev/null || echo "")
+
+    debug_save_json "05-chunking" "output.json" <<< "${chunk_result}"
+    debug_time "05-chunking" "end"
+
     # Build summary for user confirmation
     # Extract mode-specific fields to avoid passing large args to jq
     local mode_fields
@@ -329,6 +356,14 @@ build_review_data() {
         fi
     fi
 
+    # Build chunk JSON for inclusion in output (null if not chunked or chunking failed)
+    local chunk_json="null"
+    local chunk_meta_json="null"
+    if [[ -n "${chunk_result}" ]] && echo "${chunk_result}" | jq -e '.chunked == true' > /dev/null 2>&1; then
+        chunk_json=$(echo "${chunk_result}" | jq '.chunks')
+        chunk_meta_json=$(echo "${chunk_result}" | jq '{chunked: .chunked, reason: .reason, chunk_count: .chunk_count}')
+    fi
+
     local -a jq_args=(
         -n
         --arg mode "${mode}"
@@ -343,6 +378,8 @@ build_review_data() {
         --argjson pr "${pr_json}"
         --arg reviewer_username "${reviewer_username}"
         --arg is_own_pr "${is_own_pr}"
+        --argjson chunks "${chunk_json}"
+        --argjson chunk_metadata "${chunk_meta_json}"
     )
 
     # Add mode-specific arguments
@@ -353,7 +390,7 @@ build_review_data() {
     jq_args+=(--arg draft_mode "${draft_mode}")
     jq_args+=(--arg self_mode "${self_mode}")
 
-    # Single jq invocation with conditional pr field
+    # Single jq invocation with conditional pr field and chunk data
     final_output=$(jq "${jq_args[@]}" \
         '{
             status: "ready",
@@ -372,6 +409,7 @@ build_review_data() {
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
+        + (if $chunks != null then {chunks: $chunks, chunk_metadata: $chunk_metadata} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -373,11 +373,17 @@ build_review_data() {
         fi
     fi
 
-    # Build chunk JSON for inclusion in output (null if not chunked or chunking failed)
-    local chunk_json="null"
+    # Build chunk JSON for inclusion in output (null if not chunked or chunking failed).
+    # Write chunks to a temp file and use --slurpfile to avoid ARG_MAX limits,
+    # since chunk data can be as large as the original diff (400KB+).
     local chunk_meta_json="null"
+    local chunk_json_tmpfile
+    _ORCH_CHUNK_JSON_TMPFILE=$(mktemp)
+    chunk_json_tmpfile="${_ORCH_CHUNK_JSON_TMPFILE}"
+    trap 'rm -f "${_ORCH_DIFF_TMPFILE}" "${_ORCH_CHUNK_JSON_TMPFILE}"' EXIT
+    echo "null" > "${chunk_json_tmpfile}"
     if [[ -n "${chunk_result}" ]] && echo "${chunk_result}" | jq -e '.chunked == true' > /dev/null 2>&1; then
-        chunk_json=$(echo "${chunk_result}" | jq '.chunks')
+        echo "${chunk_result}" | jq '.chunks' > "${chunk_json_tmpfile}"
         chunk_meta_json=$(echo "${chunk_result}" | jq '{chunked: .chunked, reason: .reason, chunk_count: .chunk_count}')
     fi
 
@@ -395,7 +401,7 @@ build_review_data() {
         --argjson pr "${pr_json}"
         --arg reviewer_username "${reviewer_username}"
         --arg is_own_pr "${is_own_pr}"
-        --argjson chunks "${chunk_json}"
+        --slurpfile chunks "${chunk_json_tmpfile}"
         --argjson chunk_metadata "${chunk_meta_json}"
     )
 
@@ -426,7 +432,7 @@ build_review_data() {
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr != null then {pr: $pr, reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
-        + (if $chunks != null then {chunks: $chunks, chunk_metadata: $chunk_metadata} else {} end)
+        + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -303,7 +303,9 @@ build_review_data() {
 
     # Write diff to a temp file to avoid ARG_MAX limits with --arg on large diffs
     local chunk_diff_tmpfile
-    chunk_diff_tmpfile=$(mktemp)
+    _ORCH_DIFF_TMPFILE=$(mktemp)
+    chunk_diff_tmpfile="${_ORCH_DIFF_TMPFILE}"
+    trap 'rm -f "${_ORCH_DIFF_TMPFILE}"' EXIT
     printf '%s' "${diff_content}" > "${chunk_diff_tmpfile}"
 
     chunk_result=$(jq -n \
@@ -323,8 +325,6 @@ build_review_data() {
                 min_chunk_threshold_files: $threshold_files
             }
         }' | "${SCRIPT_DIR}/chunk-diff.sh" 2> /dev/null || echo "")
-
-    rm -f "${chunk_diff_tmpfile}"
 
     if [[ -z "${chunk_result}" ]]; then
         debug_trace "05-chunking" "chunk-diff.sh failed or returned empty; falling back to un-chunked review"
@@ -385,7 +385,7 @@ build_review_data() {
         -n
         --arg mode "${mode}"
         --argjson git "${git_context}"
-        --arg diff "${diff_content}"
+        --rawfile diff "${chunk_diff_tmpfile}"
         --argjson lang "${lang_info}"
         --argjson meta "${file_metadata}"
         --argjson file "${file_info}"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -293,18 +293,29 @@ build_review_data() {
     debug_time "05-chunking" "start"
     local chunk_result=""
     local chunk_max_size_kb="${REVIEW_CODE_CHUNK_MAX_SIZE_KB:-200}"
+    [[ "${chunk_max_size_kb}" =~ ^[0-9]+$ ]] || chunk_max_size_kb=200
     local chunk_max_files="${REVIEW_CODE_CHUNK_MAX_FILES:-30}"
-    local chunk_threshold_kb="${REVIEW_CODE_CHUNK_THRESHOLD_KB:-200}"
+    [[ "${chunk_max_files}" =~ ^[0-9]+$ ]] || chunk_max_files=30
+    local chunk_threshold_kb="${REVIEW_CODE_CHUNK_THRESHOLD_KB:-400}"
+    [[ "${chunk_threshold_kb}" =~ ^[0-9]+$ ]] || chunk_threshold_kb=400
     local chunk_threshold_files="${REVIEW_CODE_CHUNK_THRESHOLD_FILES:-50}"
+    [[ "${chunk_threshold_files}" =~ ^[0-9]+$ ]] || chunk_threshold_files=50
+
+    # Write diff to a temp file to avoid ARG_MAX limits with --arg on large diffs
+    local chunk_diff_tmpfile
+    chunk_diff_tmpfile=$(mktemp)
+    printf '%s' "${diff_content}" > "${chunk_diff_tmpfile}"
 
     chunk_result=$(jq -n \
-        --arg diff "${diff_content}" \
+        --rawfile diff "${chunk_diff_tmpfile}" \
+        --argjson file_metadata "${file_metadata}" \
         --argjson max_size "${chunk_max_size_kb}" \
         --argjson max_files "${chunk_max_files}" \
         --argjson threshold_kb "${chunk_threshold_kb}" \
         --argjson threshold_files "${chunk_threshold_files}" \
         '{
             diff: $diff,
+            file_metadata: $file_metadata,
             config: {
                 max_chunk_size_kb: $max_size,
                 max_files_per_chunk: $max_files,
@@ -312,6 +323,12 @@ build_review_data() {
                 min_chunk_threshold_files: $threshold_files
             }
         }' | "${SCRIPT_DIR}/chunk-diff.sh" 2> /dev/null || echo "")
+
+    rm -f "${chunk_diff_tmpfile}"
+
+    if [[ -z "${chunk_result}" ]]; then
+        debug_trace "05-chunking" "chunk-diff.sh failed or returned empty; falling back to un-chunked review"
+    fi
 
     debug_save_json "05-chunking" "output.json" <<< "${chunk_result}"
     debug_time "05-chunking" "end"

--- a/tests/fixtures/diffs/multi-directory.diff
+++ b/tests/fixtures/diffs/multi-directory.diff
@@ -1323,3 +1323,153 @@ index abc123..def456 100644
 +    test line 17
 +    test line 18
 +    test line 19
+diff --git a/backend/services/parser.rb b/backend/services/parser.rb
+index abc123..def456 100644
+--- a/backend/services/parser.rb
++++ b/backend/services/parser.rb
+@@ -1,5 +1,25 @@
++    line 0 of backend/services/parser.rb
++    line 1 of backend/services/parser.rb
++    line 2 of backend/services/parser.rb
++    line 3 of backend/services/parser.rb
++    line 4 of backend/services/parser.rb
++    line 5 of backend/services/parser.rb
++    line 6 of backend/services/parser.rb
++    line 7 of backend/services/parser.rb
++    line 8 of backend/services/parser.rb
++    line 9 of backend/services/parser.rb
++    line 10 of backend/services/parser.rb
++    line 11 of backend/services/parser.rb
++    line 12 of backend/services/parser.rb
++    line 13 of backend/services/parser.rb
++    line 14 of backend/services/parser.rb
++    line 15 of backend/services/parser.rb
++    line 16 of backend/services/parser.rb
++    line 17 of backend/services/parser.rb
++    line 18 of backend/services/parser.rb
++    line 19 of backend/services/parser.rb
+diff --git a/backend/services/parser_spec.rb b/backend/services/parser_spec.rb
+index abc123..def456 100644
+--- a/backend/services/parser_spec.rb
++++ b/backend/services/parser_spec.rb
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/frontend/components/app.component.ts b/frontend/components/app.component.ts
+index abc123..def456 100644
+--- a/frontend/components/app.component.ts
++++ b/frontend/components/app.component.ts
+@@ -1,5 +1,25 @@
++    line 0 of frontend/components/app.component.ts
++    line 1 of frontend/components/app.component.ts
++    line 2 of frontend/components/app.component.ts
++    line 3 of frontend/components/app.component.ts
++    line 4 of frontend/components/app.component.ts
++    line 5 of frontend/components/app.component.ts
++    line 6 of frontend/components/app.component.ts
++    line 7 of frontend/components/app.component.ts
++    line 8 of frontend/components/app.component.ts
++    line 9 of frontend/components/app.component.ts
++    line 10 of frontend/components/app.component.ts
++    line 11 of frontend/components/app.component.ts
++    line 12 of frontend/components/app.component.ts
++    line 13 of frontend/components/app.component.ts
++    line 14 of frontend/components/app.component.ts
++    line 15 of frontend/components/app.component.ts
++    line 16 of frontend/components/app.component.ts
++    line 17 of frontend/components/app.component.ts
++    line 18 of frontend/components/app.component.ts
++    line 19 of frontend/components/app.component.ts
+diff --git a/frontend/components/app.component.spec.ts b/frontend/components/app.component.spec.ts
+index abc123..def456 100644
+--- a/frontend/components/app.component.spec.ts
++++ b/frontend/components/app.component.spec.ts
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/backend/models/utils_test.py b/backend/models/utils_test.py
+index abc123..def456 100644
+--- a/backend/models/utils_test.py
++++ b/backend/models/utils_test.py
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/backend/models/utils.py b/backend/models/utils.py
+index abc123..def456 100644
+--- a/backend/models/utils.py
++++ b/backend/models/utils.py
+@@ -1,5 +1,25 @@
++    line 0 of backend/models/utils.py
++    line 1 of backend/models/utils.py
++    line 2 of backend/models/utils.py
++    line 3 of backend/models/utils.py
++    line 4 of backend/models/utils.py
++    line 5 of backend/models/utils.py
++    line 6 of backend/models/utils.py
++    line 7 of backend/models/utils.py
++    line 8 of backend/models/utils.py
++    line 9 of backend/models/utils.py
++    line 10 of backend/models/utils.py
++    line 11 of backend/models/utils.py
++    line 12 of backend/models/utils.py
++    line 13 of backend/models/utils.py
++    line 14 of backend/models/utils.py
++    line 15 of backend/models/utils.py
++    line 16 of backend/models/utils.py
++    line 17 of backend/models/utils.py
++    line 18 of backend/models/utils.py
++    line 19 of backend/models/utils.py

--- a/tests/fixtures/diffs/multi-directory.diff
+++ b/tests/fixtures/diffs/multi-directory.diff
@@ -1,0 +1,1175 @@
+diff --git a/backend/api/file0.py b/backend/api/file0.py
+index abc123..def456 100644
+--- a/backend/api/file0.py
++++ b/backend/api/file0.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/api/file0.py
++    line 1 of backend/api/file0.py
++    line 2 of backend/api/file0.py
++    line 3 of backend/api/file0.py
++    line 4 of backend/api/file0.py
++    line 5 of backend/api/file0.py
++    line 6 of backend/api/file0.py
++    line 7 of backend/api/file0.py
++    line 8 of backend/api/file0.py
++    line 9 of backend/api/file0.py
++    line 10 of backend/api/file0.py
++    line 11 of backend/api/file0.py
++    line 12 of backend/api/file0.py
++    line 13 of backend/api/file0.py
++    line 14 of backend/api/file0.py
++    line 15 of backend/api/file0.py
++    line 16 of backend/api/file0.py
++    line 17 of backend/api/file0.py
++    line 18 of backend/api/file0.py
++    line 19 of backend/api/file0.py
++    line 20 of backend/api/file0.py
++    line 21 of backend/api/file0.py
++    line 22 of backend/api/file0.py
++    line 23 of backend/api/file0.py
++    line 24 of backend/api/file0.py
++    line 25 of backend/api/file0.py
++    line 26 of backend/api/file0.py
++    line 27 of backend/api/file0.py
++    line 28 of backend/api/file0.py
++    line 29 of backend/api/file0.py
++    line 30 of backend/api/file0.py
++    line 31 of backend/api/file0.py
++    line 32 of backend/api/file0.py
++    line 33 of backend/api/file0.py
++    line 34 of backend/api/file0.py
++    line 35 of backend/api/file0.py
++    line 36 of backend/api/file0.py
++    line 37 of backend/api/file0.py
++    line 38 of backend/api/file0.py
++    line 39 of backend/api/file0.py
++    line 40 of backend/api/file0.py
++    line 41 of backend/api/file0.py
++    line 42 of backend/api/file0.py
++    line 43 of backend/api/file0.py
++    line 44 of backend/api/file0.py
++    line 45 of backend/api/file0.py
++    line 46 of backend/api/file0.py
++    line 47 of backend/api/file0.py
++    line 48 of backend/api/file0.py
++    line 49 of backend/api/file0.py
+diff --git a/backend/api/file1.py b/backend/api/file1.py
+index abc123..def456 100644
+--- a/backend/api/file1.py
++++ b/backend/api/file1.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/api/file1.py
++    line 1 of backend/api/file1.py
++    line 2 of backend/api/file1.py
++    line 3 of backend/api/file1.py
++    line 4 of backend/api/file1.py
++    line 5 of backend/api/file1.py
++    line 6 of backend/api/file1.py
++    line 7 of backend/api/file1.py
++    line 8 of backend/api/file1.py
++    line 9 of backend/api/file1.py
++    line 10 of backend/api/file1.py
++    line 11 of backend/api/file1.py
++    line 12 of backend/api/file1.py
++    line 13 of backend/api/file1.py
++    line 14 of backend/api/file1.py
++    line 15 of backend/api/file1.py
++    line 16 of backend/api/file1.py
++    line 17 of backend/api/file1.py
++    line 18 of backend/api/file1.py
++    line 19 of backend/api/file1.py
++    line 20 of backend/api/file1.py
++    line 21 of backend/api/file1.py
++    line 22 of backend/api/file1.py
++    line 23 of backend/api/file1.py
++    line 24 of backend/api/file1.py
++    line 25 of backend/api/file1.py
++    line 26 of backend/api/file1.py
++    line 27 of backend/api/file1.py
++    line 28 of backend/api/file1.py
++    line 29 of backend/api/file1.py
++    line 30 of backend/api/file1.py
++    line 31 of backend/api/file1.py
++    line 32 of backend/api/file1.py
++    line 33 of backend/api/file1.py
++    line 34 of backend/api/file1.py
++    line 35 of backend/api/file1.py
++    line 36 of backend/api/file1.py
++    line 37 of backend/api/file1.py
++    line 38 of backend/api/file1.py
++    line 39 of backend/api/file1.py
++    line 40 of backend/api/file1.py
++    line 41 of backend/api/file1.py
++    line 42 of backend/api/file1.py
++    line 43 of backend/api/file1.py
++    line 44 of backend/api/file1.py
++    line 45 of backend/api/file1.py
++    line 46 of backend/api/file1.py
++    line 47 of backend/api/file1.py
++    line 48 of backend/api/file1.py
++    line 49 of backend/api/file1.py
+diff --git a/backend/api/file2.py b/backend/api/file2.py
+index abc123..def456 100644
+--- a/backend/api/file2.py
++++ b/backend/api/file2.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/api/file2.py
++    line 1 of backend/api/file2.py
++    line 2 of backend/api/file2.py
++    line 3 of backend/api/file2.py
++    line 4 of backend/api/file2.py
++    line 5 of backend/api/file2.py
++    line 6 of backend/api/file2.py
++    line 7 of backend/api/file2.py
++    line 8 of backend/api/file2.py
++    line 9 of backend/api/file2.py
++    line 10 of backend/api/file2.py
++    line 11 of backend/api/file2.py
++    line 12 of backend/api/file2.py
++    line 13 of backend/api/file2.py
++    line 14 of backend/api/file2.py
++    line 15 of backend/api/file2.py
++    line 16 of backend/api/file2.py
++    line 17 of backend/api/file2.py
++    line 18 of backend/api/file2.py
++    line 19 of backend/api/file2.py
++    line 20 of backend/api/file2.py
++    line 21 of backend/api/file2.py
++    line 22 of backend/api/file2.py
++    line 23 of backend/api/file2.py
++    line 24 of backend/api/file2.py
++    line 25 of backend/api/file2.py
++    line 26 of backend/api/file2.py
++    line 27 of backend/api/file2.py
++    line 28 of backend/api/file2.py
++    line 29 of backend/api/file2.py
++    line 30 of backend/api/file2.py
++    line 31 of backend/api/file2.py
++    line 32 of backend/api/file2.py
++    line 33 of backend/api/file2.py
++    line 34 of backend/api/file2.py
++    line 35 of backend/api/file2.py
++    line 36 of backend/api/file2.py
++    line 37 of backend/api/file2.py
++    line 38 of backend/api/file2.py
++    line 39 of backend/api/file2.py
++    line 40 of backend/api/file2.py
++    line 41 of backend/api/file2.py
++    line 42 of backend/api/file2.py
++    line 43 of backend/api/file2.py
++    line 44 of backend/api/file2.py
++    line 45 of backend/api/file2.py
++    line 46 of backend/api/file2.py
++    line 47 of backend/api/file2.py
++    line 48 of backend/api/file2.py
++    line 49 of backend/api/file2.py
+diff --git a/backend/api/file3.py b/backend/api/file3.py
+index abc123..def456 100644
+--- a/backend/api/file3.py
++++ b/backend/api/file3.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/api/file3.py
++    line 1 of backend/api/file3.py
++    line 2 of backend/api/file3.py
++    line 3 of backend/api/file3.py
++    line 4 of backend/api/file3.py
++    line 5 of backend/api/file3.py
++    line 6 of backend/api/file3.py
++    line 7 of backend/api/file3.py
++    line 8 of backend/api/file3.py
++    line 9 of backend/api/file3.py
++    line 10 of backend/api/file3.py
++    line 11 of backend/api/file3.py
++    line 12 of backend/api/file3.py
++    line 13 of backend/api/file3.py
++    line 14 of backend/api/file3.py
++    line 15 of backend/api/file3.py
++    line 16 of backend/api/file3.py
++    line 17 of backend/api/file3.py
++    line 18 of backend/api/file3.py
++    line 19 of backend/api/file3.py
++    line 20 of backend/api/file3.py
++    line 21 of backend/api/file3.py
++    line 22 of backend/api/file3.py
++    line 23 of backend/api/file3.py
++    line 24 of backend/api/file3.py
++    line 25 of backend/api/file3.py
++    line 26 of backend/api/file3.py
++    line 27 of backend/api/file3.py
++    line 28 of backend/api/file3.py
++    line 29 of backend/api/file3.py
++    line 30 of backend/api/file3.py
++    line 31 of backend/api/file3.py
++    line 32 of backend/api/file3.py
++    line 33 of backend/api/file3.py
++    line 34 of backend/api/file3.py
++    line 35 of backend/api/file3.py
++    line 36 of backend/api/file3.py
++    line 37 of backend/api/file3.py
++    line 38 of backend/api/file3.py
++    line 39 of backend/api/file3.py
++    line 40 of backend/api/file3.py
++    line 41 of backend/api/file3.py
++    line 42 of backend/api/file3.py
++    line 43 of backend/api/file3.py
++    line 44 of backend/api/file3.py
++    line 45 of backend/api/file3.py
++    line 46 of backend/api/file3.py
++    line 47 of backend/api/file3.py
++    line 48 of backend/api/file3.py
++    line 49 of backend/api/file3.py
+diff --git a/backend/api/file4.py b/backend/api/file4.py
+index abc123..def456 100644
+--- a/backend/api/file4.py
++++ b/backend/api/file4.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/api/file4.py
++    line 1 of backend/api/file4.py
++    line 2 of backend/api/file4.py
++    line 3 of backend/api/file4.py
++    line 4 of backend/api/file4.py
++    line 5 of backend/api/file4.py
++    line 6 of backend/api/file4.py
++    line 7 of backend/api/file4.py
++    line 8 of backend/api/file4.py
++    line 9 of backend/api/file4.py
++    line 10 of backend/api/file4.py
++    line 11 of backend/api/file4.py
++    line 12 of backend/api/file4.py
++    line 13 of backend/api/file4.py
++    line 14 of backend/api/file4.py
++    line 15 of backend/api/file4.py
++    line 16 of backend/api/file4.py
++    line 17 of backend/api/file4.py
++    line 18 of backend/api/file4.py
++    line 19 of backend/api/file4.py
++    line 20 of backend/api/file4.py
++    line 21 of backend/api/file4.py
++    line 22 of backend/api/file4.py
++    line 23 of backend/api/file4.py
++    line 24 of backend/api/file4.py
++    line 25 of backend/api/file4.py
++    line 26 of backend/api/file4.py
++    line 27 of backend/api/file4.py
++    line 28 of backend/api/file4.py
++    line 29 of backend/api/file4.py
++    line 30 of backend/api/file4.py
++    line 31 of backend/api/file4.py
++    line 32 of backend/api/file4.py
++    line 33 of backend/api/file4.py
++    line 34 of backend/api/file4.py
++    line 35 of backend/api/file4.py
++    line 36 of backend/api/file4.py
++    line 37 of backend/api/file4.py
++    line 38 of backend/api/file4.py
++    line 39 of backend/api/file4.py
++    line 40 of backend/api/file4.py
++    line 41 of backend/api/file4.py
++    line 42 of backend/api/file4.py
++    line 43 of backend/api/file4.py
++    line 44 of backend/api/file4.py
++    line 45 of backend/api/file4.py
++    line 46 of backend/api/file4.py
++    line 47 of backend/api/file4.py
++    line 48 of backend/api/file4.py
++    line 49 of backend/api/file4.py
+diff --git a/backend/models/file0.py b/backend/models/file0.py
+index abc123..def456 100644
+--- a/backend/models/file0.py
++++ b/backend/models/file0.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/models/file0.py
++    line 1 of backend/models/file0.py
++    line 2 of backend/models/file0.py
++    line 3 of backend/models/file0.py
++    line 4 of backend/models/file0.py
++    line 5 of backend/models/file0.py
++    line 6 of backend/models/file0.py
++    line 7 of backend/models/file0.py
++    line 8 of backend/models/file0.py
++    line 9 of backend/models/file0.py
++    line 10 of backend/models/file0.py
++    line 11 of backend/models/file0.py
++    line 12 of backend/models/file0.py
++    line 13 of backend/models/file0.py
++    line 14 of backend/models/file0.py
++    line 15 of backend/models/file0.py
++    line 16 of backend/models/file0.py
++    line 17 of backend/models/file0.py
++    line 18 of backend/models/file0.py
++    line 19 of backend/models/file0.py
++    line 20 of backend/models/file0.py
++    line 21 of backend/models/file0.py
++    line 22 of backend/models/file0.py
++    line 23 of backend/models/file0.py
++    line 24 of backend/models/file0.py
++    line 25 of backend/models/file0.py
++    line 26 of backend/models/file0.py
++    line 27 of backend/models/file0.py
++    line 28 of backend/models/file0.py
++    line 29 of backend/models/file0.py
++    line 30 of backend/models/file0.py
++    line 31 of backend/models/file0.py
++    line 32 of backend/models/file0.py
++    line 33 of backend/models/file0.py
++    line 34 of backend/models/file0.py
++    line 35 of backend/models/file0.py
++    line 36 of backend/models/file0.py
++    line 37 of backend/models/file0.py
++    line 38 of backend/models/file0.py
++    line 39 of backend/models/file0.py
++    line 40 of backend/models/file0.py
++    line 41 of backend/models/file0.py
++    line 42 of backend/models/file0.py
++    line 43 of backend/models/file0.py
++    line 44 of backend/models/file0.py
++    line 45 of backend/models/file0.py
++    line 46 of backend/models/file0.py
++    line 47 of backend/models/file0.py
++    line 48 of backend/models/file0.py
++    line 49 of backend/models/file0.py
+diff --git a/backend/models/file1.py b/backend/models/file1.py
+index abc123..def456 100644
+--- a/backend/models/file1.py
++++ b/backend/models/file1.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/models/file1.py
++    line 1 of backend/models/file1.py
++    line 2 of backend/models/file1.py
++    line 3 of backend/models/file1.py
++    line 4 of backend/models/file1.py
++    line 5 of backend/models/file1.py
++    line 6 of backend/models/file1.py
++    line 7 of backend/models/file1.py
++    line 8 of backend/models/file1.py
++    line 9 of backend/models/file1.py
++    line 10 of backend/models/file1.py
++    line 11 of backend/models/file1.py
++    line 12 of backend/models/file1.py
++    line 13 of backend/models/file1.py
++    line 14 of backend/models/file1.py
++    line 15 of backend/models/file1.py
++    line 16 of backend/models/file1.py
++    line 17 of backend/models/file1.py
++    line 18 of backend/models/file1.py
++    line 19 of backend/models/file1.py
++    line 20 of backend/models/file1.py
++    line 21 of backend/models/file1.py
++    line 22 of backend/models/file1.py
++    line 23 of backend/models/file1.py
++    line 24 of backend/models/file1.py
++    line 25 of backend/models/file1.py
++    line 26 of backend/models/file1.py
++    line 27 of backend/models/file1.py
++    line 28 of backend/models/file1.py
++    line 29 of backend/models/file1.py
++    line 30 of backend/models/file1.py
++    line 31 of backend/models/file1.py
++    line 32 of backend/models/file1.py
++    line 33 of backend/models/file1.py
++    line 34 of backend/models/file1.py
++    line 35 of backend/models/file1.py
++    line 36 of backend/models/file1.py
++    line 37 of backend/models/file1.py
++    line 38 of backend/models/file1.py
++    line 39 of backend/models/file1.py
++    line 40 of backend/models/file1.py
++    line 41 of backend/models/file1.py
++    line 42 of backend/models/file1.py
++    line 43 of backend/models/file1.py
++    line 44 of backend/models/file1.py
++    line 45 of backend/models/file1.py
++    line 46 of backend/models/file1.py
++    line 47 of backend/models/file1.py
++    line 48 of backend/models/file1.py
++    line 49 of backend/models/file1.py
+diff --git a/backend/models/file2.py b/backend/models/file2.py
+index abc123..def456 100644
+--- a/backend/models/file2.py
++++ b/backend/models/file2.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/models/file2.py
++    line 1 of backend/models/file2.py
++    line 2 of backend/models/file2.py
++    line 3 of backend/models/file2.py
++    line 4 of backend/models/file2.py
++    line 5 of backend/models/file2.py
++    line 6 of backend/models/file2.py
++    line 7 of backend/models/file2.py
++    line 8 of backend/models/file2.py
++    line 9 of backend/models/file2.py
++    line 10 of backend/models/file2.py
++    line 11 of backend/models/file2.py
++    line 12 of backend/models/file2.py
++    line 13 of backend/models/file2.py
++    line 14 of backend/models/file2.py
++    line 15 of backend/models/file2.py
++    line 16 of backend/models/file2.py
++    line 17 of backend/models/file2.py
++    line 18 of backend/models/file2.py
++    line 19 of backend/models/file2.py
++    line 20 of backend/models/file2.py
++    line 21 of backend/models/file2.py
++    line 22 of backend/models/file2.py
++    line 23 of backend/models/file2.py
++    line 24 of backend/models/file2.py
++    line 25 of backend/models/file2.py
++    line 26 of backend/models/file2.py
++    line 27 of backend/models/file2.py
++    line 28 of backend/models/file2.py
++    line 29 of backend/models/file2.py
++    line 30 of backend/models/file2.py
++    line 31 of backend/models/file2.py
++    line 32 of backend/models/file2.py
++    line 33 of backend/models/file2.py
++    line 34 of backend/models/file2.py
++    line 35 of backend/models/file2.py
++    line 36 of backend/models/file2.py
++    line 37 of backend/models/file2.py
++    line 38 of backend/models/file2.py
++    line 39 of backend/models/file2.py
++    line 40 of backend/models/file2.py
++    line 41 of backend/models/file2.py
++    line 42 of backend/models/file2.py
++    line 43 of backend/models/file2.py
++    line 44 of backend/models/file2.py
++    line 45 of backend/models/file2.py
++    line 46 of backend/models/file2.py
++    line 47 of backend/models/file2.py
++    line 48 of backend/models/file2.py
++    line 49 of backend/models/file2.py
+diff --git a/backend/models/file3.py b/backend/models/file3.py
+index abc123..def456 100644
+--- a/backend/models/file3.py
++++ b/backend/models/file3.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/models/file3.py
++    line 1 of backend/models/file3.py
++    line 2 of backend/models/file3.py
++    line 3 of backend/models/file3.py
++    line 4 of backend/models/file3.py
++    line 5 of backend/models/file3.py
++    line 6 of backend/models/file3.py
++    line 7 of backend/models/file3.py
++    line 8 of backend/models/file3.py
++    line 9 of backend/models/file3.py
++    line 10 of backend/models/file3.py
++    line 11 of backend/models/file3.py
++    line 12 of backend/models/file3.py
++    line 13 of backend/models/file3.py
++    line 14 of backend/models/file3.py
++    line 15 of backend/models/file3.py
++    line 16 of backend/models/file3.py
++    line 17 of backend/models/file3.py
++    line 18 of backend/models/file3.py
++    line 19 of backend/models/file3.py
++    line 20 of backend/models/file3.py
++    line 21 of backend/models/file3.py
++    line 22 of backend/models/file3.py
++    line 23 of backend/models/file3.py
++    line 24 of backend/models/file3.py
++    line 25 of backend/models/file3.py
++    line 26 of backend/models/file3.py
++    line 27 of backend/models/file3.py
++    line 28 of backend/models/file3.py
++    line 29 of backend/models/file3.py
++    line 30 of backend/models/file3.py
++    line 31 of backend/models/file3.py
++    line 32 of backend/models/file3.py
++    line 33 of backend/models/file3.py
++    line 34 of backend/models/file3.py
++    line 35 of backend/models/file3.py
++    line 36 of backend/models/file3.py
++    line 37 of backend/models/file3.py
++    line 38 of backend/models/file3.py
++    line 39 of backend/models/file3.py
++    line 40 of backend/models/file3.py
++    line 41 of backend/models/file3.py
++    line 42 of backend/models/file3.py
++    line 43 of backend/models/file3.py
++    line 44 of backend/models/file3.py
++    line 45 of backend/models/file3.py
++    line 46 of backend/models/file3.py
++    line 47 of backend/models/file3.py
++    line 48 of backend/models/file3.py
++    line 49 of backend/models/file3.py
+diff --git a/backend/models/file4.py b/backend/models/file4.py
+index abc123..def456 100644
+--- a/backend/models/file4.py
++++ b/backend/models/file4.py
+@@ -1,5 +1,55 @@
++    line 0 of backend/models/file4.py
++    line 1 of backend/models/file4.py
++    line 2 of backend/models/file4.py
++    line 3 of backend/models/file4.py
++    line 4 of backend/models/file4.py
++    line 5 of backend/models/file4.py
++    line 6 of backend/models/file4.py
++    line 7 of backend/models/file4.py
++    line 8 of backend/models/file4.py
++    line 9 of backend/models/file4.py
++    line 10 of backend/models/file4.py
++    line 11 of backend/models/file4.py
++    line 12 of backend/models/file4.py
++    line 13 of backend/models/file4.py
++    line 14 of backend/models/file4.py
++    line 15 of backend/models/file4.py
++    line 16 of backend/models/file4.py
++    line 17 of backend/models/file4.py
++    line 18 of backend/models/file4.py
++    line 19 of backend/models/file4.py
++    line 20 of backend/models/file4.py
++    line 21 of backend/models/file4.py
++    line 22 of backend/models/file4.py
++    line 23 of backend/models/file4.py
++    line 24 of backend/models/file4.py
++    line 25 of backend/models/file4.py
++    line 26 of backend/models/file4.py
++    line 27 of backend/models/file4.py
++    line 28 of backend/models/file4.py
++    line 29 of backend/models/file4.py
++    line 30 of backend/models/file4.py
++    line 31 of backend/models/file4.py
++    line 32 of backend/models/file4.py
++    line 33 of backend/models/file4.py
++    line 34 of backend/models/file4.py
++    line 35 of backend/models/file4.py
++    line 36 of backend/models/file4.py
++    line 37 of backend/models/file4.py
++    line 38 of backend/models/file4.py
++    line 39 of backend/models/file4.py
++    line 40 of backend/models/file4.py
++    line 41 of backend/models/file4.py
++    line 42 of backend/models/file4.py
++    line 43 of backend/models/file4.py
++    line 44 of backend/models/file4.py
++    line 45 of backend/models/file4.py
++    line 46 of backend/models/file4.py
++    line 47 of backend/models/file4.py
++    line 48 of backend/models/file4.py
++    line 49 of backend/models/file4.py
+diff --git a/frontend/components/file0.tsx b/frontend/components/file0.tsx
+index abc123..def456 100644
+--- a/frontend/components/file0.tsx
++++ b/frontend/components/file0.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/components/file0.tsx
++    line 1 of frontend/components/file0.tsx
++    line 2 of frontend/components/file0.tsx
++    line 3 of frontend/components/file0.tsx
++    line 4 of frontend/components/file0.tsx
++    line 5 of frontend/components/file0.tsx
++    line 6 of frontend/components/file0.tsx
++    line 7 of frontend/components/file0.tsx
++    line 8 of frontend/components/file0.tsx
++    line 9 of frontend/components/file0.tsx
++    line 10 of frontend/components/file0.tsx
++    line 11 of frontend/components/file0.tsx
++    line 12 of frontend/components/file0.tsx
++    line 13 of frontend/components/file0.tsx
++    line 14 of frontend/components/file0.tsx
++    line 15 of frontend/components/file0.tsx
++    line 16 of frontend/components/file0.tsx
++    line 17 of frontend/components/file0.tsx
++    line 18 of frontend/components/file0.tsx
++    line 19 of frontend/components/file0.tsx
++    line 20 of frontend/components/file0.tsx
++    line 21 of frontend/components/file0.tsx
++    line 22 of frontend/components/file0.tsx
++    line 23 of frontend/components/file0.tsx
++    line 24 of frontend/components/file0.tsx
++    line 25 of frontend/components/file0.tsx
++    line 26 of frontend/components/file0.tsx
++    line 27 of frontend/components/file0.tsx
++    line 28 of frontend/components/file0.tsx
++    line 29 of frontend/components/file0.tsx
++    line 30 of frontend/components/file0.tsx
++    line 31 of frontend/components/file0.tsx
++    line 32 of frontend/components/file0.tsx
++    line 33 of frontend/components/file0.tsx
++    line 34 of frontend/components/file0.tsx
++    line 35 of frontend/components/file0.tsx
++    line 36 of frontend/components/file0.tsx
++    line 37 of frontend/components/file0.tsx
++    line 38 of frontend/components/file0.tsx
++    line 39 of frontend/components/file0.tsx
++    line 40 of frontend/components/file0.tsx
++    line 41 of frontend/components/file0.tsx
++    line 42 of frontend/components/file0.tsx
++    line 43 of frontend/components/file0.tsx
++    line 44 of frontend/components/file0.tsx
++    line 45 of frontend/components/file0.tsx
++    line 46 of frontend/components/file0.tsx
++    line 47 of frontend/components/file0.tsx
++    line 48 of frontend/components/file0.tsx
++    line 49 of frontend/components/file0.tsx
+diff --git a/frontend/components/file1.tsx b/frontend/components/file1.tsx
+index abc123..def456 100644
+--- a/frontend/components/file1.tsx
++++ b/frontend/components/file1.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/components/file1.tsx
++    line 1 of frontend/components/file1.tsx
++    line 2 of frontend/components/file1.tsx
++    line 3 of frontend/components/file1.tsx
++    line 4 of frontend/components/file1.tsx
++    line 5 of frontend/components/file1.tsx
++    line 6 of frontend/components/file1.tsx
++    line 7 of frontend/components/file1.tsx
++    line 8 of frontend/components/file1.tsx
++    line 9 of frontend/components/file1.tsx
++    line 10 of frontend/components/file1.tsx
++    line 11 of frontend/components/file1.tsx
++    line 12 of frontend/components/file1.tsx
++    line 13 of frontend/components/file1.tsx
++    line 14 of frontend/components/file1.tsx
++    line 15 of frontend/components/file1.tsx
++    line 16 of frontend/components/file1.tsx
++    line 17 of frontend/components/file1.tsx
++    line 18 of frontend/components/file1.tsx
++    line 19 of frontend/components/file1.tsx
++    line 20 of frontend/components/file1.tsx
++    line 21 of frontend/components/file1.tsx
++    line 22 of frontend/components/file1.tsx
++    line 23 of frontend/components/file1.tsx
++    line 24 of frontend/components/file1.tsx
++    line 25 of frontend/components/file1.tsx
++    line 26 of frontend/components/file1.tsx
++    line 27 of frontend/components/file1.tsx
++    line 28 of frontend/components/file1.tsx
++    line 29 of frontend/components/file1.tsx
++    line 30 of frontend/components/file1.tsx
++    line 31 of frontend/components/file1.tsx
++    line 32 of frontend/components/file1.tsx
++    line 33 of frontend/components/file1.tsx
++    line 34 of frontend/components/file1.tsx
++    line 35 of frontend/components/file1.tsx
++    line 36 of frontend/components/file1.tsx
++    line 37 of frontend/components/file1.tsx
++    line 38 of frontend/components/file1.tsx
++    line 39 of frontend/components/file1.tsx
++    line 40 of frontend/components/file1.tsx
++    line 41 of frontend/components/file1.tsx
++    line 42 of frontend/components/file1.tsx
++    line 43 of frontend/components/file1.tsx
++    line 44 of frontend/components/file1.tsx
++    line 45 of frontend/components/file1.tsx
++    line 46 of frontend/components/file1.tsx
++    line 47 of frontend/components/file1.tsx
++    line 48 of frontend/components/file1.tsx
++    line 49 of frontend/components/file1.tsx
+diff --git a/frontend/components/file2.tsx b/frontend/components/file2.tsx
+index abc123..def456 100644
+--- a/frontend/components/file2.tsx
++++ b/frontend/components/file2.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/components/file2.tsx
++    line 1 of frontend/components/file2.tsx
++    line 2 of frontend/components/file2.tsx
++    line 3 of frontend/components/file2.tsx
++    line 4 of frontend/components/file2.tsx
++    line 5 of frontend/components/file2.tsx
++    line 6 of frontend/components/file2.tsx
++    line 7 of frontend/components/file2.tsx
++    line 8 of frontend/components/file2.tsx
++    line 9 of frontend/components/file2.tsx
++    line 10 of frontend/components/file2.tsx
++    line 11 of frontend/components/file2.tsx
++    line 12 of frontend/components/file2.tsx
++    line 13 of frontend/components/file2.tsx
++    line 14 of frontend/components/file2.tsx
++    line 15 of frontend/components/file2.tsx
++    line 16 of frontend/components/file2.tsx
++    line 17 of frontend/components/file2.tsx
++    line 18 of frontend/components/file2.tsx
++    line 19 of frontend/components/file2.tsx
++    line 20 of frontend/components/file2.tsx
++    line 21 of frontend/components/file2.tsx
++    line 22 of frontend/components/file2.tsx
++    line 23 of frontend/components/file2.tsx
++    line 24 of frontend/components/file2.tsx
++    line 25 of frontend/components/file2.tsx
++    line 26 of frontend/components/file2.tsx
++    line 27 of frontend/components/file2.tsx
++    line 28 of frontend/components/file2.tsx
++    line 29 of frontend/components/file2.tsx
++    line 30 of frontend/components/file2.tsx
++    line 31 of frontend/components/file2.tsx
++    line 32 of frontend/components/file2.tsx
++    line 33 of frontend/components/file2.tsx
++    line 34 of frontend/components/file2.tsx
++    line 35 of frontend/components/file2.tsx
++    line 36 of frontend/components/file2.tsx
++    line 37 of frontend/components/file2.tsx
++    line 38 of frontend/components/file2.tsx
++    line 39 of frontend/components/file2.tsx
++    line 40 of frontend/components/file2.tsx
++    line 41 of frontend/components/file2.tsx
++    line 42 of frontend/components/file2.tsx
++    line 43 of frontend/components/file2.tsx
++    line 44 of frontend/components/file2.tsx
++    line 45 of frontend/components/file2.tsx
++    line 46 of frontend/components/file2.tsx
++    line 47 of frontend/components/file2.tsx
++    line 48 of frontend/components/file2.tsx
++    line 49 of frontend/components/file2.tsx
+diff --git a/frontend/components/file3.tsx b/frontend/components/file3.tsx
+index abc123..def456 100644
+--- a/frontend/components/file3.tsx
++++ b/frontend/components/file3.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/components/file3.tsx
++    line 1 of frontend/components/file3.tsx
++    line 2 of frontend/components/file3.tsx
++    line 3 of frontend/components/file3.tsx
++    line 4 of frontend/components/file3.tsx
++    line 5 of frontend/components/file3.tsx
++    line 6 of frontend/components/file3.tsx
++    line 7 of frontend/components/file3.tsx
++    line 8 of frontend/components/file3.tsx
++    line 9 of frontend/components/file3.tsx
++    line 10 of frontend/components/file3.tsx
++    line 11 of frontend/components/file3.tsx
++    line 12 of frontend/components/file3.tsx
++    line 13 of frontend/components/file3.tsx
++    line 14 of frontend/components/file3.tsx
++    line 15 of frontend/components/file3.tsx
++    line 16 of frontend/components/file3.tsx
++    line 17 of frontend/components/file3.tsx
++    line 18 of frontend/components/file3.tsx
++    line 19 of frontend/components/file3.tsx
++    line 20 of frontend/components/file3.tsx
++    line 21 of frontend/components/file3.tsx
++    line 22 of frontend/components/file3.tsx
++    line 23 of frontend/components/file3.tsx
++    line 24 of frontend/components/file3.tsx
++    line 25 of frontend/components/file3.tsx
++    line 26 of frontend/components/file3.tsx
++    line 27 of frontend/components/file3.tsx
++    line 28 of frontend/components/file3.tsx
++    line 29 of frontend/components/file3.tsx
++    line 30 of frontend/components/file3.tsx
++    line 31 of frontend/components/file3.tsx
++    line 32 of frontend/components/file3.tsx
++    line 33 of frontend/components/file3.tsx
++    line 34 of frontend/components/file3.tsx
++    line 35 of frontend/components/file3.tsx
++    line 36 of frontend/components/file3.tsx
++    line 37 of frontend/components/file3.tsx
++    line 38 of frontend/components/file3.tsx
++    line 39 of frontend/components/file3.tsx
++    line 40 of frontend/components/file3.tsx
++    line 41 of frontend/components/file3.tsx
++    line 42 of frontend/components/file3.tsx
++    line 43 of frontend/components/file3.tsx
++    line 44 of frontend/components/file3.tsx
++    line 45 of frontend/components/file3.tsx
++    line 46 of frontend/components/file3.tsx
++    line 47 of frontend/components/file3.tsx
++    line 48 of frontend/components/file3.tsx
++    line 49 of frontend/components/file3.tsx
+diff --git a/frontend/components/file4.tsx b/frontend/components/file4.tsx
+index abc123..def456 100644
+--- a/frontend/components/file4.tsx
++++ b/frontend/components/file4.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/components/file4.tsx
++    line 1 of frontend/components/file4.tsx
++    line 2 of frontend/components/file4.tsx
++    line 3 of frontend/components/file4.tsx
++    line 4 of frontend/components/file4.tsx
++    line 5 of frontend/components/file4.tsx
++    line 6 of frontend/components/file4.tsx
++    line 7 of frontend/components/file4.tsx
++    line 8 of frontend/components/file4.tsx
++    line 9 of frontend/components/file4.tsx
++    line 10 of frontend/components/file4.tsx
++    line 11 of frontend/components/file4.tsx
++    line 12 of frontend/components/file4.tsx
++    line 13 of frontend/components/file4.tsx
++    line 14 of frontend/components/file4.tsx
++    line 15 of frontend/components/file4.tsx
++    line 16 of frontend/components/file4.tsx
++    line 17 of frontend/components/file4.tsx
++    line 18 of frontend/components/file4.tsx
++    line 19 of frontend/components/file4.tsx
++    line 20 of frontend/components/file4.tsx
++    line 21 of frontend/components/file4.tsx
++    line 22 of frontend/components/file4.tsx
++    line 23 of frontend/components/file4.tsx
++    line 24 of frontend/components/file4.tsx
++    line 25 of frontend/components/file4.tsx
++    line 26 of frontend/components/file4.tsx
++    line 27 of frontend/components/file4.tsx
++    line 28 of frontend/components/file4.tsx
++    line 29 of frontend/components/file4.tsx
++    line 30 of frontend/components/file4.tsx
++    line 31 of frontend/components/file4.tsx
++    line 32 of frontend/components/file4.tsx
++    line 33 of frontend/components/file4.tsx
++    line 34 of frontend/components/file4.tsx
++    line 35 of frontend/components/file4.tsx
++    line 36 of frontend/components/file4.tsx
++    line 37 of frontend/components/file4.tsx
++    line 38 of frontend/components/file4.tsx
++    line 39 of frontend/components/file4.tsx
++    line 40 of frontend/components/file4.tsx
++    line 41 of frontend/components/file4.tsx
++    line 42 of frontend/components/file4.tsx
++    line 43 of frontend/components/file4.tsx
++    line 44 of frontend/components/file4.tsx
++    line 45 of frontend/components/file4.tsx
++    line 46 of frontend/components/file4.tsx
++    line 47 of frontend/components/file4.tsx
++    line 48 of frontend/components/file4.tsx
++    line 49 of frontend/components/file4.tsx
+diff --git a/frontend/hooks/file0.tsx b/frontend/hooks/file0.tsx
+index abc123..def456 100644
+--- a/frontend/hooks/file0.tsx
++++ b/frontend/hooks/file0.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/hooks/file0.tsx
++    line 1 of frontend/hooks/file0.tsx
++    line 2 of frontend/hooks/file0.tsx
++    line 3 of frontend/hooks/file0.tsx
++    line 4 of frontend/hooks/file0.tsx
++    line 5 of frontend/hooks/file0.tsx
++    line 6 of frontend/hooks/file0.tsx
++    line 7 of frontend/hooks/file0.tsx
++    line 8 of frontend/hooks/file0.tsx
++    line 9 of frontend/hooks/file0.tsx
++    line 10 of frontend/hooks/file0.tsx
++    line 11 of frontend/hooks/file0.tsx
++    line 12 of frontend/hooks/file0.tsx
++    line 13 of frontend/hooks/file0.tsx
++    line 14 of frontend/hooks/file0.tsx
++    line 15 of frontend/hooks/file0.tsx
++    line 16 of frontend/hooks/file0.tsx
++    line 17 of frontend/hooks/file0.tsx
++    line 18 of frontend/hooks/file0.tsx
++    line 19 of frontend/hooks/file0.tsx
++    line 20 of frontend/hooks/file0.tsx
++    line 21 of frontend/hooks/file0.tsx
++    line 22 of frontend/hooks/file0.tsx
++    line 23 of frontend/hooks/file0.tsx
++    line 24 of frontend/hooks/file0.tsx
++    line 25 of frontend/hooks/file0.tsx
++    line 26 of frontend/hooks/file0.tsx
++    line 27 of frontend/hooks/file0.tsx
++    line 28 of frontend/hooks/file0.tsx
++    line 29 of frontend/hooks/file0.tsx
++    line 30 of frontend/hooks/file0.tsx
++    line 31 of frontend/hooks/file0.tsx
++    line 32 of frontend/hooks/file0.tsx
++    line 33 of frontend/hooks/file0.tsx
++    line 34 of frontend/hooks/file0.tsx
++    line 35 of frontend/hooks/file0.tsx
++    line 36 of frontend/hooks/file0.tsx
++    line 37 of frontend/hooks/file0.tsx
++    line 38 of frontend/hooks/file0.tsx
++    line 39 of frontend/hooks/file0.tsx
++    line 40 of frontend/hooks/file0.tsx
++    line 41 of frontend/hooks/file0.tsx
++    line 42 of frontend/hooks/file0.tsx
++    line 43 of frontend/hooks/file0.tsx
++    line 44 of frontend/hooks/file0.tsx
++    line 45 of frontend/hooks/file0.tsx
++    line 46 of frontend/hooks/file0.tsx
++    line 47 of frontend/hooks/file0.tsx
++    line 48 of frontend/hooks/file0.tsx
++    line 49 of frontend/hooks/file0.tsx
+diff --git a/frontend/hooks/file1.tsx b/frontend/hooks/file1.tsx
+index abc123..def456 100644
+--- a/frontend/hooks/file1.tsx
++++ b/frontend/hooks/file1.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/hooks/file1.tsx
++    line 1 of frontend/hooks/file1.tsx
++    line 2 of frontend/hooks/file1.tsx
++    line 3 of frontend/hooks/file1.tsx
++    line 4 of frontend/hooks/file1.tsx
++    line 5 of frontend/hooks/file1.tsx
++    line 6 of frontend/hooks/file1.tsx
++    line 7 of frontend/hooks/file1.tsx
++    line 8 of frontend/hooks/file1.tsx
++    line 9 of frontend/hooks/file1.tsx
++    line 10 of frontend/hooks/file1.tsx
++    line 11 of frontend/hooks/file1.tsx
++    line 12 of frontend/hooks/file1.tsx
++    line 13 of frontend/hooks/file1.tsx
++    line 14 of frontend/hooks/file1.tsx
++    line 15 of frontend/hooks/file1.tsx
++    line 16 of frontend/hooks/file1.tsx
++    line 17 of frontend/hooks/file1.tsx
++    line 18 of frontend/hooks/file1.tsx
++    line 19 of frontend/hooks/file1.tsx
++    line 20 of frontend/hooks/file1.tsx
++    line 21 of frontend/hooks/file1.tsx
++    line 22 of frontend/hooks/file1.tsx
++    line 23 of frontend/hooks/file1.tsx
++    line 24 of frontend/hooks/file1.tsx
++    line 25 of frontend/hooks/file1.tsx
++    line 26 of frontend/hooks/file1.tsx
++    line 27 of frontend/hooks/file1.tsx
++    line 28 of frontend/hooks/file1.tsx
++    line 29 of frontend/hooks/file1.tsx
++    line 30 of frontend/hooks/file1.tsx
++    line 31 of frontend/hooks/file1.tsx
++    line 32 of frontend/hooks/file1.tsx
++    line 33 of frontend/hooks/file1.tsx
++    line 34 of frontend/hooks/file1.tsx
++    line 35 of frontend/hooks/file1.tsx
++    line 36 of frontend/hooks/file1.tsx
++    line 37 of frontend/hooks/file1.tsx
++    line 38 of frontend/hooks/file1.tsx
++    line 39 of frontend/hooks/file1.tsx
++    line 40 of frontend/hooks/file1.tsx
++    line 41 of frontend/hooks/file1.tsx
++    line 42 of frontend/hooks/file1.tsx
++    line 43 of frontend/hooks/file1.tsx
++    line 44 of frontend/hooks/file1.tsx
++    line 45 of frontend/hooks/file1.tsx
++    line 46 of frontend/hooks/file1.tsx
++    line 47 of frontend/hooks/file1.tsx
++    line 48 of frontend/hooks/file1.tsx
++    line 49 of frontend/hooks/file1.tsx
+diff --git a/frontend/hooks/file2.tsx b/frontend/hooks/file2.tsx
+index abc123..def456 100644
+--- a/frontend/hooks/file2.tsx
++++ b/frontend/hooks/file2.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/hooks/file2.tsx
++    line 1 of frontend/hooks/file2.tsx
++    line 2 of frontend/hooks/file2.tsx
++    line 3 of frontend/hooks/file2.tsx
++    line 4 of frontend/hooks/file2.tsx
++    line 5 of frontend/hooks/file2.tsx
++    line 6 of frontend/hooks/file2.tsx
++    line 7 of frontend/hooks/file2.tsx
++    line 8 of frontend/hooks/file2.tsx
++    line 9 of frontend/hooks/file2.tsx
++    line 10 of frontend/hooks/file2.tsx
++    line 11 of frontend/hooks/file2.tsx
++    line 12 of frontend/hooks/file2.tsx
++    line 13 of frontend/hooks/file2.tsx
++    line 14 of frontend/hooks/file2.tsx
++    line 15 of frontend/hooks/file2.tsx
++    line 16 of frontend/hooks/file2.tsx
++    line 17 of frontend/hooks/file2.tsx
++    line 18 of frontend/hooks/file2.tsx
++    line 19 of frontend/hooks/file2.tsx
++    line 20 of frontend/hooks/file2.tsx
++    line 21 of frontend/hooks/file2.tsx
++    line 22 of frontend/hooks/file2.tsx
++    line 23 of frontend/hooks/file2.tsx
++    line 24 of frontend/hooks/file2.tsx
++    line 25 of frontend/hooks/file2.tsx
++    line 26 of frontend/hooks/file2.tsx
++    line 27 of frontend/hooks/file2.tsx
++    line 28 of frontend/hooks/file2.tsx
++    line 29 of frontend/hooks/file2.tsx
++    line 30 of frontend/hooks/file2.tsx
++    line 31 of frontend/hooks/file2.tsx
++    line 32 of frontend/hooks/file2.tsx
++    line 33 of frontend/hooks/file2.tsx
++    line 34 of frontend/hooks/file2.tsx
++    line 35 of frontend/hooks/file2.tsx
++    line 36 of frontend/hooks/file2.tsx
++    line 37 of frontend/hooks/file2.tsx
++    line 38 of frontend/hooks/file2.tsx
++    line 39 of frontend/hooks/file2.tsx
++    line 40 of frontend/hooks/file2.tsx
++    line 41 of frontend/hooks/file2.tsx
++    line 42 of frontend/hooks/file2.tsx
++    line 43 of frontend/hooks/file2.tsx
++    line 44 of frontend/hooks/file2.tsx
++    line 45 of frontend/hooks/file2.tsx
++    line 46 of frontend/hooks/file2.tsx
++    line 47 of frontend/hooks/file2.tsx
++    line 48 of frontend/hooks/file2.tsx
++    line 49 of frontend/hooks/file2.tsx
+diff --git a/frontend/hooks/file3.tsx b/frontend/hooks/file3.tsx
+index abc123..def456 100644
+--- a/frontend/hooks/file3.tsx
++++ b/frontend/hooks/file3.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/hooks/file3.tsx
++    line 1 of frontend/hooks/file3.tsx
++    line 2 of frontend/hooks/file3.tsx
++    line 3 of frontend/hooks/file3.tsx
++    line 4 of frontend/hooks/file3.tsx
++    line 5 of frontend/hooks/file3.tsx
++    line 6 of frontend/hooks/file3.tsx
++    line 7 of frontend/hooks/file3.tsx
++    line 8 of frontend/hooks/file3.tsx
++    line 9 of frontend/hooks/file3.tsx
++    line 10 of frontend/hooks/file3.tsx
++    line 11 of frontend/hooks/file3.tsx
++    line 12 of frontend/hooks/file3.tsx
++    line 13 of frontend/hooks/file3.tsx
++    line 14 of frontend/hooks/file3.tsx
++    line 15 of frontend/hooks/file3.tsx
++    line 16 of frontend/hooks/file3.tsx
++    line 17 of frontend/hooks/file3.tsx
++    line 18 of frontend/hooks/file3.tsx
++    line 19 of frontend/hooks/file3.tsx
++    line 20 of frontend/hooks/file3.tsx
++    line 21 of frontend/hooks/file3.tsx
++    line 22 of frontend/hooks/file3.tsx
++    line 23 of frontend/hooks/file3.tsx
++    line 24 of frontend/hooks/file3.tsx
++    line 25 of frontend/hooks/file3.tsx
++    line 26 of frontend/hooks/file3.tsx
++    line 27 of frontend/hooks/file3.tsx
++    line 28 of frontend/hooks/file3.tsx
++    line 29 of frontend/hooks/file3.tsx
++    line 30 of frontend/hooks/file3.tsx
++    line 31 of frontend/hooks/file3.tsx
++    line 32 of frontend/hooks/file3.tsx
++    line 33 of frontend/hooks/file3.tsx
++    line 34 of frontend/hooks/file3.tsx
++    line 35 of frontend/hooks/file3.tsx
++    line 36 of frontend/hooks/file3.tsx
++    line 37 of frontend/hooks/file3.tsx
++    line 38 of frontend/hooks/file3.tsx
++    line 39 of frontend/hooks/file3.tsx
++    line 40 of frontend/hooks/file3.tsx
++    line 41 of frontend/hooks/file3.tsx
++    line 42 of frontend/hooks/file3.tsx
++    line 43 of frontend/hooks/file3.tsx
++    line 44 of frontend/hooks/file3.tsx
++    line 45 of frontend/hooks/file3.tsx
++    line 46 of frontend/hooks/file3.tsx
++    line 47 of frontend/hooks/file3.tsx
++    line 48 of frontend/hooks/file3.tsx
++    line 49 of frontend/hooks/file3.tsx
+diff --git a/frontend/hooks/file4.tsx b/frontend/hooks/file4.tsx
+index abc123..def456 100644
+--- a/frontend/hooks/file4.tsx
++++ b/frontend/hooks/file4.tsx
+@@ -1,5 +1,55 @@
++    line 0 of frontend/hooks/file4.tsx
++    line 1 of frontend/hooks/file4.tsx
++    line 2 of frontend/hooks/file4.tsx
++    line 3 of frontend/hooks/file4.tsx
++    line 4 of frontend/hooks/file4.tsx
++    line 5 of frontend/hooks/file4.tsx
++    line 6 of frontend/hooks/file4.tsx
++    line 7 of frontend/hooks/file4.tsx
++    line 8 of frontend/hooks/file4.tsx
++    line 9 of frontend/hooks/file4.tsx
++    line 10 of frontend/hooks/file4.tsx
++    line 11 of frontend/hooks/file4.tsx
++    line 12 of frontend/hooks/file4.tsx
++    line 13 of frontend/hooks/file4.tsx
++    line 14 of frontend/hooks/file4.tsx
++    line 15 of frontend/hooks/file4.tsx
++    line 16 of frontend/hooks/file4.tsx
++    line 17 of frontend/hooks/file4.tsx
++    line 18 of frontend/hooks/file4.tsx
++    line 19 of frontend/hooks/file4.tsx
++    line 20 of frontend/hooks/file4.tsx
++    line 21 of frontend/hooks/file4.tsx
++    line 22 of frontend/hooks/file4.tsx
++    line 23 of frontend/hooks/file4.tsx
++    line 24 of frontend/hooks/file4.tsx
++    line 25 of frontend/hooks/file4.tsx
++    line 26 of frontend/hooks/file4.tsx
++    line 27 of frontend/hooks/file4.tsx
++    line 28 of frontend/hooks/file4.tsx
++    line 29 of frontend/hooks/file4.tsx
++    line 30 of frontend/hooks/file4.tsx
++    line 31 of frontend/hooks/file4.tsx
++    line 32 of frontend/hooks/file4.tsx
++    line 33 of frontend/hooks/file4.tsx
++    line 34 of frontend/hooks/file4.tsx
++    line 35 of frontend/hooks/file4.tsx
++    line 36 of frontend/hooks/file4.tsx
++    line 37 of frontend/hooks/file4.tsx
++    line 38 of frontend/hooks/file4.tsx
++    line 39 of frontend/hooks/file4.tsx
++    line 40 of frontend/hooks/file4.tsx
++    line 41 of frontend/hooks/file4.tsx
++    line 42 of frontend/hooks/file4.tsx
++    line 43 of frontend/hooks/file4.tsx
++    line 44 of frontend/hooks/file4.tsx
++    line 45 of frontend/hooks/file4.tsx
++    line 46 of frontend/hooks/file4.tsx
++    line 47 of frontend/hooks/file4.tsx
++    line 48 of frontend/hooks/file4.tsx
++    line 49 of frontend/hooks/file4.tsx
+diff --git a/backend/api/test_file0.py b/backend/api/test_file0.py
+index abc123..def456 100644
+--- a/backend/api/test_file0.py
++++ b/backend/api/test_file0.py
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/backend/api/test_file1.py b/backend/api/test_file1.py
+index abc123..def456 100644
+--- a/backend/api/test_file1.py
++++ b/backend/api/test_file1.py
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/backend/api/test_file2.py b/backend/api/test_file2.py
+index abc123..def456 100644
+--- a/backend/api/test_file2.py
++++ b/backend/api/test_file2.py
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19

--- a/tests/fixtures/diffs/multi-directory.diff
+++ b/tests/fixtures/diffs/multi-directory.diff
@@ -1173,3 +1173,153 @@ index abc123..def456 100644
 +    test line 17
 +    test line 18
 +    test line 19
+diff --git a/backend/services/handler.go b/backend/services/handler.go
+index abc123..def456 100644
+--- a/backend/services/handler.go
++++ b/backend/services/handler.go
+@@ -1,5 +1,25 @@
++    line 0 of backend/services/handler.go
++    line 1 of backend/services/handler.go
++    line 2 of backend/services/handler.go
++    line 3 of backend/services/handler.go
++    line 4 of backend/services/handler.go
++    line 5 of backend/services/handler.go
++    line 6 of backend/services/handler.go
++    line 7 of backend/services/handler.go
++    line 8 of backend/services/handler.go
++    line 9 of backend/services/handler.go
++    line 10 of backend/services/handler.go
++    line 11 of backend/services/handler.go
++    line 12 of backend/services/handler.go
++    line 13 of backend/services/handler.go
++    line 14 of backend/services/handler.go
++    line 15 of backend/services/handler.go
++    line 16 of backend/services/handler.go
++    line 17 of backend/services/handler.go
++    line 18 of backend/services/handler.go
++    line 19 of backend/services/handler.go
+diff --git a/backend/services/handler_test.go b/backend/services/handler_test.go
+index abc123..def456 100644
+--- a/backend/services/handler_test.go
++++ b/backend/services/handler_test.go
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/frontend/utils/format.ts b/frontend/utils/format.ts
+index abc123..def456 100644
+--- a/frontend/utils/format.ts
++++ b/frontend/utils/format.ts
+@@ -1,5 +1,25 @@
++    line 0 of frontend/utils/format.ts
++    line 1 of frontend/utils/format.ts
++    line 2 of frontend/utils/format.ts
++    line 3 of frontend/utils/format.ts
++    line 4 of frontend/utils/format.ts
++    line 5 of frontend/utils/format.ts
++    line 6 of frontend/utils/format.ts
++    line 7 of frontend/utils/format.ts
++    line 8 of frontend/utils/format.ts
++    line 9 of frontend/utils/format.ts
++    line 10 of frontend/utils/format.ts
++    line 11 of frontend/utils/format.ts
++    line 12 of frontend/utils/format.ts
++    line 13 of frontend/utils/format.ts
++    line 14 of frontend/utils/format.ts
++    line 15 of frontend/utils/format.ts
++    line 16 of frontend/utils/format.ts
++    line 17 of frontend/utils/format.ts
++    line 18 of frontend/utils/format.ts
++    line 19 of frontend/utils/format.ts
+diff --git a/frontend/utils/format.test.ts b/frontend/utils/format.test.ts
+index abc123..def456 100644
+--- a/frontend/utils/format.test.ts
++++ b/frontend/utils/format.test.ts
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19
+diff --git a/frontend/lib/helpers.ts b/frontend/lib/helpers.ts
+index abc123..def456 100644
+--- a/frontend/lib/helpers.ts
++++ b/frontend/lib/helpers.ts
+@@ -1,5 +1,25 @@
++    line 0 of frontend/lib/helpers.ts
++    line 1 of frontend/lib/helpers.ts
++    line 2 of frontend/lib/helpers.ts
++    line 3 of frontend/lib/helpers.ts
++    line 4 of frontend/lib/helpers.ts
++    line 5 of frontend/lib/helpers.ts
++    line 6 of frontend/lib/helpers.ts
++    line 7 of frontend/lib/helpers.ts
++    line 8 of frontend/lib/helpers.ts
++    line 9 of frontend/lib/helpers.ts
++    line 10 of frontend/lib/helpers.ts
++    line 11 of frontend/lib/helpers.ts
++    line 12 of frontend/lib/helpers.ts
++    line 13 of frontend/lib/helpers.ts
++    line 14 of frontend/lib/helpers.ts
++    line 15 of frontend/lib/helpers.ts
++    line 16 of frontend/lib/helpers.ts
++    line 17 of frontend/lib/helpers.ts
++    line 18 of frontend/lib/helpers.ts
++    line 19 of frontend/lib/helpers.ts
+diff --git a/frontend/lib/__tests__/helpers.ts b/frontend/lib/__tests__/helpers.ts
+index abc123..def456 100644
+--- a/frontend/lib/__tests__/helpers.ts
++++ b/frontend/lib/__tests__/helpers.ts
+@@ -1,5 +1,25 @@
++    test line 0
++    test line 1
++    test line 2
++    test line 3
++    test line 4
++    test line 5
++    test line 6
++    test line 7
++    test line 8
++    test line 9
++    test line 10
++    test line 11
++    test line 12
++    test line 13
++    test line 14
++    test line 15
++    test line 16
++    test line 17
++    test line 18
++    test line 19

--- a/tests/unit/test-chunk-diff.bats
+++ b/tests/unit/test-chunk-diff.bats
@@ -366,3 +366,95 @@ index abc..def 100644
     [ "$status" -eq 0 ]
     [[ "$(echo "$output" | jq -r '.reason')" == *"exceeds threshold"* ]]
 }
+
+# =============================================================================
+# Size-based splitting tests
+# =============================================================================
+
+@test "chunk-diff: size-based splitting with low max_chunk_size_kb" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    # Use a very low max_chunk_size_kb (1KB) but high max_files_per_chunk to force
+    # size-based splitting rather than file-count-based splitting
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 5, "min_chunk_threshold_kb": 0, "max_chunk_size_kb": 1, "max_files_per_chunk": 100}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+    # With 1KB limit, there should be many chunks since each file is ~1KB+
+    chunk_count=$(echo "$output" | jq '.chunk_count')
+    [ "$chunk_count" -gt 2 ]
+}
+
+# =============================================================================
+# chunk_count consistency tests
+# =============================================================================
+
+@test "chunk-diff: chunk_count equals chunks array length" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+    # Verify chunk_count matches the actual number of chunks and ids are sequential
+    echo "$output" | jq -e '.chunk_count == (.chunks | length)'
+    echo "$output" | jq -e '[.chunks[].id] == [range(1; (.chunks | length) + 1)]'
+}
+
+# =============================================================================
+# Additional test-file pairing pattern tests
+# =============================================================================
+
+@test "chunk-diff: Go _test.go files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # handler_test.go should be in the same chunk as handler.go
+    impl_chunk=$(echo "$output" | jq --arg f "backend/services/handler.go" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "backend/services/handler_test.go" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: JS .test.ts files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # format.test.ts should be in the same chunk as format.ts
+    impl_chunk=$(echo "$output" | jq --arg f "frontend/utils/format.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "frontend/utils/format.test.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: __tests__ directory files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # frontend/lib/__tests__/helpers.ts should be in the same chunk as frontend/lib/helpers.ts
+    impl_chunk=$(echo "$output" | jq --arg f "frontend/lib/helpers.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "frontend/lib/__tests__/helpers.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}

--- a/tests/unit/test-chunk-diff.bats
+++ b/tests/unit/test-chunk-diff.bats
@@ -232,8 +232,6 @@ setup() {
     run bash -c "printf '%s' '$input' | '$SCRIPT'"
     [ "$status" -eq 0 ]
 
-    # Collect all files across all chunks
-    all_chunk_files=$(echo "$output" | jq '[.chunks[].files[]] | sort')
     # Count unique files
     unique_count=$(echo "$output" | jq '[.chunks[].files[]] | unique | length')
     total_count=$(echo "$output" | jq '[.chunks[].files[]] | length')
@@ -457,4 +455,157 @@ index abc..def 100644
     impl_chunk=$(echo "$output" | jq --arg f "frontend/lib/helpers.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
     test_chunk=$(echo "$output" | jq --arg f "frontend/lib/__tests__/helpers.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
     [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: Ruby _spec.rb files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # parser_spec.rb should be in the same chunk as parser.rb
+    impl_chunk=$(echo "$output" | jq --arg f "backend/services/parser.rb" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "backend/services/parser_spec.rb" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: Angular .spec.ts files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # app.component.spec.ts should be in the same chunk as app.component.ts
+    impl_chunk=$(echo "$output" | jq --arg f "frontend/components/app.component.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "frontend/components/app.component.spec.ts" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: generic _test suffix files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # utils_test.py should be in the same chunk as utils.py
+    impl_chunk=$(echo "$output" | jq --arg f "backend/models/utils.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "backend/models/utils_test.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+# =============================================================================
+# Threshold boundary tests
+# =============================================================================
+
+@test "chunk-diff: exceeds file threshold only still triggers chunking" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    # High KB threshold (won't be exceeded), low file threshold (will be exceeded)
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 9999, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+}
+
+@test "chunk-diff: exceeds KB threshold only still triggers chunking" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    # Low KB threshold (will be exceeded), high file threshold (won't be exceeded)
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 9999, "min_chunk_threshold_kb": 1, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+}
+
+# =============================================================================
+# file_metadata integration tests
+# =============================================================================
+
+@test "chunk-diff: file_metadata likely_test_path pairs files via forward mapping" {
+    # Build a small diff with four files
+    local diff=""
+    for f in src/app.py src/my_app_test.py src/utils.py src/helper.py; do
+        diff="${diff}diff --git a/$f b/$f
+index abc..def 100644
+--- a/$f
++++ b/$f
+@@ -1,3 +1,4 @@
++line from $f
+"
+    done
+
+    # my_app_test.py would not be paired by filename patterns (no matching impl),
+    # but file_metadata says app.py's likely_test_path is my_app_test.py
+    local metadata
+    metadata=$(jq -nc '{modified_files: [
+        {path: "src/app.py", is_test: false, likely_test_path: "src/my_app_test.py"},
+        {path: "src/my_app_test.py", is_test: true, likely_test_path: ""},
+        {path: "src/utils.py", is_test: false, likely_test_path: ""},
+        {path: "src/helper.py", is_test: false, likely_test_path: ""}
+    ]}')
+    local input
+    input=$(jq -n --arg diff "$diff" --argjson meta "$metadata" \
+        '{"diff": $diff, "file_metadata": $meta, "config": {"min_chunk_threshold_files": 2, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 2}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+
+    # app.py and my_app_test.py should be in the same chunk via likely_test_path
+    impl_chunk=$(echo "$output" | jq --arg f "src/app.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "src/my_app_test.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" = "$test_chunk" ]
+}
+
+@test "chunk-diff: file_metadata is_test=false skips pattern matching" {
+    # Build a diff with a file named test_config.py that is NOT a test file
+    local diff=""
+    for f in src/test_config.py src/config.py src/other.py src/another.py; do
+        diff="${diff}diff --git a/$f b/$f
+index abc..def 100644
+--- a/$f
++++ b/$f
+@@ -1,3 +1,4 @@
++line from $f
+"
+    done
+
+    # Metadata says test_config.py is NOT a test (despite the name)
+    local metadata
+    metadata=$(jq -nc '{modified_files: [
+        {path: "src/test_config.py", is_test: false, likely_test_path: ""},
+        {path: "src/config.py", is_test: false, likely_test_path: ""},
+        {path: "src/other.py", is_test: false, likely_test_path: ""},
+        {path: "src/another.py", is_test: false, likely_test_path: ""}
+    ]}')
+    local input
+    input=$(jq -n --arg diff "$diff" --argjson meta "$metadata" \
+        '{"diff": $diff, "file_metadata": $meta, "config": {"min_chunk_threshold_files": 2, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 2}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+
+    # test_config.py should NOT be paired with config.py since metadata says it's not a test
+    impl_chunk=$(echo "$output" | jq --arg f "src/config.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    test_chunk=$(echo "$output" | jq --arg f "src/test_config.py" '[.chunks[] | select(.files | index($f))] | .[0].id')
+    [ "$impl_chunk" != "$test_chunk" ]
 }

--- a/tests/unit/test-chunk-diff.bats
+++ b/tests/unit/test-chunk-diff.bats
@@ -1,0 +1,368 @@
+#!/usr/bin/env bats
+# Tests for chunk-diff.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/chunk-diff.sh"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures/diffs"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "chunk-diff: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "chunk-diff: uses set -euo pipefail" {
+    run bash -c "head -30 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "chunk-diff: has main function" {
+    run bash -c "grep -q '^main()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "chunk-diff: can be sourced without executing main" {
+    output=$(source "$SCRIPT" 2>&1)
+    [ -z "$output" ]
+}
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "chunk-diff: rejects invalid JSON input" {
+    run bash -c "echo 'not json' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid JSON"* ]]
+}
+
+@test "chunk-diff: outputs valid JSON on success" {
+    run bash -c "echo '{\"diff\": \"\"}' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.' > /dev/null
+}
+
+# =============================================================================
+# Empty/small diff tests
+# =============================================================================
+
+@test "chunk-diff: empty diff returns chunked false" {
+    run bash -c "echo '{\"diff\": \"\"}' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == false'
+    echo "$output" | jq -e '.reason == "empty diff"'
+}
+
+@test "chunk-diff: null diff returns chunked false" {
+    run bash -c "echo '{\"diff\": null}' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == false'
+}
+
+@test "chunk-diff: small diff returns chunked false with reason" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" '{"diff": $diff}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == false'
+    [[ "$(echo "$output" | jq -r '.reason')" == *"below threshold"* ]]
+}
+
+@test "chunk-diff: small diff has no chunks array" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" '{"diff": $diff}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # When below threshold, chunks field should not be present
+    has_chunks=$(echo "$output" | jq 'has("chunks")')
+    [ "$has_chunks" = "false" ]
+}
+
+# =============================================================================
+# Large diff chunking tests
+# =============================================================================
+
+@test "chunk-diff: large diff with many files returns chunked true" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+}
+
+@test "chunk-diff: chunked output includes chunk_count" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    chunk_count=$(echo "$output" | jq '.chunk_count')
+    [ "$chunk_count" -gt 1 ]
+}
+
+@test "chunk-diff: chunked output includes chunks array" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunks | type == "array"'
+    echo "$output" | jq -e '.chunks | length > 0'
+}
+
+@test "chunk-diff: each chunk has required fields" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # Every chunk must have id, label, files, diff, size_kb
+    echo "$output" | jq -e '.chunks | all(has("id", "label", "files", "diff", "size_kb"))'
+}
+
+@test "chunk-diff: chunk ids are sequential starting at 1" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    first_id=$(echo "$output" | jq '.chunks[0].id')
+    [ "$first_id" -eq 1 ]
+}
+
+# =============================================================================
+# Test file pairing tests
+# =============================================================================
+
+@test "chunk-diff: test files are paired with implementation files" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # For each test file (test_file0.py, test_file1.py, test_file2.py),
+    # its implementation file (file0.py, file1.py, file2.py) should be in the same chunk
+    for i in 0 1 2; do
+        impl="backend/api/file${i}.py"
+        test="backend/api/test_file${i}.py"
+        # Find which chunk has the test file, then check that the impl is there too
+        impl_chunk=$(echo "$output" | jq --arg f "$impl" '[.chunks[] | select(.files | index($f))] | .[0].id')
+        test_chunk=$(echo "$output" | jq --arg f "$test" '[.chunks[] | select(.files | index($f))] | .[0].id')
+        [ "$impl_chunk" = "$test_chunk" ]
+    done
+}
+
+# =============================================================================
+# Directory grouping tests
+# =============================================================================
+
+@test "chunk-diff: files in same directory tend to group together" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 10}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # frontend/components has 5 files. They should all be in the same chunk
+    # since they sort adjacently and 5 files fits within the 10-file limit.
+    component_chunks=$(echo "$output" | jq '[.chunks[] | select(.files | any(startswith("frontend/components/")))] | length')
+    [ "$component_chunks" -eq 1 ]
+}
+
+# =============================================================================
+# Diff integrity tests
+# =============================================================================
+
+@test "chunk-diff: chunk diffs start with diff --git" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Every chunk's diff should start with "diff --git"
+    echo "$output" | jq -e '.chunks | all(.diff | startswith("diff --git"))'
+}
+
+@test "chunk-diff: no files lost or duplicated across chunks" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Collect all files across all chunks
+    all_chunk_files=$(echo "$output" | jq '[.chunks[].files[]] | sort')
+    # Count unique files
+    unique_count=$(echo "$output" | jq '[.chunks[].files[]] | unique | length')
+    total_count=$(echo "$output" | jq '[.chunks[].files[]] | length')
+    # No duplicates
+    [ "$unique_count" = "$total_count" ]
+
+    # Total files should equal the number of diff segments in the original
+    expected_count=$(echo "$diff_content" | grep -c '^diff --git' || true)
+    [ "$total_count" -eq "$expected_count" ]
+}
+
+# =============================================================================
+# Configuration override tests
+# =============================================================================
+
+@test "chunk-diff: custom config overrides defaults" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+
+    # With very low threshold, even a small diff should be chunked
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 5, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 5}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    # Should be chunked since there are >5 files
+    echo "$output" | jq -e '.chunked == true'
+
+    # Each chunk should have at most 5 files
+    echo "$output" | jq -e '.chunks | all(.files | length <= 5)'
+}
+
+@test "chunk-diff: respects max_files_per_chunk" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 5, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 6}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+    echo "$output" | jq -e '.chunks | all(.files | length <= 6)'
+}
+
+@test "chunk-diff: missing config fields use defaults" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    # No config at all - should use defaults
+    local input
+    input=$(jq -n --arg diff "$diff_content" '{"diff": $diff}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # Small diff should not be chunked with default thresholds
+    echo "$output" | jq -e '.chunked == false'
+}
+
+# =============================================================================
+# Single file edge case tests
+# =============================================================================
+
+@test "chunk-diff: single file diff returns chunked false" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/simple-single-file.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 0, "min_chunk_threshold_kb": 0}}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # A single file can never produce multiple chunks
+    echo "$output" | jq -e '.chunked == false'
+}
+
+@test "chunk-diff: all files in one directory may produce single chunk" {
+    # Generate a diff where all files are in the same directory
+    local diff=""
+    for i in $(seq 1 5); do
+        diff="${diff}diff --git a/src/file${i}.py b/src/file${i}.py
+index abc..def 100644
+--- a/src/file${i}.py
++++ b/src/file${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+
+    local input
+    input=$(jq -n --arg diff "$diff" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 3, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 10}}')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # 5 files in one directory with max 10 per chunk should fit in one chunk
+    echo "$output" | jq -e '.chunked == false'
+}
+
+# =============================================================================
+# Chunk label tests
+# =============================================================================
+
+@test "chunk-diff: chunk labels contain file count" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    # Every label should contain "files"
+    echo "$output" | jq -e '.chunks | all(.label | contains("files"))'
+}
+
+# =============================================================================
+# Reason string tests
+# =============================================================================
+
+@test "chunk-diff: chunked reason mentions exceeds threshold" {
+    local diff_content
+    diff_content=$(cat "$FIXTURES_DIR/multi-directory.diff")
+    local input
+    input=$(jq -n --arg diff "$diff_content" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 10, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 8}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.reason')" == *"exceeds threshold"* ]]
+}

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -786,10 +786,12 @@ teardown() {
 }
 
 @test "review-orchestrator.sh: chunk threshold env vars are respected" {
-    # Generate many files to trigger chunking with low threshold
+    # Generate many files and stage them to trigger chunking with low threshold.
+    # Files must be staged so they appear in the diff for local mode.
     for i in $(seq 1 15); do
         echo "content $i" > "file${i}.txt"
     done
+    git add .
 
     export REVIEW_CODE_CHUNK_THRESHOLD_FILES=5
     export REVIEW_CODE_CHUNK_THRESHOLD_KB=0
@@ -800,11 +802,9 @@ teardown() {
 
     # With 15 files and threshold of 5, chunking should activate
     has_chunks=$(echo "$output" | jq 'has("chunks")')
-    if [ "$has_chunks" = "true" ]; then
-        # Verify chunk_metadata is present too
-        echo "$output" | jq -e '.chunk_metadata.chunked == true'
-        echo "$output" | jq -e '.chunk_metadata.chunk_count > 1'
-    fi
+    [ "$has_chunks" = "true" ]
+    echo "$output" | jq -e '.chunk_metadata.chunked == true'
+    echo "$output" | jq -e '.chunk_metadata.chunk_count > 1'
 
     # The full diff must still be present
     echo "$output" | jq -e 'has("diff")'

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -757,3 +757,55 @@ teardown() {
     branch=$(echo "$output" | jq -r '.branch')
     [ "$branch" = "feature-branch" ]
 }
+
+# =============================================================================
+# Diff chunking integration tests
+# =============================================================================
+
+@test "review-orchestrator.sh: small diff does not produce chunks field" {
+    echo "change" > file.txt
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+    [ "$status" -eq 0 ]
+    has_chunks=$(echo "$output" | jq 'has("chunks")')
+    [ "$has_chunks" = "false" ]
+}
+
+@test "review-orchestrator.sh: small diff does not produce chunk_metadata field" {
+    echo "change" > file.txt
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+    [ "$status" -eq 0 ]
+    has_meta=$(echo "$output" | jq 'has("chunk_metadata")')
+    [ "$has_meta" = "false" ]
+}
+
+@test "review-orchestrator.sh: diff field always present regardless of chunking" {
+    echo "change" > file.txt
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("diff")'
+}
+
+@test "review-orchestrator.sh: chunk threshold env vars are respected" {
+    # Generate many files to trigger chunking with low threshold
+    for i in $(seq 1 15); do
+        echo "content $i" > "file${i}.txt"
+    done
+
+    export REVIEW_CODE_CHUNK_THRESHOLD_FILES=5
+    export REVIEW_CODE_CHUNK_THRESHOLD_KB=0
+    export REVIEW_CODE_CHUNK_MAX_FILES=4
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"
+    [ "$status" -eq 0 ]
+
+    # With 15 files and threshold of 5, chunking should activate
+    has_chunks=$(echo "$output" | jq 'has("chunks")')
+    if [ "$has_chunks" = "true" ]; then
+        # Verify chunk_metadata is present too
+        echo "$output" | jq -e '.chunk_metadata.chunked == true'
+        echo "$output" | jq -e '.chunk_metadata.chunk_count > 1'
+    fi
+
+    # The full diff must still be present
+    echo "$output" | jq -e 'has("diff")'
+}


### PR DESCRIPTION
## Summary

- Adds `chunk-diff.sh` that splits oversized diffs into logical chunks using directory proximity, test file pairing, and size balancing heuristics
- Integrates chunking into the review orchestrator and handler so agents process chunks independently
- Activates only when diff exceeds configurable thresholds (default 200KB or 50 files); small PRs are completely unaffected
- Synthesis step deduplicates findings across both agents and chunks

## Test plan

- [ ] 26 new unit tests for `chunk-diff.sh` cover: threshold behavior, test file pairing, directory grouping, size balancing, edge cases
- [ ] 4 new orchestrator tests verify chunking integration
- [ ] All 1032 existing tests still pass
- [ ] Manual test with a large PR (50+ files) to verify chunking activates and produces coherent reviews