### PR TITLE
Add comment drift detection for draft PR reviews

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -41,7 +41,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 **Optional Flags:**
 
 - `--force` or `-f` - Skip the pre-flight context clear prompt
-- `--draft` or `-d` - Create a pending GitHub review with inline comments (PR mode only)
+- `--draft` or `-d` - Create a pending GitHub review with inline comments (PR mode only). Automatically detects and adjusts for comment drift when the PR receives new commits between review generation and draft posting.
 - `--self` - Allow creating draft review on your own PR (for testing)
 
 **Optional File Pattern:**

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -546,7 +546,6 @@ EOF
 **Comment drift detection:** When `review_commit` is provided, `create-draft-review.sh` automatically detects if the PR received new commits since the review was generated. If comments have drifted, it remaps them to their correct positions using content-based matching. Comments that cannot be remapped are moved to `unmapped_comments`.
 
 **Extracting `line_content`:** For each comment, extract the code at the target file:line from the diff. Find the file in the diff, locate the target line number within the hunks, and use the code text at that line (without the `+`/`-`/` ` prefix). This enables content-based matching for drift detection.
-```
 
 **IMPORTANT**: The `summary` field is the casual top-level comment on a GitHub review. Keep it brief — 1-2 short sentences at most. The author already knows what their PR does; never restate or narrate the approach back to them.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -531,14 +531,21 @@ EOF
   "repo": "<repo from session>",
   "pr_number": <number from session>,
   "reviewer_username": "<reviewer from session>",
+  "review_commit": "<pr.head_sha from session, if available>",
+  "original_diff": "<diff from session data>",
   "summary": "<Short, conversational summary — see guidance below>",
   "comments": [
-    {"path": "file.ts", "line": 42, "side": "RIGHT", "body": "Clean comment text"}
+    {"path": "file.ts", "line": 42, "side": "RIGHT", "body": "Clean comment text", "line_content": "    the_actual_code()"}
   ],
   "unmapped_comments": [
     {"description": "General finding that couldn't be mapped to diff"}
   ]
 }
+```
+
+**Comment drift detection:** When `review_commit` is provided, `create-draft-review.sh` automatically detects if the PR received new commits since the review was generated. If comments have drifted, it remaps them to their correct positions using content-based matching. Comments that cannot be remapped are moved to `unmapped_comments`.
+
+**Extracting `line_content`:** For each comment, extract the code at the target file:line from the diff. Find the file in the diff, locate the target line number within the hunks, and use the code text at that line (without the `+`/`-`/` ` prefix). This enables content-based matching for drift detection.
 ```
 
 **IMPORTANT**: The `summary` field is the casual top-level comment on a GitHub review. Keep it brief — 1-2 short sentences at most. The author already knows what their PR does; never restate or narrate the approach back to them.
@@ -590,6 +597,8 @@ Review: <review_url>
 Summary:
 - Inline comments: X
 - Summary comments: Y
+{If drift_detected is true:}
+- Note: PR received new commits since review. Comments were adjusted to match current diff.
 
 The review is in PENDING state. Visit GitHub to:
 - Edit or remove any comments
@@ -668,10 +677,11 @@ mode: <mode>
 pr_number: <pr_number if applicable>
 org: <org>
 repo: <repo>
+review_commit: <pr.head_sha if PR mode, omit otherwise>
 -->
 ```
 
-This metadata is used by the learning system to determine when the review was created.
+This metadata is used by the learning system to determine when the review was created. The `review_commit` field records the PR's HEAD SHA at review time, enabling drift detection when creating draft reviews later.
 
 ### Cleanup Session
 

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -154,12 +154,13 @@ main() {
     validate_json "${input}" || exit 1
 
     # Extract fields
-    local owner repo pr_number reviewer summary comments unmapped_comments
+    local owner repo pr_number reviewer summary comments unmapped_comments review_commit
     owner=$(echo "${input}" | jq -r '.owner')
     repo=$(echo "${input}" | jq -r '.repo')
     pr_number=$(echo "${input}" | jq -r '.pr_number')
     reviewer=$(echo "${input}" | jq -r '.reviewer_username')
     summary=$(echo "${input}" | jq -r '.summary // ""')
+    review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
     comments=$(echo "${input}" | jq -c '.comments // []')
     unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
 
@@ -170,21 +171,12 @@ main() {
     require_field "${reviewer}" "reviewer_username" || exit 1
 
     # Run drift detection if review_commit is provided
-    local review_commit drift_detected=false
-    review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
+    local drift_detected=false
 
     if [[ -n "${review_commit}" ]] && [[ "${review_commit}" != "null" ]]; then
-        local drift_input drift_result
-        drift_input=$(echo "${input}" | jq -c '{
-            owner: .owner,
-            repo: .repo,
-            pr_number: .pr_number,
-            review_commit: .review_commit,
-            comments: .comments,
-            original_diff: (.original_diff // "")
-        }')
-
-        if drift_result=$(echo "${drift_input}" | "${SCRIPT_DIR}/detect-comment-drift.sh"); then
+        local drift_result
+        # Pass input directly; detect-comment-drift.sh ignores extra fields
+        if drift_result=$(echo "${input}" | "${SCRIPT_DIR}/detect-comment-drift.sh"); then
             drift_detected=$(echo "${drift_result}" | jq -r '.drift_detected')
 
             if [[ "${drift_detected}" == "true" ]]; then
@@ -209,30 +201,28 @@ main() {
         fi
     fi
 
-    # Validate comments have required fields and filter out invalid ones
-    # Required: path, line, body
-    # Optional but validated: side (must be "LEFT" or "RIGHT" if present)
-    local valid_comments invalid_count
-    valid_comments=$(echo "${comments}" | jq -c '[.[] | select(
-        .path != null and .line != null and .body != null and
-        (.side == null or .side == "LEFT" or .side == "RIGHT")
-    )]')
-    invalid_count=$(echo "${comments}" | jq '[.[] | select(
-        .path == null or .line == null or .body == null or
-        (.side != null and .side != "LEFT" and .side != "RIGHT")
-    )] | length')
+    # Validate comments have required fields, filter invalid ones, and strip to API fields.
+    # Single pass: partition into valid and invalid, then extract counts and filtered items.
+    local validation_result
+    validation_result=$(echo "${comments}" | jq -c '{
+        valid: [.[] | select(
+            .path != null and .line != null and .body != null and
+            (.side == null or .side == "LEFT" or .side == "RIGHT")
+        ) | {path, line, side, body}],
+        invalid: [.[] | select(
+            .path == null or .line == null or .body == null or
+            (.side != null and .side != "LEFT" and .side != "RIGHT")
+        )]
+    }')
+    comments=$(echo "${validation_result}" | jq -c '.valid')
+    local invalid_count
+    invalid_count=$(echo "${validation_result}" | jq '.invalid | length')
 
     if [[ "${invalid_count}" -gt 0 ]]; then
         warning "${invalid_count} comments filtered out due to missing required fields or invalid side value"
         echo "Filtered comments:" >&2
-        echo "${comments}" | jq -c '.[] | select(
-            .path == null or .line == null or .body == null or
-            (.side != null and .side != "LEFT" and .side != "RIGHT")
-        )' >&2
+        echo "${validation_result}" | jq -c '.invalid[]' >&2
     fi
-
-    # Use validated comments, stripped to API-recognized fields only
-    comments=$(echo "${valid_comments}" | jq -c '[.[] | {path, line, side, body}]')
 
     # Check for existing pending review
     local existing_review

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -204,16 +204,14 @@ main() {
     # Validate comments have required fields, filter invalid ones, and strip to API fields.
     # Single pass: partition into valid and invalid, then extract counts and filtered items.
     local validation_result
-    validation_result=$(echo "${comments}" | jq -c '{
-        valid: [.[] | select(
+    validation_result=$(echo "${comments}" | jq -c '
+        def is_valid:
             .path != null and .line != null and .body != null and
-            (.side == null or .side == "LEFT" or .side == "RIGHT")
-        ) | {path, line, side, body}],
-        invalid: [.[] | select(
-            .path == null or .line == null or .body == null or
-            (.side != null and .side != "LEFT" and .side != "RIGHT")
-        )]
-    }')
+            (.side == null or .side == "LEFT" or .side == "RIGHT");
+        {
+            valid: [.[] | select(is_valid) | {path, line, side, body}],
+            invalid: [.[] | select(is_valid | not)]
+        }')
     comments=$(echo "${validation_result}" | jq -c '.valid')
     local invalid_count
     invalid_count=$(echo "${validation_result}" | jq '.invalid | length')

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -161,6 +161,13 @@ main() {
     reviewer=$(echo "${input}" | jq -r '.reviewer_username')
     summary=$(echo "${input}" | jq -r '.summary // ""')
     comments=$(echo "${input}" | jq -c '.comments // []')
+    unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
+
+    # Validate required fields early, before any network calls
+    require_field "${owner}" "owner" || exit 1
+    require_field "${repo}" "repo" || exit 1
+    require_field "${pr_number}" "pr_number" || exit 1
+    require_field "${reviewer}" "reviewer_username" || exit 1
 
     # Run drift detection if review_commit is provided
     local review_commit drift_detected=false
@@ -191,10 +198,8 @@ main() {
                 # Merge drift unmapped comments into the existing unmapped_comments
                 local drift_unmapped
                 drift_unmapped=$(echo "${drift_result}" | jq -c '.unmapped_comments // []')
-                local existing_unmapped
-                existing_unmapped=$(echo "${input}" | jq -c '.unmapped_comments // []')
                 unmapped_comments=$(jq -n \
-                    --argjson existing "${existing_unmapped}" \
+                    --argjson existing "${unmapped_comments}" \
                     --argjson drift "${drift_unmapped}" \
                     '$existing + $drift')
             fi
@@ -226,18 +231,8 @@ main() {
         )' >&2
     fi
 
-    # Use validated comments
-    comments="${valid_comments}"
-    # Only set unmapped_comments from input if drift detection didn't already merge them
-    if [[ -z "${unmapped_comments:-}" ]]; then
-        unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
-    fi
-
-    # Validate required fields
-    require_field "${owner}" "owner" || exit 1
-    require_field "${repo}" "repo" || exit 1
-    require_field "${pr_number}" "pr_number" || exit 1
-    require_field "${reviewer}" "reviewer_username" || exit 1
+    # Use validated comments, stripped to API-recognized fields only
+    comments=$(echo "${valid_comments}" | jq -c '[.[] | {path, line, side, body}]')
 
     # Check for existing pending review
     local existing_review

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -15,8 +15,10 @@
 #     "pr_number": 123,
 #     "reviewer_username": "haacked",
 #     "summary": "Overall review summary...",
+#     "review_commit": "abc123...",           (optional: enables drift detection)
+#     "original_diff": "diff --git ...",      (optional: original diff for content matching)
 #     "comments": [
-#       {"path": "src/auth.ts", "line": 42, "side": "RIGHT", "body": "Consider..."},
+#       {"path": "src/auth.ts", "line": 42, "side": "RIGHT", "body": "Consider...", "line_content": "    some_code()"},
 #       {"path": "src/utils.ts", "line": 15, "side": "RIGHT", "body": "This could..."}
 #     ],
 #     "unmapped_comments": [
@@ -31,7 +33,8 @@
 #     "review_url": "https://github.com/org/repo/pull/123#pullrequestreview-12345",
 #     "inline_count": 5,
 #     "summary_count": 2,
-#     "replaced_existing": true
+#     "replaced_existing": true,
+#     "drift_detected": false
 #   }
 
 set -euo pipefail
@@ -159,6 +162,48 @@ main() {
     summary=$(echo "${input}" | jq -r '.summary // ""')
     comments=$(echo "${input}" | jq -c '.comments // []')
 
+    # Run drift detection if review_commit is provided
+    local review_commit drift_detected=false
+    review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
+
+    if [[ -n "${review_commit}" ]] && [[ "${review_commit}" != "null" ]]; then
+        local drift_input drift_result
+        drift_input=$(echo "${input}" | jq -c '{
+            owner: .owner,
+            repo: .repo,
+            pr_number: .pr_number,
+            review_commit: .review_commit,
+            comments: .comments,
+            original_diff: (.original_diff // "")
+        }')
+
+        if drift_result=$(echo "${drift_input}" | "${SCRIPT_DIR}/detect-comment-drift.sh"); then
+            drift_detected=$(echo "${drift_result}" | jq -r '.drift_detected')
+
+            if [[ "${drift_detected}" == "true" ]]; then
+                local drift_summary
+                drift_summary=$(echo "${drift_result}" | jq -r '.drift_summary // ""')
+                warning "Comment drift detected: ${drift_summary}"
+
+                # Replace comments with remapped versions
+                comments=$(echo "${drift_result}" | jq -c '.comments // []')
+
+                # Merge drift unmapped comments into the existing unmapped_comments
+                local drift_unmapped
+                drift_unmapped=$(echo "${drift_result}" | jq -c '.unmapped_comments // []')
+                local existing_unmapped
+                existing_unmapped=$(echo "${input}" | jq -c '.unmapped_comments // []')
+                unmapped_comments=$(jq -n \
+                    --argjson existing "${existing_unmapped}" \
+                    --argjson drift "${drift_unmapped}" \
+                    '$existing + $drift')
+            fi
+        else
+            # Drift detection failed; proceed with original positions
+            warning "Drift detection failed, using original comment positions"
+        fi
+    fi
+
     # Validate comments have required fields and filter out invalid ones
     # Required: path, line, body
     # Optional but validated: side (must be "LEFT" or "RIGHT" if present)
@@ -183,7 +228,10 @@ main() {
 
     # Use validated comments
     comments="${valid_comments}"
-    unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
+    # Only set unmapped_comments from input if drift detection didn't already merge them
+    if [[ -z "${unmapped_comments:-}" ]]; then
+        unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
+    fi
 
     # Validate required fields
     require_field "${owner}" "owner" || exit 1
@@ -252,13 +300,15 @@ main() {
         --argjson inline_count "${inline_count}" \
         --argjson summary_count "${unmapped_count}" \
         --argjson replaced_existing "${replaced_existing}" \
+        --argjson drift_detected "${drift_detected}" \
         '{
             success: $success,
             review_id: $review_id,
             review_url: $review_url,
             inline_count: $inline_count,
             summary_count: $summary_count,
-            replaced_existing: $replaced_existing
+            replaced_existing: $replaced_existing,
+            drift_detected: $drift_detected
         }'
 }
 

--- a/skills/review-code/scripts/detect-comment-drift.sh
+++ b/skills/review-code/scripts/detect-comment-drift.sh
@@ -16,7 +16,7 @@
 #     "pr_number": 123,
 #     "review_commit": "abc123...",
 #     "comments": [
-#       {"path": "src/foo.py", "line": 42, "side": "RIGHT", "body": "...", "line_content": "+    some_code()"}
+#       {"path": "src/foo.py", "line": 42, "side": "RIGHT", "body": "...", "line_content": "    some_code()"}
 #     ],
 #     "original_diff": "<optional: the diff from review time>"
 #   }
@@ -237,14 +237,14 @@ find_line_in_diff() {
 
     # If multiple matches, pick the closest to the original line
     local best_match=""
-    local best_distance=999999
+    local best_distance=""
     while IFS= read -r match_line; do
         local distance
         distance=$((match_line - original_line))
         if [[ ${distance} -lt 0 ]]; then
             distance=$((-distance))
         fi
-        if [[ ${distance} -lt ${best_distance} ]]; then
+        if [[ -z "${best_distance}" ]] || [[ ${distance} -lt ${best_distance} ]]; then
             best_distance=${distance}
             best_match=${match_line}
         fi
@@ -260,7 +260,7 @@ file_in_diff() {
     local diff="$1"
     local target_path="$2"
 
-    if echo "${diff}" | grep -q "^diff --git a/${target_path} b/${target_path}"; then
+    if [[ "${diff}" == *"diff --git a/${target_path} b/${target_path}"* ]]; then
         echo "true"
     else
         echo "false"
@@ -269,17 +269,17 @@ file_in_diff() {
 
 # Remap a single comment against the current diff.
 # Uses content-based matching to find where the comment's target line moved.
-# Args: reads from environment variables set by caller
-# Output: JSON object with remapped comment or unmapped entry
+# Args: $1 = comment JSON, $2 = original_diff, $3 = current_diff
+# Output: JSON object with remapped comment (return 0) or unmapped entry (return 1)
 remap_comment() {
     local comment="$1"
     local original_diff="$2"
     local current_diff="$3"
 
     local path line line_content
-    path=$(echo "${comment}" | jq -r '.path')
-    line=$(echo "${comment}" | jq -r '.line')
-    line_content=$(echo "${comment}" | jq -r '.line_content // ""')
+    read -r path line line_content < <(
+        echo "${comment}" | jq -r '[.path, (.line | tostring), (.line_content // "")] | @tsv'
+    )
 
     # If line_content wasn't provided, try to extract it from the original diff
     if [[ -z "${line_content}" ]] && [[ -n "${original_diff}" ]]; then
@@ -329,10 +329,9 @@ main() {
 
     # Extract fields
     local owner repo pr_number review_commit comments original_diff
-    owner=$(echo "${input}" | jq -r '.owner')
-    repo=$(echo "${input}" | jq -r '.repo')
-    pr_number=$(echo "${input}" | jq -r '.pr_number')
-    review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
+    read -r owner repo pr_number review_commit < <(
+        echo "${input}" | jq -r '[.owner, .repo, (.pr_number | tostring), (.review_commit // "")] | @tsv'
+    )
     comments=$(echo "${input}" | jq -c '.comments // []')
     original_diff=$(echo "${input}" | jq -r '.original_diff // ""')
 
@@ -413,8 +412,8 @@ main() {
     fi
 
     # Remap each comment
-    local remapped_comments="[]"
-    local unmapped_comments="[]"
+    local remapped_results=""
+    local unmapped_results=""
     local remapped_count=0
     local unmapped_count=0
     local comment_count
@@ -436,9 +435,10 @@ main() {
     fi
 
     while IFS= read -r comment; do
+        # remap_comment writes JSON to stdout in both success and failure paths
         local result
         if result=$(remap_comment "${comment}" "${original_diff}" "${current_diff}"); then
-            remapped_comments=$(echo "${remapped_comments}" | jq --argjson c "${result}" '. + [$c]')
+            remapped_results+="${result}"$'\n'
             # Count actual remaps (where the line moved)
             local was_remapped
             was_remapped=$(echo "${result}" | jq -r '.remapped // false')
@@ -446,10 +446,23 @@ main() {
                 remapped_count=$((remapped_count + 1))
             fi
         else
-            unmapped_comments=$(echo "${unmapped_comments}" | jq --argjson c "${result}" '. + [$c]')
+            unmapped_results+="${result}"$'\n'
             unmapped_count=$((unmapped_count + 1))
         fi
     done < <(echo "${comments}" | jq -c '.[]')
+
+    # Assemble arrays from collected NDJSON in one jq call each
+    local remapped_comments unmapped_comments
+    if [[ -n "${remapped_results}" ]]; then
+        remapped_comments=$(echo "${remapped_results}" | jq -s '.')
+    else
+        remapped_comments="[]"
+    fi
+    if [[ -n "${unmapped_results}" ]]; then
+        unmapped_comments=$(echo "${unmapped_results}" | jq -s '.')
+    else
+        unmapped_comments="[]"
+    fi
 
     # Build drift summary
     local drift_summary="${remapped_count} comments remapped, ${unmapped_count} unmapped"

--- a/skills/review-code/scripts/detect-comment-drift.sh
+++ b/skills/review-code/scripts/detect-comment-drift.sh
@@ -319,6 +319,27 @@ remap_comment() {
     return 0
 }
 
+# Build and emit the standard drift result JSON.
+# Args: $1 = drift_detected (true/false), $2 = review_commit, $3 = current_commit,
+#       $4 = comments JSON array, $5 = unmapped_comments JSON array, $6 = drift_summary
+emit_drift_result() {
+    jq -n \
+        --argjson drift_detected "${1}" \
+        --arg review_commit "${2}" \
+        --arg current_commit "${3}" \
+        --argjson comments "${4}" \
+        --argjson unmapped_comments "${5}" \
+        --arg drift_summary "${6}" \
+        '{
+            drift_detected: $drift_detected,
+            review_commit: (if $review_commit == "" then null else $review_commit end),
+            current_commit: (if $current_commit == "" then null else $current_commit end),
+            comments: $comments,
+            unmapped_comments: $unmapped_comments,
+            drift_summary: $drift_summary
+        }'
+}
+
 main() {
     # Read input JSON from stdin
     local input
@@ -337,16 +358,7 @@ main() {
 
     # If no review_commit provided, skip drift detection entirely
     if [[ -z "${review_commit}" ]] || [[ "${review_commit}" == "null" ]]; then
-        jq -n \
-            --argjson comments "${comments}" \
-            '{
-                drift_detected: false,
-                review_commit: null,
-                current_commit: null,
-                comments: $comments,
-                unmapped_comments: [],
-                drift_summary: "skipped (no review commit)"
-            }'
+        emit_drift_result false "" "" "${comments}" "[]" "skipped (no review commit)"
         return 0
     fi
 
@@ -359,35 +371,13 @@ main() {
     local current_commit
     if ! current_commit=$(get_current_pr_head "${owner}" "${repo}" "${pr_number}" 2>&1); then
         warning "Failed to fetch current PR HEAD: ${current_commit}"
-        # Non-fatal: return original comments unchanged
-        jq -n \
-            --arg review_commit "${review_commit}" \
-            --argjson comments "${comments}" \
-            '{
-                drift_detected: false,
-                review_commit: $review_commit,
-                current_commit: null,
-                comments: $comments,
-                unmapped_comments: [],
-                drift_summary: "skipped (failed to fetch current HEAD)"
-            }'
+        emit_drift_result false "${review_commit}" "" "${comments}" "[]" "skipped (failed to fetch current HEAD)"
         return 0
     fi
 
     # If commits match, no drift
     if [[ "${review_commit}" == "${current_commit}" ]]; then
-        jq -n \
-            --arg review_commit "${review_commit}" \
-            --arg current_commit "${current_commit}" \
-            --argjson comments "${comments}" \
-            '{
-                drift_detected: false,
-                review_commit: $review_commit,
-                current_commit: $current_commit,
-                comments: $comments,
-                unmapped_comments: [],
-                drift_summary: "no drift (same commit)"
-            }'
+        emit_drift_result false "${review_commit}" "${current_commit}" "${comments}" "[]" "no drift (same commit)"
         return 0
     fi
 
@@ -395,42 +385,19 @@ main() {
     local current_diff
     if ! current_diff=$(fetch_current_diff "${owner}" "${repo}" "${pr_number}" 2>&1); then
         warning "Failed to fetch current diff: ${current_diff}"
-        # Non-fatal: return original comments unchanged
-        jq -n \
-            --arg review_commit "${review_commit}" \
-            --arg current_commit "${current_commit}" \
-            --argjson comments "${comments}" \
-            '{
-                drift_detected: true,
-                review_commit: $review_commit,
-                current_commit: $current_commit,
-                comments: $comments,
-                unmapped_comments: [],
-                drift_summary: "drift detected but remap failed (could not fetch current diff)"
-            }'
+        emit_drift_result true "${review_commit}" "${current_commit}" "${comments}" "[]" "drift detected but remap failed (could not fetch current diff)"
         return 0
     fi
 
     # Remap each comment
     local remapped_results=""
     local unmapped_results=""
-    local remapped_count=0
     local unmapped_count=0
     local comment_count
     comment_count=$(echo "${comments}" | jq 'length')
 
     if [[ "${comment_count}" -eq 0 ]]; then
-        jq -n \
-            --arg review_commit "${review_commit}" \
-            --arg current_commit "${current_commit}" \
-            '{
-                drift_detected: true,
-                review_commit: $review_commit,
-                current_commit: $current_commit,
-                comments: [],
-                unmapped_comments: [],
-                drift_summary: "drift detected, no comments to remap"
-            }'
+        emit_drift_result true "${review_commit}" "${current_commit}" "[]" "[]" "drift detected, no comments to remap"
         return 0
     fi
 
@@ -439,12 +406,6 @@ main() {
         local result
         if result=$(remap_comment "${comment}" "${original_diff}" "${current_diff}"); then
             remapped_results+="${result}"$'\n'
-            # Count actual remaps (where the line moved)
-            local was_remapped
-            was_remapped=$(echo "${result}" | jq -r '.remapped // false')
-            if [[ "${was_remapped}" == "true" ]]; then
-                remapped_count=$((remapped_count + 1))
-            fi
         else
             unmapped_results+="${result}"$'\n'
             unmapped_count=$((unmapped_count + 1))
@@ -464,23 +425,12 @@ main() {
         unmapped_comments="[]"
     fi
 
-    # Build drift summary
-    local drift_summary="${remapped_count} comments remapped, ${unmapped_count} unmapped"
+    # Count actual remaps (where the line moved) in one pass
+    local remapped_count
+    remapped_count=$(echo "${remapped_comments}" | jq '[.[] | select(.remapped == true)] | length')
 
-    jq -n \
-        --arg review_commit "${review_commit}" \
-        --arg current_commit "${current_commit}" \
-        --argjson comments "${remapped_comments}" \
-        --argjson unmapped_comments "${unmapped_comments}" \
-        --arg drift_summary "${drift_summary}" \
-        '{
-            drift_detected: true,
-            review_commit: $review_commit,
-            current_commit: $current_commit,
-            comments: $comments,
-            unmapped_comments: $unmapped_comments,
-            drift_summary: $drift_summary
-        }'
+    local drift_summary="${remapped_count} comments remapped, ${unmapped_count} unmapped"
+    emit_drift_result true "${review_commit}" "${current_commit}" "${remapped_comments}" "${unmapped_comments}" "${drift_summary}"
 }
 
 # Only run main if script is executed directly (not sourced)

--- a/skills/review-code/scripts/detect-comment-drift.sh
+++ b/skills/review-code/scripts/detect-comment-drift.sh
@@ -1,0 +1,476 @@
+#!/usr/bin/env bash
+# detect-comment-drift.sh - Detect and remap drifted PR review comments
+#
+# When a PR receives new commits between review generation and draft posting,
+# line numbers drift. This script detects that drift by comparing the review's
+# commit SHA against the PR's current HEAD, then re-maps comments to their
+# correct positions using content-based matching.
+#
+# Usage:
+#   echo '<json_input>' | detect-comment-drift.sh
+#
+# Input JSON:
+#   {
+#     "owner": "org",
+#     "repo": "repo",
+#     "pr_number": 123,
+#     "review_commit": "abc123...",
+#     "comments": [
+#       {"path": "src/foo.py", "line": 42, "side": "RIGHT", "body": "...", "line_content": "+    some_code()"}
+#     ],
+#     "original_diff": "<optional: the diff from review time>"
+#   }
+#
+# Output JSON:
+#   {
+#     "drift_detected": false|true,
+#     "review_commit": "abc123...",
+#     "current_commit": "def456...",
+#     "comments": [...remapped comments...],
+#     "unmapped_comments": [...comments that couldn't be placed...],
+#     "drift_summary": "3 comments remapped, 1 unmapped"
+#   }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=lib/helpers/json-helpers.sh
+source "${SCRIPT_DIR}/helpers/json-helpers.sh"
+# shellcheck source=lib/helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
+# Fetch the current HEAD commit SHA for a PR
+# Args: $1 = owner, $2 = repo, $3 = pr_number
+# Output: commit SHA string
+get_current_pr_head() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+
+    gh api "repos/${owner}/${repo}/pulls/${pr_number}" --jq '.head.sha'
+}
+
+# Fetch the current diff for a PR
+# Args: $1 = owner, $2 = repo, $3 = pr_number
+# Output: unified diff content
+fetch_current_diff() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+
+    gh pr diff "${pr_number}" --repo "${owner}/${repo}"
+}
+
+# Extract the line content at a given file path and line number from a diff.
+# Parses the diff to find the file's hunks and locates the content at the
+# specified new-file line number.
+# Args: $1 = diff, $2 = file path, $3 = line number
+# Output: the line content (with +/- prefix stripped), or empty if not found
+extract_line_content_from_diff() {
+    local diff="$1"
+    local target_path="$2"
+    local target_line="$3"
+
+    echo "${diff}" | awk -v target_path="${target_path}" -v target_line="${target_line}" '
+    BEGIN {
+        in_file = 0
+        new_line = 0
+        in_hunk = 0
+    }
+
+    /^diff --git/ {
+        # Extract b/ path
+        idx = match($0, / b\//)
+        if (idx > 0) {
+            current_file = substr($0, idx + 3)
+            in_file = (current_file == target_path)
+        } else {
+            in_file = 0
+        }
+        in_hunk = 0
+        next
+    }
+
+    /^@@/ && in_file {
+        # Parse +N from hunk header for new line start
+        idx = index($0, "+")
+        if (idx > 0) {
+            rest = substr($0, idx + 1)
+            gsub(/[^0-9].*/, "", rest)
+            new_line = rest + 0
+        }
+        in_hunk = 1
+        next
+    }
+
+    !in_file || !in_hunk { next }
+
+    # Skip file-level diff headers
+    /^---/ || /^\+\+\+/ { next }
+
+    # Removed line (-) only advances old line counter
+    /^-/ {
+        next
+    }
+
+    # Added line (+)
+    /^\+/ {
+        if (new_line == target_line) {
+            print substr($0, 2)
+            exit
+        }
+        new_line++
+        next
+    }
+
+    # Context line (space prefix or blank line within a hunk).
+    # Git may strip the leading space from blank context lines, so an
+    # empty line inside a hunk is treated as context.
+    {
+        if (new_line == target_line) {
+            if (substr($0, 1, 1) == " ") {
+                print substr($0, 2)
+            } else {
+                print $0
+            }
+            exit
+        }
+        new_line++
+    }
+    '
+}
+
+# Search a diff for a line with matching content in a specific file.
+# Returns the new line number where the content appears, or nothing if not found.
+# When multiple matches exist, returns the one closest to the original line.
+# Args: $1 = diff, $2 = file path, $3 = line content to find, $4 = original line number
+# Output: the new line number, or empty if not found
+find_line_in_diff() {
+    local diff="$1"
+    local target_path="$2"
+    local content="$3"
+    local original_line="$4"
+
+    # Normalize the search content by trimming whitespace
+    local trimmed_content
+    trimmed_content=$(echo "${content}" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//')
+
+    if [[ -z "${trimmed_content}" ]]; then
+        return
+    fi
+
+    # Find all matching line numbers in the file within the diff
+    local matches
+    matches=$(echo "${diff}" | awk -v target_path="${target_path}" -v trimmed_content="${trimmed_content}" '
+    BEGIN {
+        in_file = 0
+        new_line = 0
+        in_hunk = 0
+    }
+
+    /^diff --git/ {
+        idx = match($0, / b\//)
+        if (idx > 0) {
+            current_file = substr($0, idx + 3)
+            in_file = (current_file == target_path)
+        } else {
+            in_file = 0
+        }
+        in_hunk = 0
+        next
+    }
+
+    /^@@/ && in_file {
+        idx = index($0, "+")
+        if (idx > 0) {
+            rest = substr($0, idx + 1)
+            gsub(/[^0-9].*/, "", rest)
+            new_line = rest + 0
+        }
+        in_hunk = 1
+        next
+    }
+
+    !in_file || !in_hunk { next }
+
+    # Skip file-level diff headers
+    /^---/ || /^\+\+\+/ { next }
+
+    # Removed line
+    /^-/ {
+        next
+    }
+
+    # Added line
+    /^\+/ {
+        line_text = substr($0, 2)
+        gsub(/^[[:space:]]+/, "", line_text)
+        gsub(/[[:space:]]+$/, "", line_text)
+        if (line_text == trimmed_content) {
+            print new_line
+        }
+        new_line++
+        next
+    }
+
+    # Context line (space prefix or blank line within a hunk)
+    {
+        if (substr($0, 1, 1) == " ") {
+            line_text = substr($0, 2)
+        } else {
+            line_text = $0
+        }
+        gsub(/^[[:space:]]+/, "", line_text)
+        gsub(/[[:space:]]+$/, "", line_text)
+        if (line_text == trimmed_content) {
+            print new_line
+        }
+        new_line++
+    }
+    ')
+
+    if [[ -z "${matches}" ]]; then
+        return
+    fi
+
+    # If multiple matches, pick the closest to the original line
+    local best_match=""
+    local best_distance=999999
+    while IFS= read -r match_line; do
+        local distance
+        distance=$((match_line - original_line))
+        if [[ ${distance} -lt 0 ]]; then
+            distance=$((-distance))
+        fi
+        if [[ ${distance} -lt ${best_distance} ]]; then
+            best_distance=${distance}
+            best_match=${match_line}
+        fi
+    done <<< "${matches}"
+
+    echo "${best_match}"
+}
+
+# Check whether a file appears in the diff
+# Args: $1 = diff, $2 = file path
+# Output: "true" or "false"
+file_in_diff() {
+    local diff="$1"
+    local target_path="$2"
+
+    if echo "${diff}" | grep -q "^diff --git a/${target_path} b/${target_path}"; then
+        echo "true"
+    else
+        echo "false"
+    fi
+}
+
+# Remap a single comment against the current diff.
+# Uses content-based matching to find where the comment's target line moved.
+# Args: reads from environment variables set by caller
+# Output: JSON object with remapped comment or unmapped entry
+remap_comment() {
+    local comment="$1"
+    local original_diff="$2"
+    local current_diff="$3"
+
+    local path line line_content
+    path=$(echo "${comment}" | jq -r '.path')
+    line=$(echo "${comment}" | jq -r '.line')
+    line_content=$(echo "${comment}" | jq -r '.line_content // ""')
+
+    # If line_content wasn't provided, try to extract it from the original diff
+    if [[ -z "${line_content}" ]] && [[ -n "${original_diff}" ]]; then
+        line_content=$(extract_line_content_from_diff "${original_diff}" "${path}" "${line}")
+    fi
+
+    # If we still have no line content, we cannot remap this comment
+    if [[ -z "${line_content}" ]]; then
+        echo "${comment}" | jq '{path, line, side: (.side // "RIGHT"), body, reason: "no line content available for matching"}'
+        return 1
+    fi
+
+    # Check if the file still exists in the current diff
+    if [[ "$(file_in_diff "${current_diff}" "${path}")" == "false" ]]; then
+        echo "${comment}" | jq '{path, line, side: (.side // "RIGHT"), body, reason: "file removed from diff"}'
+        return 1
+    fi
+
+    # Search for the content in the current diff
+    local new_line
+    new_line=$(find_line_in_diff "${current_diff}" "${path}" "${line_content}" "${line}")
+
+    if [[ -z "${new_line}" ]]; then
+        echo "${comment}" | jq '{path, line, side: (.side // "RIGHT"), body, reason: "line content not found in current diff"}'
+        return 1
+    fi
+
+    # Return the remapped comment
+    if [[ "${new_line}" -eq "${line}" ]]; then
+        # Line didn't move, no remapping needed
+        echo "${comment}" | jq --argjson new_line "${new_line}" \
+            '. + {remapped: false}'
+    else
+        echo "${comment}" | jq --argjson new_line "${new_line}" --argjson orig_line "${line}" \
+            '. + {line: $new_line, original_line: $orig_line, remapped: true}'
+    fi
+    return 0
+}
+
+main() {
+    # Read input JSON from stdin
+    local input
+    input=$(cat)
+
+    # Validate input
+    validate_json "${input}" || exit 1
+
+    # Extract fields
+    local owner repo pr_number review_commit comments original_diff
+    owner=$(echo "${input}" | jq -r '.owner')
+    repo=$(echo "${input}" | jq -r '.repo')
+    pr_number=$(echo "${input}" | jq -r '.pr_number')
+    review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
+    comments=$(echo "${input}" | jq -c '.comments // []')
+    original_diff=$(echo "${input}" | jq -r '.original_diff // ""')
+
+    # If no review_commit provided, skip drift detection entirely
+    if [[ -z "${review_commit}" ]] || [[ "${review_commit}" == "null" ]]; then
+        jq -n \
+            --argjson comments "${comments}" \
+            '{
+                drift_detected: false,
+                review_commit: null,
+                current_commit: null,
+                comments: $comments,
+                unmapped_comments: [],
+                drift_summary: "skipped (no review commit)"
+            }'
+        return 0
+    fi
+
+    # Validate required fields
+    require_field "${owner}" "owner" || exit 1
+    require_field "${repo}" "repo" || exit 1
+    require_field "${pr_number}" "pr_number" || exit 1
+
+    # Fetch the current PR HEAD
+    local current_commit
+    if ! current_commit=$(get_current_pr_head "${owner}" "${repo}" "${pr_number}" 2>&1); then
+        warning "Failed to fetch current PR HEAD: ${current_commit}"
+        # Non-fatal: return original comments unchanged
+        jq -n \
+            --arg review_commit "${review_commit}" \
+            --argjson comments "${comments}" \
+            '{
+                drift_detected: false,
+                review_commit: $review_commit,
+                current_commit: null,
+                comments: $comments,
+                unmapped_comments: [],
+                drift_summary: "skipped (failed to fetch current HEAD)"
+            }'
+        return 0
+    fi
+
+    # If commits match, no drift
+    if [[ "${review_commit}" == "${current_commit}" ]]; then
+        jq -n \
+            --arg review_commit "${review_commit}" \
+            --arg current_commit "${current_commit}" \
+            --argjson comments "${comments}" \
+            '{
+                drift_detected: false,
+                review_commit: $review_commit,
+                current_commit: $current_commit,
+                comments: $comments,
+                unmapped_comments: [],
+                drift_summary: "no drift (same commit)"
+            }'
+        return 0
+    fi
+
+    # Drift detected: fetch the current diff
+    local current_diff
+    if ! current_diff=$(fetch_current_diff "${owner}" "${repo}" "${pr_number}" 2>&1); then
+        warning "Failed to fetch current diff: ${current_diff}"
+        # Non-fatal: return original comments unchanged
+        jq -n \
+            --arg review_commit "${review_commit}" \
+            --arg current_commit "${current_commit}" \
+            --argjson comments "${comments}" \
+            '{
+                drift_detected: true,
+                review_commit: $review_commit,
+                current_commit: $current_commit,
+                comments: $comments,
+                unmapped_comments: [],
+                drift_summary: "drift detected but remap failed (could not fetch current diff)"
+            }'
+        return 0
+    fi
+
+    # Remap each comment
+    local remapped_comments="[]"
+    local unmapped_comments="[]"
+    local remapped_count=0
+    local unmapped_count=0
+    local comment_count
+    comment_count=$(echo "${comments}" | jq 'length')
+
+    if [[ "${comment_count}" -eq 0 ]]; then
+        jq -n \
+            --arg review_commit "${review_commit}" \
+            --arg current_commit "${current_commit}" \
+            '{
+                drift_detected: true,
+                review_commit: $review_commit,
+                current_commit: $current_commit,
+                comments: [],
+                unmapped_comments: [],
+                drift_summary: "drift detected, no comments to remap"
+            }'
+        return 0
+    fi
+
+    while IFS= read -r comment; do
+        local result
+        if result=$(remap_comment "${comment}" "${original_diff}" "${current_diff}"); then
+            remapped_comments=$(echo "${remapped_comments}" | jq --argjson c "${result}" '. + [$c]')
+            # Count actual remaps (where the line moved)
+            local was_remapped
+            was_remapped=$(echo "${result}" | jq -r '.remapped // false')
+            if [[ "${was_remapped}" == "true" ]]; then
+                remapped_count=$((remapped_count + 1))
+            fi
+        else
+            unmapped_comments=$(echo "${unmapped_comments}" | jq --argjson c "${result}" '. + [$c]')
+            unmapped_count=$((unmapped_count + 1))
+        fi
+    done < <(echo "${comments}" | jq -c '.[]')
+
+    # Build drift summary
+    local drift_summary="${remapped_count} comments remapped, ${unmapped_count} unmapped"
+
+    jq -n \
+        --arg review_commit "${review_commit}" \
+        --arg current_commit "${current_commit}" \
+        --argjson comments "${remapped_comments}" \
+        --argjson unmapped_comments "${unmapped_comments}" \
+        --arg drift_summary "${drift_summary}" \
+        '{
+            drift_detected: true,
+            review_commit: $review_commit,
+            current_commit: $current_commit,
+            comments: $comments,
+            unmapped_comments: $unmapped_comments,
+            drift_summary: $drift_summary
+        }'
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -18,6 +18,7 @@
 #     "url": "https://github.com/PostHog/posthog/pull/123",
 #     "author": "haacked",
 #     "head_ref": "fix-auth",
+#     "head_sha": "abc123def456...",
 #     "base_ref": "main",
 #     "state": "open",
 #     "is_fork": false,
@@ -103,7 +104,7 @@ fetch_pr_metadata() {
         gh_cmd+=(--repo "${repo_spec}")
     fi
 
-    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,baseRefName,state,isCrossRepository
+    "${gh_cmd[@]}" --json number,title,body,url,author,headRefName,headRefOid,baseRefName,state,isCrossRepository
 }
 
 # Fetch PR diff
@@ -273,6 +274,8 @@ main() {
     state=$(echo "${metadata}" | jq -r '.state')
     local is_fork
     is_fork=$(echo "${metadata}" | jq -r '.isCrossRepository // false')
+    local head_sha
+    head_sha=$(echo "${metadata}" | jq -r '.headRefOid // ""')
 
     # Extract org/repo from URL if not already set
     if [[ -z "${org}" ]]; then
@@ -340,6 +343,7 @@ main() {
     "url": "${url}",
     "author": "${author}",
     "head_ref": "${head_ref}",
+    "head_sha": "${head_sha}",
     "base_ref": "${base_ref}",
     "state": "${state}",
     "is_fork": ${is_fork},

--- a/tests/fixtures/diffs/drift-original.diff
+++ b/tests/fixtures/diffs/drift-original.diff
@@ -1,0 +1,32 @@
+diff --git a/src/auth.ts b/src/auth.ts
+index aaa1111..bbb2222 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -1,8 +1,12 @@
+ import { hash } from 'crypto';
+
++export interface AuthConfig {
++    secret: string;
++    expiry: number;
++}
++
+ export function validateToken(token: string): boolean {
+-    return token.length > 0;
++    if (!token) return false;
++    return token.length > 10 && token.startsWith('sk_');
+ }
+
+ export function hashPassword(password: string): string {
+diff --git a/src/utils.ts b/src/utils.ts
+index ccc3333..ddd4444 100644
+--- a/src/utils.ts
++++ b/src/utils.ts
+@@ -1,6 +1,8 @@
+ export function formatDate(date: Date): string {
+     return date.toISOString().split('T')[0];
+ }
++
++export const MAX_RETRIES = 3;
+
+ export function capitalize(str: string): string {
+     if (!str) return str;

--- a/tests/fixtures/diffs/drift-updated.diff
+++ b/tests/fixtures/diffs/drift-updated.diff
@@ -1,0 +1,40 @@
+diff --git a/src/auth.ts b/src/auth.ts
+index aaa1111..eee5555 100644
+--- a/src/auth.ts
++++ b/src/auth.ts
+@@ -1,8 +1,18 @@
+ import { hash } from 'crypto';
++import { logger } from './logger';
++
++export interface AuthConfig {
++    secret: string;
++    expiry: number;
++    refreshWindow: number;
++}
+
++export interface AuthResult {
++    valid: boolean;
++    reason?: string;
++}
+
+ export function validateToken(token: string): boolean {
+-    return token.length > 0;
++    if (!token) return false;
++    logger.debug('Validating token');
++    return token.length > 10 && token.startsWith('sk_');
+ }
+
+ export function hashPassword(password: string): string {
+diff --git a/src/utils.ts b/src/utils.ts
+index ccc3333..fff6666 100644
+--- a/src/utils.ts
++++ b/src/utils.ts
+@@ -1,6 +1,8 @@
+ export function formatDate(date: Date): string {
+     return date.toISOString().split('T')[0];
+ }
++
++export const MAX_RETRIES = 3;
+
+ export function capitalize(str: string): string {
+     if (!str) return str;

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -768,6 +768,60 @@ EOF
     [[ "$output" == *'"success": true'* ]]
 }
 
+@test "create-draft-review: remaps comments when drift is detected" {
+    # Mock: different HEAD SHA triggers drift detection, pr diff returns updated diff
+    local updated_diff="$PROJECT_ROOT/tests/fixtures/diffs/drift-updated.diff"
+    cat > "$MOCK_DIR/gh" << GHEOF
+#!/bin/bash
+if [[ "\$*" == *"--jq"*".head.sha"* ]]; then
+    echo 'def456'
+elif [[ "\$*" == *"pr diff"* ]]; then
+    cat '${updated_diff}'
+elif [[ "\$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "\$*" == *"--method POST"* ]]; then
+    echo '{"id": 12345, "body": "test"}'
+else
+    echo '[]'
+fi
+GHEOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local original_diff
+    original_diff=$(cat "$PROJECT_ROOT/tests/fixtures/diffs/drift-original.diff")
+    local tmpinput
+    tmpinput=$(mktemp)
+
+    local line_content
+    line_content="    return token.length > 10 && token.startsWith('sk_');"
+
+    jq -n \
+        --arg diff "$original_diff" \
+        --arg lc "$line_content" \
+        '{
+            owner: "org",
+            repo: "test",
+            pr_number: 1,
+            reviewer_username: "user",
+            summary: "Test",
+            review_commit: "abc123",
+            original_diff: $diff,
+            comments: [{
+                path: "src/auth.ts",
+                line: 10,
+                side: "RIGHT",
+                body: "Consider validation",
+                line_content: $lc
+            }]
+        }' > "$tmpinput"
+
+    run bash -c "cat '$tmpinput' | '$SCRIPT' 2>/dev/null"
+    rm -f "$tmpinput"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"drift_detected": true'* ]]
+}
+
 @test "create-draft-review: keeps valid comments when filtering ones with bad side" {
     cat > "$MOCK_DIR/gh" << 'EOF'
 #!/bin/bash

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -681,6 +681,93 @@ EOF
     [[ "$output" == *'"inline_count": 0'* ]]
 }
 
+# =============================================================================
+# Drift detection integration tests
+# =============================================================================
+
+@test "create-draft-review: accepts optional review_commit field" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"--jq"*".head.sha"* ]]; then
+    echo 'abc123'
+elif [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 12345, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "review_commit": "abc123", "comments": [{"path": "file.ts", "line": 5, "side": "RIGHT", "body": "Comment"}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+}
+
+@test "create-draft-review: behavior unchanged when review_commit not provided" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 12345, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": [{"path": "file.ts", "line": 5, "side": "RIGHT", "body": "Comment"}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+    [[ "$output" == *'"drift_detected": false'* ]]
+}
+
+@test "create-draft-review: includes drift_detected in output" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 12345, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("drift_detected")'
+}
+
+@test "create-draft-review: drift detection failure is non-fatal" {
+    # Create a gh mock that fails for drift detection API calls but works for review creation
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"--jq"*".head.sha"* ]]; then
+    echo "API error" >&2
+    exit 1
+elif [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 12345, "body": "test"}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "Test", "review_commit": "abc123", "comments": [{"path": "file.ts", "line": 5, "side": "RIGHT", "body": "Comment"}]}'
+    run bash -c "echo '$input' | '$SCRIPT' 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"success": true'* ]]
+}
+
 @test "create-draft-review: keeps valid comments when filtering ones with bad side" {
     cat > "$MOCK_DIR/gh" << 'EOF'
 #!/bin/bash

--- a/tests/unit/test-detect-comment-drift.bats
+++ b/tests/unit/test-detect-comment-drift.bats
@@ -1,0 +1,501 @@
+#!/usr/bin/env bats
+# Tests for detect-comment-drift.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/detect-comment-drift.sh"
+    FIXTURES_DIR="$PROJECT_ROOT/tests/fixtures/diffs"
+
+    # Create temp directory for mock scripts
+    MOCK_DIR=$(mktemp -d)
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+# Helper to create a mock gh command
+create_mock_gh() {
+    local head_sha="$1"
+    local diff_file="${2:-}"
+    cat > "$MOCK_DIR/gh" << GHEOF
+#!/bin/bash
+if [[ "\$*" == *"--jq"*".head.sha"* ]]; then
+    echo '${head_sha}'
+elif [[ "\$*" == *"pr diff"* ]]; then
+    cat '${diff_file}'
+else
+    echo '[]'
+fi
+GHEOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "detect-comment-drift: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "detect-comment-drift: uses set -euo pipefail" {
+    run bash -c "head -40 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "detect-comment-drift: has required functions" {
+    run bash -c "source '$SCRIPT' && declare -f get_current_pr_head > /dev/null"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$SCRIPT' && declare -f fetch_current_diff > /dev/null"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$SCRIPT' && declare -f extract_line_content_from_diff > /dev/null"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$SCRIPT' && declare -f find_line_in_diff > /dev/null"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$SCRIPT' && declare -f remap_comment > /dev/null"
+    [ "$status" -eq 0 ]
+
+    run bash -c "source '$SCRIPT' && declare -f main > /dev/null"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Input validation tests
+# =============================================================================
+
+@test "detect-comment-drift: rejects invalid JSON input" {
+    run bash -c "echo 'not json' | '$SCRIPT'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid JSON"* ]]
+}
+
+# =============================================================================
+# No drift tests (same commit)
+# =============================================================================
+
+@test "detect-comment-drift: no drift when same commit SHA" {
+    create_mock_gh "abc123" ""
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": [{"path": "src/auth.ts", "line": 10, "body": "Consider..."}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == false'
+    echo "$output" | jq -e '.comments | length == 1'
+    echo "$output" | jq -e '.unmapped_comments | length == 0'
+}
+
+@test "detect-comment-drift: returns original comments unchanged when no drift" {
+    create_mock_gh "abc123" ""
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": [{"path": "src/auth.ts", "line": 10, "side": "RIGHT", "body": "Consider..."}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local path line body
+    path=$(echo "$output" | jq -r '.comments[0].path')
+    line=$(echo "$output" | jq -r '.comments[0].line')
+    body=$(echo "$output" | jq -r '.comments[0].body')
+    [ "$path" = "src/auth.ts" ]
+    [ "$line" = "10" ]
+    [ "$body" = "Consider..." ]
+}
+
+# =============================================================================
+# Missing review_commit tests
+# =============================================================================
+
+@test "detect-comment-drift: skips drift detection when review_commit is missing" {
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "comments": [{"path": "src/auth.ts", "line": 10, "body": "Consider..."}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == false'
+    echo "$output" | jq -e '.drift_summary == "skipped (no review commit)"'
+}
+
+@test "detect-comment-drift: skips drift detection when review_commit is null" {
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": null, "comments": [{"path": "src/auth.ts", "line": 10, "body": "Consider..."}]}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == false'
+}
+
+# =============================================================================
+# Drift detection with successful remap
+# =============================================================================
+
+@test "detect-comment-drift: detects drift and remaps comment to new position" {
+    # The original diff has the token validation line at new-file line 10.
+    # The updated diff has it at new-file line 18 (extra lines added above).
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local original_diff
+    original_diff=$(cat "$FIXTURES_DIR/drift-original.diff")
+    local tmpinput
+    tmpinput=$(mktemp)
+
+    # Use --arg for the line_content to preserve single quotes correctly
+    local line_content
+    line_content="    return token.length > 10 && token.startsWith('sk_');"
+
+    jq -n \
+        --arg diff "$original_diff" \
+        --arg lc "$line_content" \
+        '{
+            owner: "org",
+            repo: "repo",
+            pr_number: 42,
+            review_commit: "abc123",
+            original_diff: $diff,
+            comments: [{
+                path: "src/auth.ts",
+                line: 10,
+                side: "RIGHT",
+                body: "Consider adding token format validation",
+                line_content: $lc
+            }]
+        }' > "$tmpinput"
+
+    run bash -c "cat '$tmpinput' | '$SCRIPT' 2>/dev/null"
+    rm -f "$tmpinput"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.review_commit == "abc123"'
+    echo "$output" | jq -e '.current_commit == "def456"'
+    # The comment should be remapped (line moved from 10 to 18)
+    echo "$output" | jq -e '.comments | length == 1'
+    echo "$output" | jq -e '.unmapped_comments | length == 0'
+}
+
+@test "detect-comment-drift: uses line_content for matching when provided" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/utils.ts",
+            line: 6,
+            side: "RIGHT",
+            body: "Magic number",
+            line_content: "export const MAX_RETRIES = 3;"
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 1'
+}
+
+# =============================================================================
+# Drift with unmapped comments
+# =============================================================================
+
+@test "detect-comment-drift: moves comment to unmapped when line content removed" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/auth.ts",
+            line: 5,
+            side: "RIGHT",
+            body: "This line has a problem",
+            line_content: "this_content_does_not_exist_anywhere();"
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 0'
+    echo "$output" | jq -e '.unmapped_comments | length == 1'
+    echo "$output" | jq -e '.unmapped_comments[0].reason != null'
+}
+
+@test "detect-comment-drift: moves comment to unmapped when file removed from diff" {
+    # Create a mock that returns a diff without the target file
+    local simple_diff="$FIXTURES_DIR/simple-single-file.diff"
+    create_mock_gh "def456" "$simple_diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/auth.ts",
+            line: 5,
+            side: "RIGHT",
+            body: "This file is gone",
+            line_content: "some_code();"
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 0'
+    echo "$output" | jq -e '.unmapped_comments | length == 1'
+    echo "$output" | jq -e '.unmapped_comments[0].reason == "file removed from diff"'
+}
+
+# =============================================================================
+# Content matching edge cases
+# =============================================================================
+
+@test "detect-comment-drift: handles trimmed whitespace matching" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    # The line_content has extra whitespace that should be trimmed during matching
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/auth.ts",
+            line: 3,
+            side: "RIGHT",
+            body: "Interface naming",
+            line_content: "  export interface AuthConfig {  "
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 1'
+}
+
+@test "detect-comment-drift: handles empty comments array" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 0'
+    echo "$output" | jq -e '.unmapped_comments | length == 0'
+}
+
+# =============================================================================
+# extract_line_content_from_diff tests
+# =============================================================================
+
+@test "detect-comment-drift: extracts line content from original diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/drift-original.diff")
+
+    # Line 10 in src/auth.ts in the original diff is the token validation line
+    run bash -c "
+        source '$SCRIPT'
+        extract_line_content_from_diff \"\$(cat '$FIXTURES_DIR/drift-original.diff')\" 'src/auth.ts' 10
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"token.length > 10"* ]]
+}
+
+@test "detect-comment-drift: returns empty for nonexistent file" {
+    run bash -c "
+        source '$SCRIPT'
+        extract_line_content_from_diff \"\$(cat '$FIXTURES_DIR/drift-original.diff')\" 'nonexistent.ts' 1
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "detect-comment-drift: returns empty for line outside diff range" {
+    run bash -c "
+        source '$SCRIPT'
+        extract_line_content_from_diff \"\$(cat '$FIXTURES_DIR/drift-original.diff')\" 'src/auth.ts' 999
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# =============================================================================
+# find_line_in_diff tests
+# =============================================================================
+
+@test "detect-comment-drift: finds line at new position in diff" {
+    local diff
+    diff=$(cat "$FIXTURES_DIR/drift-updated.diff")
+
+    run bash -c "
+        source '$SCRIPT'
+        find_line_in_diff \"\$(cat '$FIXTURES_DIR/drift-updated.diff')\" 'src/utils.ts' 'export const MAX_RETRIES = 3;' 6
+    "
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+}
+
+@test "detect-comment-drift: returns empty when content not found" {
+    run bash -c "
+        source '$SCRIPT'
+        find_line_in_diff \"\$(cat '$FIXTURES_DIR/drift-updated.diff')\" 'src/auth.ts' 'this_line_does_not_exist();' 1
+    "
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# =============================================================================
+# file_in_diff tests
+# =============================================================================
+
+@test "detect-comment-drift: detects file present in diff" {
+    run bash -c "
+        source '$SCRIPT'
+        file_in_diff \"\$(cat '$FIXTURES_DIR/drift-original.diff')\" 'src/auth.ts'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+}
+
+@test "detect-comment-drift: detects file absent from diff" {
+    run bash -c "
+        source '$SCRIPT'
+        file_in_diff \"\$(cat '$FIXTURES_DIR/drift-original.diff')\" 'nonexistent.ts'
+    "
+    [ "$status" -eq 0 ]
+    [ "$output" = "false" ]
+}
+
+# =============================================================================
+# Drift summary tests
+# =============================================================================
+
+@test "detect-comment-drift: produces correct drift summary" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [
+            {
+                path: "src/utils.ts",
+                line: 6,
+                side: "RIGHT",
+                body: "Magic number",
+                line_content: "export const MAX_RETRIES = 3;"
+            },
+            {
+                path: "src/auth.ts",
+                line: 5,
+                side: "RIGHT",
+                body: "This is gone",
+                line_content: "this_content_does_not_exist_anywhere();"
+            }
+        ]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.drift_summary | contains("unmapped")'
+}
+
+# =============================================================================
+# Output format tests
+# =============================================================================
+
+@test "detect-comment-drift: outputs valid JSON" {
+    create_mock_gh "abc123" ""
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT' | jq empty"
+    [ "$status" -eq 0 ]
+}
+
+@test "detect-comment-drift: includes all required output fields" {
+    create_mock_gh "abc123" ""
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'has("drift_detected")'
+    echo "$output" | jq -e 'has("review_commit")'
+    echo "$output" | jq -e 'has("current_commit")'
+    echo "$output" | jq -e 'has("comments")'
+    echo "$output" | jq -e 'has("unmapped_comments")'
+    echo "$output" | jq -e 'has("drift_summary")'
+}
+
+# =============================================================================
+# Graceful failure tests
+# =============================================================================
+
+@test "detect-comment-drift: handles gh API failure gracefully" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+echo "API rate limit exceeded" >&2
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local input='{"owner": "org", "repo": "repo", "pr_number": 42, "review_commit": "abc123", "comments": [{"path": "test.ts", "line": 1, "body": "hi"}]}'
+    # Redirect stderr to /dev/null so warning messages don't pollute the JSON output
+    run bash -c "echo '$input' | '$SCRIPT' 2>/dev/null"
+    [ "$status" -eq 0 ]
+    # Should return gracefully with original comments
+    echo "$output" | jq -e '.drift_detected == false'
+    echo "$output" | jq -e '.comments | length == 1'
+}
+
+# =============================================================================
+# Integration with original_diff tests
+# =============================================================================
+
+@test "detect-comment-drift: extracts line_content from original_diff when not on comment" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local original_diff
+    original_diff=$(cat "$FIXTURES_DIR/drift-original.diff")
+
+    # Comment targets line 5 (MAX_RETRIES) without line_content, but original_diff is provided
+    # so the script should extract it automatically and use it for matching
+    local tmpinput
+    tmpinput=$(mktemp)
+
+    jq -n \
+        --arg diff "$original_diff" \
+        '{
+            owner: "org",
+            repo: "repo",
+            pr_number: 42,
+            review_commit: "abc123",
+            original_diff: $diff,
+            comments: [{
+                path: "src/utils.ts",
+                line: 5,
+                side: "RIGHT",
+                body: "Magic number"
+            }]
+        }' > "$tmpinput"
+
+    run bash -c "cat '$tmpinput' | '$SCRIPT' 2>/dev/null"
+    rm -f "$tmpinput"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.drift_detected == true'
+    echo "$output" | jq -e '.comments | length == 1'
+}

--- a/tests/unit/test-detect-comment-drift.bats
+++ b/tests/unit/test-detect-comment-drift.bats
@@ -172,6 +172,9 @@ GHEOF
     # The comment should be remapped (line moved from 10 to 18)
     echo "$output" | jq -e '.comments | length == 1'
     echo "$output" | jq -e '.unmapped_comments | length == 0'
+    echo "$output" | jq -e '.comments[0].line == 18'
+    echo "$output" | jq -e '.comments[0].original_line == 10'
+    echo "$output" | jq -e '.comments[0].remapped == true'
 }
 
 @test "detect-comment-drift: uses line_content for matching when provided" {
@@ -225,7 +228,7 @@ GHEOF
     echo "$output" | jq -e '.drift_detected == true'
     echo "$output" | jq -e '.comments | length == 0'
     echo "$output" | jq -e '.unmapped_comments | length == 1'
-    echo "$output" | jq -e '.unmapped_comments[0].reason != null'
+    echo "$output" | jq -e '.unmapped_comments[0].reason == "line content not found in current diff"'
 }
 
 @test "detect-comment-drift: moves comment to unmapped when file removed from diff" {
@@ -259,6 +262,53 @@ GHEOF
 # =============================================================================
 # Content matching edge cases
 # =============================================================================
+
+@test "detect-comment-drift: marks comment as not remapped when line unchanged" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/utils.ts",
+            line: 5,
+            side: "RIGHT",
+            body: "Magic number",
+            line_content: "export const MAX_RETRIES = 3;"
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.comments[0].remapped == false'
+    echo "$output" | jq -e '.comments[0].line == 5'
+}
+
+@test "detect-comment-drift: unmaps comment with no line_content and no original_diff" {
+    create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
+
+    local input
+    input=$(jq -n '{
+        owner: "org",
+        repo: "repo",
+        pr_number: 42,
+        review_commit: "abc123",
+        comments: [{
+            path: "src/auth.ts",
+            line: 5,
+            side: "RIGHT",
+            body: "Some comment"
+        }]
+    }')
+
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.unmapped_comments | length == 1'
+    echo "$output" | jq -e '.unmapped_comments[0].reason == "no line content available for matching"'
+}
 
 @test "detect-comment-drift: handles trimmed whitespace matching" {
     create_mock_gh "def456" "$FIXTURES_DIR/drift-updated.diff"
@@ -344,7 +394,22 @@ GHEOF
         find_line_in_diff \"\$(cat '$FIXTURES_DIR/drift-updated.diff')\" 'src/utils.ts' 'export const MAX_RETRIES = 3;' 6
     "
     [ "$status" -eq 0 ]
-    [ -n "$output" ]
+    [ "$output" = "5" ]
+}
+
+@test "detect-comment-drift: find_line_in_diff picks closest match among duplicates" {
+    # Build a diff with duplicate content lines at positions 1, 3, 5
+    local diff
+    diff=$(printf 'diff --git a/f.ts b/f.ts\n--- a/f.ts\n+++ b/f.ts\n@@ -1,5 +1,5 @@\n+return null;\n+something_else();\n+return null;\n+more_code();\n+return null;\n')
+
+    # Original line 4: closest "return null;" is at line 3 (distance 1) vs line 1 (distance 3) and line 5 (distance 1)
+    # When tied, the first found at distance 1 wins (line 3)
+    run bash -c "
+        source '$SCRIPT'
+        find_line_in_diff \"\$1\" 'f.ts' 'return null;' 4
+    " -- "$diff"
+    [ "$status" -eq 0 ]
+    [ "$output" = "3" ] || [ "$output" = "5" ]
 }
 
 @test "detect-comment-drift: returns empty when content not found" {

--- a/tests/unit/test-pr-context.bats
+++ b/tests/unit/test-pr-context.bats
@@ -244,6 +244,20 @@ setup() {
 }
 
 # =============================================================================
+# head_sha tests
+# =============================================================================
+
+@test "pr-context.sh: fetch_pr_metadata requests headRefOid field" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && declare -f fetch_pr_metadata | grep -q 'headRefOid'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-context.sh: main outputs head_sha field in JSON" {
+    run bash -c "source '$PROJECT_ROOT/skills/review-code/scripts/pr-context.sh' && declare -f main | grep -q 'head_sha'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
 # fetch_linked_issues tests
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Adds `detect-comment-drift.sh` that compares the review's commit SHA against the PR's current HEAD and re-maps comment positions using content-based matching
- Integrates into `create-draft-review.sh` as an opt-in step (activated when `review_commit` is provided)
- Captures `head_sha` from GitHub API in `pr-context.sh`
- Non-fatal: falls back to original positions if drift detection fails

## Test plan

- [ ] 26 new unit tests for `detect-comment-drift.sh` cover: no-drift, successful remap, unmapped comments, trimmed matching, API failure fallback
- [ ] 6 new tests for existing scripts (`create-draft-review.sh`, `pr-context.sh`)
- [ ] All 1034 existing tests still pass
- [ ] Manual test: review a PR, wait for new commits, verify comments land on correct lines