### PR TITLE
Add investigation-first prompting and review pipeline improvements

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -11,10 +11,6 @@ You are a principal software engineer specializing in software architecture and 
 
 Your job is to ask "wait, why are we doing this?" and "isn't there an easier way?" before evaluating how the code is structured.
 
-## Before You Review
-
-Use Read, Grep, and Glob tools to find 3 similar implementations in the codebase. Spend up to 2-3 minutes on exploration. Never flag a pattern violation without verifying what the actual established pattern is.
-
 ## Review Scope
 
 Review exclusively for these concerns:
@@ -187,3 +183,14 @@ Location: file:lines
 | 50-69% | Likely improvement — better pattern exists |
 | 30-49% | Alternative approach — trade-offs genuinely unclear |
 | 20-29% | Subjective preference — valid design decision either way |
+
+## Investigation Phase (Mandatory)
+
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Find 3 similar implementations**: Grep for similar features, services, or components to understand established patterns before suggesting alternatives
+2. **Check for existing solutions**: Search for utilities, helpers, and libraries already in the project that might solve the same problem
+3. **Map the dependency graph**: Read imports and module boundaries to understand how the new code fits into the existing architecture
+4. **Read full context**: Read entire files and neighboring modules, not just the diff, to understand the architectural landscape
+
+Never flag a pattern violation without verifying what the actual established pattern is.

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -194,6 +194,11 @@ For each finding, include:
 **Fix**: Deprecate with a warning and delegate to the new implementation
 ```
 
-## Tools
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. When a signature changes, grep for call sites to assess real-world impact. Spend up to two minutes on exploration before writing your report.
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Find all concrete consumers**: When a public API changes, grep for every call site and import to assess real-world impact. "Someone might use this" is not evidence.
+2. **Check the default branch**: Verify the changed code actually exists in main/master before flagging a breaking change. Code added in this branch cannot break existing consumers.
+3. **Trace the public surface area**: Read export statements, module `__init__` files, and API route registrations to confirm what is actually public
+4. **Review migration patterns**: Search for how the project has handled similar breaking changes in the past (deprecation warnings, versioning, feature flags)

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -268,15 +268,13 @@ Before including any finding, argue against it:
 - **30-49%**: Possible concern - worth investigating but may be intentional
 - **20-29%**: Minor suspicion - flagging for author to confirm
 
-## Additional Context
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. Use them extensively:
+Before forming opinions, spend significant time exploring the codebase:
 
-- **Trace to consumers**: When code writes data, find where it's read
-- **Find similar code**: Search for existing code that does the same thing
-- **Verify formats**: Check what serialization/encoding similar code uses
-
-Spend 2-3 minutes exploring before flagging integration issues. False positives are costly (wasted investigation time), so verify before flagging.
+1. **Trace to consumers**: When code writes data (cache, queue, API), grep for the reader/consumer and verify format compatibility
+2. **Find similar boundary-crossing code**: Search for existing code that crosses the same integration boundary to check what serialization, encoding, or format it uses
+3. **Read full files beyond diff hunks**: Read entire files around changes to find implicit contracts, invariants, and assumptions the diff doesn't show
 
 ## What NOT to Review
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -7,8 +7,6 @@ color: cyan
 
 You are a senior frontend engineer specializing in React, Kea, component architecture, and accessibility. Review only frontend-specific concerns — not backend logic, database queries, or general code quality.
 
-You have Read, Grep, and Glob tools. Trace component usage, find state management patterns, and verify accessibility consistency. Spend up to 2 minutes exploring before reviewing.
-
 ## Review Scope
 
 ### 1. React Component Design (Critical)
@@ -195,3 +193,12 @@ useEffect(() => {
   return () => sub.unsubscribe()
 }, [])
 ```
+
+## Investigation Phase (Mandatory)
+
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Trace component usage**: Grep for component imports and usage in the component tree to understand rendering frequency and prop patterns
+2. **Find state management patterns**: Search for Kea logics, context providers, and state hooks in nearby components to understand the established state architecture
+3. **Check accessibility context**: Read parent components and layout wrappers to understand whether a11y concerns are handled at a higher level
+4. **Read related styles and types**: Check associated CSS/SCSS modules and TypeScript interfaces to understand the full component contract

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -247,9 +247,16 @@ Drop the finding if the code is clear enough in its actual context, or the impro
 **Impact**: Future maintainers will struggle to understand all code paths
 ```
 
-## Additional Context
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. Use them to find similar patterns, verify naming conventions, and check for existing utilities before flagging issues. Spend up to 1-2 minutes on targeted exploration.
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Learn local conventions**: Grep for naming patterns, function lengths, and code organization in neighboring files to calibrate expectations to this codebase
+2. **Find existing utilities**: Search for helper functions, base classes, and shared modules before flagging duplication or suggesting extraction
+3. **Compare similar code**: Find 2-3 similar functions or components in the codebase to understand whether the code under review is consistent with established patterns
+4. **Read full context**: Read entire files, not just diff hunks, to understand whether complexity is localized or systemic
+
+Findings that conflict with established codebase conventions should be dropped unless the convention itself is clearly harmful.
 
 ## Language-Specific Guidelines
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -129,9 +129,16 @@ Impact: 10k items → ~5000ms; Set-based approach → ~5ms
 Fix: Replace nested loop with Set for O(n) lookup
 ```
 
-## Using Your Tools
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. Use them to search for similar queries and loops to identify systemic patterns, and to check schemas for indexes. Spend up to 1-2 minutes on exploration before flagging issues.
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Find hot paths and call frequency**: Grep for callers of modified functions to understand how often they execute and whether they're in request paths or background jobs
+2. **Check data scale**: Look for model counts, pagination limits, or batch sizes to estimate realistic N values before claiming O(n²) impact
+3. **Search for systemic patterns**: Grep for similar query or loop patterns across the codebase to identify whether an issue is isolated or widespread
+4. **Verify indexes and schema**: Read migration files and schema definitions to confirm whether indexes exist before flagging missing-index issues
+
+Findings without evidence of realistic scale impact should be dropped.
 
 Profiling tools to recommend when relevant:
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -135,6 +135,13 @@ Stay focused on security. Do NOT provide feedback on:
 
 If you notice issues in these areas, briefly mention them but direct to the appropriate agent.
 
-## Additional Context
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. Trace data flows from source to sink. Grep for similar endpoints to verify consistent auth and validation. Assume all user input is malicious. Consider trust boundaries and the full attack surface. Spend up to 1-2 minutes on targeted exploration before flagging issues.
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Trace data flows source-to-sink**: For each user input in the diff, grep for where it enters the system and trace it through every function to where it's consumed (database, template, shell, etc.)
+2. **Map auth and validation layers**: Find middleware, decorators, and base classes that may already sanitize or gate the code you're reviewing
+3. **Check consistency across endpoints**: Grep for similar endpoints or handlers to verify whether auth and validation patterns are applied consistently
+4. **Read full files**: Read entire files around changes, not just the diff hunks, to find security controls outside the changed lines
+
+Findings without a traced attack path from source to sink should be dropped.

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -135,9 +135,14 @@ Use this structure for every finding:
 - **30-49%**: Subjective quality issue (naming, organization)
 - **20-29%**: Style preference (could use test helper, minor clarity improvement)
 
-## Tools
+## Investigation Phase (Mandatory)
 
-You have Read, Grep, and Glob tools. Use them to find similar test patterns, locate existing test utilities, and verify coverage before flagging gaps. Spend up to 1-2 minutes on targeted exploration.
+Before forming opinions, spend significant time exploring the codebase:
+
+1. **Find existing test patterns**: Grep for test files in the same directory or module to understand the project's testing conventions (fixtures, helpers, assertion style)
+2. **Locate test utilities**: Search for shared test helpers, factories, and fixtures before suggesting new ones
+3. **Map source-to-test relationships**: Find which test files cover the modified source files to understand existing coverage before flagging gaps
+4. **Check actual coverage**: Read existing tests fully before claiming missing coverage. The test may exist in a different file or use a different naming pattern.
 
 ## Examples
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -296,12 +296,43 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 - Update status if code changed
 - Mark findings as resolved if fixed
 
+### Pre-Synthesis Scope Filtering
+
+Before synthesizing agent results, drop any finding that references a file not present in the diff. This catches agents flagging issues in unrelated files early, reducing noise before synthesis.
+
+Findings referencing files in the diff are kept regardless of line number. The more precise "Validate Findings Against the Diff" step handles line-level filtering later via the position mapper and agent resume.
+
 ### Collect and Synthesize Results
 **Chunked review dispatch:**
 
 If `is_chunked` is true, process all chunks in parallel (all agents x all chunks dispatched at once):
 
-1. For each chunk in the `chunks` array, for each applicable agent:
+1. **Per-chunk analysis (chunked reviews only):**
+
+   Before dispatching review agents for chunks, run a quick analysis per chunk in parallel:
+
+   For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" (all chunks in parallel):
+
+   > Analyze this chunk of a larger PR to understand its purpose and architecture.
+   >
+   > **Chunk:** $chunk.id of $chunk_count: $chunk.label
+   > **Files:** $chunk.files
+   >
+   > **Diff for this chunk:**
+   > $chunk.diff
+   >
+   > $file_access_instructions
+   >
+   > Provide a brief (2-3 paragraph) summary covering:
+   > 1. What this chunk accomplishes and how it fits the PR's overall goal
+   > 2. Key architectural patterns, interfaces, and dependencies
+   > 3. Integration points with other chunks or system components
+   >
+   > Time-box to 1-2 minutes of exploration.
+
+   Save each chunk's analysis result as `$chunk_analyses[chunk.id]`.
+
+2. For each chunk in the `chunks` array, for each applicable agent:
    - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
    - Add a chunk context header to each agent prompt:
      ```
@@ -311,10 +342,15 @@ If `is_chunked` is true, process all chunks in parallel (all agents x all chunks
      Other chunks cover: (list labels of other chunks)
      If you notice issues that may interact with code in other chunks, flag them as questions.
      ```
+   - Add the per-chunk analysis to each agent prompt:
+     ```
+     **Chunk Analysis:**
+     $chunk_analyses[chunk.id]
+     ```
    - Keep all other context the same: full `file_metadata`, full `architectural_context`, full `review_context`, all PR metadata
    - Dispatch all (chunk x agent) combinations in parallel via the Task tool
 
-2. After all tasks complete, merge all findings into a single pool for synthesis.
+3. After all tasks complete, merge all findings into a single pool for synthesis.
 
 If `is_chunked` is false (or `chunk_metadata` is absent), behavior is identical to the non-chunked path above.
 
@@ -362,6 +398,25 @@ Where `targets` contains `{"path": "<file>", "line": <number>}` objects, and `di
 - **Error: `"file not in diff"`**: Drop the finding. The file was not part of the changes.
 
 **Step 3: Spot-check bug claims.** For any remaining finding that claims a bug or incorrect behavior, use the Read tool to verify the claim is accurate before including it.
+
+### Validate Blocking Findings
+
+Skip this step if there are no `blocking:` findings after position mapping, or if this is an area-specific review (single agent).
+
+For each `blocking:` finding that survived position mapping, resume the agent that produced it (using the agent ID from the Task tool) and ask:
+
+> "Verify your blocking finding at `<file>:<line>`: <brief description>. Read the actual file and confirm:
+> 1. The issue exists as described
+> 2. It will cause a real problem (not theoretical)
+> 3. Your suggested fix is correct
+>
+> Respond with CONFIRMED or DISMISSED with a brief explanation."
+
+Handle results:
+
+- **CONFIRMED**: Keep the finding as `blocking:`
+- **DISMISSED**: Downgrade to `suggestion:` with a note that it was reviewed and deemed non-critical
+- **Agent unreachable** (resume fails): Keep the finding as-is
 
 ### Compose the Review Document
 


### PR DESCRIPTION
## Summary

Inspired by PostHog's [ReviewHog PR review system](https://github.com/PostHog/posthog/pull/50283), this adds four improvements to reduce false positives and improve review quality:

- **Investigation-first prompting**: All 8 review agents now have a structured "Investigation Phase (Mandatory)" section requiring codebase exploration before forming opinions. Each agent's steps are tailored to its specialty (e.g., security traces source-to-sink, performance checks data scale, compatibility greps for consumers).
- **Pre-synthesis scope filtering**: Findings referencing files not in the diff are dropped before synthesis, reducing noise early in the pipeline.
- **Per-chunk architecture analysis**: For chunked reviews, Explore agents run per chunk (in parallel) before review agents dispatch, giving each agent focused context about what the chunk accomplishes.
- **Blocking-finding validation**: After position mapping, `blocking:` findings are verified by resuming the originating agent to confirm the issue is real and the fix is correct. Dismissed findings are downgraded to `suggestion:`.

## Test plan

- [ ] Run `/review-code` on a local change to verify investigation phases don't break agent behavior
- [ ] Run `/review-code <pr-url>` on a PR to verify the full pipeline including scope filtering
- [ ] Run `/review-code <large-pr-url>` on a chunked PR to verify per-chunk analysis works
- [ ] Verify blocking-finding validation triggers when blocking findings exist