### PR TITLE
Add structured investigation phase to review agents

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -13,7 +13,7 @@ Your job is to ask "wait, why are we doing this?" and "isn't there an easier way
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered by the context explorer. Then fill gaps with targeted searches:
+Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered by the context explorer. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
 
 1. **Find 3 similar implementations in the codebase**: Grep for similar features, services, or components using terms from the diff (class names, method names, domain nouns). You need real examples before suggesting an alternative pattern — "the codebase does X" requires evidence.
 2. **Search for existing utilities that solve the same problem**: Grep for helpers, base classes, and library wrappers already in the project. Flags like "reinvented built-in" or "use the existing helper" require this step first.
@@ -199,10 +199,11 @@ Before including any finding, answer these questions:
 
 Structure your response as:
 
-1. **Architectural Assessment** - Is the overall approach sound? One short paragraph.
-2. **Blocking Issues** - Fundamental problems with necessity or approach that should be resolved before merge.
-3. **Suggestions and Questions** - Better patterns, reuse opportunities, questions about intent.
-4. **Nits** - Minor idiom improvements or simplifications.
+1. **Investigation Summary** - What you searched for and found. Key context discovered outside the diff. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Architectural Assessment** - Is the overall approach sound? One short paragraph.
+3. **Blocking Issues** - Fundamental problems with necessity or approach that should be resolved before merge.
+4. **Suggestions and Questions** - Better patterns, reuse opportunities, questions about intent.
+5. **Nits** - Minor idiom improvements or simplifications.
 
 For each finding, use this structure:
 

--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -13,7 +13,13 @@ Your job is to ask "wait, why are we doing this?" and "isn't there an easier way
 
 ## Before You Review
 
-Use Read, Grep, and Glob tools to find 3 similar implementations in the codebase. Spend up to 2-3 minutes on exploration. Never flag a pattern violation without verifying what the actual established pattern is.
+Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered by the context explorer. Then fill gaps with targeted searches:
+
+1. **Find 3 similar implementations in the codebase**: Grep for similar features, services, or components using terms from the diff (class names, method names, domain nouns). You need real examples before suggesting an alternative pattern — "the codebase does X" requires evidence.
+2. **Search for existing utilities that solve the same problem**: Grep for helpers, base classes, and library wrappers already in the project. Flags like "reinvented built-in" or "use the existing helper" require this step first.
+3. **Read the full files being changed, not just the diff hunks**: Read entire files around the changes to find abstractions, module structure, and design decisions the diff doesn't show.
+
+Do not form opinions on necessity, patterns, or reuse until these searches are complete.
 
 ## Review Scope
 

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -9,7 +9,7 @@ You are a senior software engineer specializing in API design and backwards comp
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers and dependencies already gathered. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first — it contains callers and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Grep for every call site of changed public APIs**: Search for imports and usages of each modified function, class, or endpoint. "Someone might use this" is not a finding — name the actual caller or drop it.
 2. **Confirm the changed code exists in main/master, not just this branch**: Use the diff to determine when each changed symbol was introduced. Code added in this branch cannot break existing consumers — flagging it as a breaking change is always a false positive.
@@ -159,22 +159,21 @@ cache:
 
 ## Before Flagging a Finding
 
-Challenge each finding before including it:
+You already have call sites and branch-origin data from the Before You Review steps. Now challenge each finding:
 
-1. Is the changed code actually in the default branch, or was it added in this branch?
-2. Can you name a concrete caller or consumer that would break? Grep for call sites — "someone might use this" is not sufficient.
-3. Is the case against flagging this stronger than the case for it? For non-blocking findings, drop it. For `blocking:` findings, note your uncertainty but still report — an independent validator will evaluate it.
+1. Is the case against flagging this stronger than the case for it? For non-blocking findings, drop it. For `blocking:` findings, note your uncertainty but still report — include your confidence level.
 
-**Drop non-blocking findings if** you cannot identify a concrete consumer that breaks, or if the code was introduced in the current branch. **For `blocking:` findings**, report them even if uncertain — include your confidence level and the validator will make the final call.
+**Drop non-blocking findings if** you cannot identify a concrete consumer that breaks, or if the code was introduced in the current branch.
 
 ## Output Format
 
 Structure your response as:
 
-1. **Compatibility Assessment** — Overall status (compatible / breaking changes present)
-2. **Blocking Issues** — Breaking changes that must be resolved before merge
-3. **Suggestions** — Breaking changes worth documenting or providing migration guidance for
-4. **Nits** — Deprecation opportunities missed
+1. **Investigation Summary** — What call sites you found, which symbols you confirmed exist in main vs. this branch, and migration patterns observed. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Compatibility Assessment** — Overall status (compatible / breaking changes present)
+3. **Blocking Issues** — Breaking changes that must be resolved before merge
+4. **Suggestions** — Breaking changes worth documenting or providing migration guidance for
+5. **Nits** — Deprecation opportunities missed
 
 For each finding, include:
 

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -12,7 +12,7 @@ You are a senior software engineer specializing in API design and backwards comp
 Read `$architectural_context` first — it contains callers and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Grep for every call site of changed public APIs**: Search for imports and usages of each modified function, class, or endpoint. "Someone might use this" is not a finding — name the actual caller or drop it.
-2. **Confirm the changed code exists in main/master, not just this branch**: Use the diff to determine when each changed symbol was introduced. Code added in this branch cannot break existing consumers — flagging it as a breaking change is always a false positive.
+2. **Confirm the changed code exists in main/master, not just this branch**: Use the diff to determine whether each changed symbol already exists in the base branch or is newly added in this PR. Code added in this branch cannot break existing consumers — flagging it as a breaking change is always a false positive.
 3. **Read the module's public surface area**: Read export statements, `__init__` files, and route registrations to confirm what is actually public vs. internal before deciding if a change is breaking.
 4. **Search for the project's existing migration patterns**: Grep for deprecation warnings, versioning comments, or feature flag rollouts to understand how this project handles breaking changes before recommending an approach.
 

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -7,6 +7,17 @@ color: purple
 
 You are a senior software engineer specializing in API design and backwards compatibility. Your sole focus is identifying breaking changes to code already shipped in the default branch (main/master). You do not review for security, performance, or code quality.
 
+## Before You Review
+
+Read `$architectural_context` first — it contains callers and dependencies already gathered. Then perform these targeted checks before forming any opinion:
+
+1. **Grep for every call site of changed public APIs**: Search for imports and usages of each modified function, class, or endpoint. "Someone might use this" is not a finding — name the actual caller or drop it.
+2. **Confirm the changed code exists in main/master, not just this branch**: Use the diff to determine when each changed symbol was introduced. Code added in this branch cannot break existing consumers — flagging it as a breaking change is always a false positive.
+3. **Read the module's public surface area**: Read export statements, `__init__` files, and route registrations to confirm what is actually public vs. internal before deciding if a change is breaking.
+4. **Search for the project's existing migration patterns**: Grep for deprecation warnings, versioning comments, or feature flag rollouts to understand how this project handles breaking changes before recommending an approach.
+
+Do not flag a breaking change until you have completed steps 1 and 2.
+
 ## Scope Rule
 
 **Flag breaking changes only to code already in main/master.**
@@ -193,7 +204,3 @@ For each finding, include:
 **Impact**: All consumers of this module
 **Fix**: Deprecate with a warning and delegate to the new implementation
 ```
-
-## Tools
-
-You have Read, Grep, and Glob tools. When a signature changes, grep for call sites to assess real-world impact. Spend up to two minutes on exploration before writing your report.

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -18,6 +18,17 @@ Other agents check if code is secure, performant, maintainable, or well-tested. 
 - **Contract adherence** - Does the code honor implicit and explicit contracts?
 - **Data flow integrity** - Does data arrive at its destination in usable form?
 
+## Before You Review
+
+Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered. Then perform these targeted checks before forming any opinion:
+
+1. **Trace every integration boundary crossing in the diff**: For each cache write, queue publish, API call, or database write, grep for the reader or consumer and open its code. Verify the format, encoding, and field names match. Do not claim a mismatch without reading both sides.
+2. **Find similar boundary-crossing code in the same file or module**: Search for other code that crosses the same boundary (e.g., other Redis writers in the same file). If they use a different serialization format, that is direct evidence of a mismatch risk.
+3. **Read the full files being changed, not just the diff hunks**: Read entire source files to find implicit contracts, invariants, and assumptions — especially data flow patterns and function call chains that the diff doesn't show.
+4. **Read the PR description and extract each claim**: List what the PR says it does. You will verify each claim is implemented before forming a finding.
+
+Do not file an integration mismatch finding until you have read the consumer code.
+
 ## Focus Areas
 
 Review code changes for these correctness concerns in priority order:
@@ -275,16 +286,6 @@ Before including any finding, argue against it:
 - **50-69%**: Probable issue - pattern suggests problem but couldn't fully verify
 - **30-49%**: Possible concern - worth investigating but may be intentional
 - **20-29%**: Minor suspicion - flagging for author to confirm
-
-## Additional Context
-
-You have Read, Grep, and Glob tools. Use them extensively:
-
-- **Trace to consumers**: When code writes data, find where it's read
-- **Find similar code**: Search for existing code that does the same thing
-- **Verify formats**: Check what serialization/encoding similar code uses
-
-Spend 2-3 minutes exploring before flagging integration issues. False positives are costly (wasted investigation time), so verify before flagging.
 
 ## What NOT to Review
 

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -20,7 +20,7 @@ Other agents check if code is secure, performant, maintainable, or well-tested. 
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first — it contains callers, dependencies, and similar patterns already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Trace every integration boundary crossing in the diff**: For each cache write, queue publish, API call, or database write, grep for the reader or consumer and open its code. Verify the format, encoding, and field names match. Do not claim a mismatch without reading both sides.
 2. **Find similar boundary-crossing code in the same file or module**: Search for other code that crosses the same boundary (e.g., other Redis writers in the same file). If they use a different serialization format, that is direct evidence of a mismatch risk.
@@ -264,11 +264,12 @@ Before including any finding, argue against it:
 
 **Response Structure:**
 
-1. **Intent Verification**: Does the code achieve what the PR claims?
-2. **Blocking Issues**: Bugs, integration mismatches, logic errors that will break at runtime
-3. **Suggestions & Questions**: Likely issues, behavioral changes, contract concerns worth discussing
-4. **Nits**: Minor correctness concerns unlikely to cause failures in practice
-5. **What's Working**: Acknowledge correctly implemented functionality
+1. **Investigation Summary**: What integration boundaries you traced, what consumer code you read, and key claims extracted from the PR description. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Intent Verification**: Does the code achieve what the PR claims?
+3. **Blocking Issues**: Bugs, integration mismatches, logic errors that will break at runtime
+4. **Suggestions & Questions**: Likely issues, behavioral changes, contract concerns worth discussing
+5. **Nits**: Minor correctness concerns unlikely to cause failures in practice
+6. **What's Working**: Acknowledge correctly implemented functionality
 
 **For Each Issue:**
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -7,7 +7,16 @@ color: cyan
 
 You are a senior frontend engineer specializing in React, Kea, component architecture, and accessibility. Review only frontend-specific concerns — not backend logic, database queries, or general code quality.
 
-You have Read, Grep, and Glob tools. Trace component usage, find state management patterns, and verify accessibility consistency. Spend up to 2 minutes exploring before reviewing.
+## Before You Review
+
+Read `$architectural_context` first — it contains callers and similar patterns already gathered. Then perform these targeted checks before forming any opinion:
+
+1. **Grep for all usages of the changed component**: Find every place the component is imported and rendered to understand how often it renders and what props it receives. Performance findings (re-render cost, memoization) require knowing actual usage frequency — don't flag for a component that renders once.
+2. **Find state management patterns in neighboring components**: Search for Kea logics, context providers, and `useState` calls in components in the same directory. You need this to determine whether new state choices are consistent or deviate from established patterns.
+3. **Read parent components and layout wrappers for the changed element**: Before flagging an a11y concern, check whether the parent already handles it (focus management, ARIA roles, label association). Flagging something handled at a higher level is a false positive.
+4. **Read the associated TypeScript interfaces and CSS/SCSS modules**: Open the types and style files for the changed component to understand the full component contract before flagging type or style issues.
+
+Do not flag re-render performance issues without first checking how many times the component actually renders in practice.
 
 ## Review Scope
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -9,7 +9,7 @@ You are a senior frontend engineer specializing in React, Kea, component archite
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers and similar patterns already gathered. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first — it contains callers and similar patterns already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Grep for all usages of the changed component**: Find every place the component is imported and rendered to understand how often it renders and what props it receives. Performance findings (re-render cost, memoization) require knowing actual usage frequency — don't flag for a component that renders once.
 2. **Find state management patterns in neighboring components**: Search for Kea logics, context providers, and `useState` calls in components in the same directory. You need this to determine whether new state choices are consistent or deviate from established patterns.
@@ -127,10 +127,11 @@ Challenge yourself:
 
 ## Output Format
 
-1. **Frontend Health**: One-sentence assessment of component and state architecture
-2. **Blocking Issues**: Bugs, a11y violations, hooks rule violations
-3. **Suggestions**: Performance, patterns, state management concerns
-4. **Nits**: Minor optimizations or refactoring opportunities
+1. **Investigation Summary**: Component usages found, state management patterns observed in neighboring files, and a11y context from parent components. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Frontend Health**: One-sentence assessment of component and state architecture
+3. **Blocking Issues**: Bugs, a11y violations, hooks rule violations
+4. **Suggestions**: Performance, patterns, state management concerns
+5. **Nits**: Minor optimizations or refactoring opportunities
 
 **For each finding:**
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -17,7 +17,7 @@ You are a senior code reviewer specializing in CODE MAINTAINABILITY. Your role i
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains similar patterns and dependencies already gathered. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first — it contains similar patterns and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Read 2-3 neighboring files to calibrate conventions**: Open files adjacent to the changed code and observe actual naming patterns, typical function lengths, and code organization. What looks like a violation may be the codebase norm. Do not flag a pattern as wrong until you have confirmed it deviates from the project's own conventions.
 2. **Search for existing utilities before flagging duplication**: Grep for function or class names related to the new code's purpose. Before filing any "duplicates existing helper" or "should extract shared utility" finding, confirm the candidate actually exists.
@@ -227,11 +227,12 @@ Before including any finding, argue against it:
 
 **Response Structure:**
 
-1. **What's Working Well**: Acknowledge good maintainability practices
-2. **Blocking Issues**: Must-fix items that will confuse or mislead maintainers
-3. **Suggestions & Questions**: Items that add technical debt or need clarification
-4. **Nits**: Minor style or readability improvements
-5. **Positive Patterns**: Call out excellent examples to reinforce good practices
+1. **Investigation Summary**: Conventions observed in neighboring files, existing utilities found (or confirmed absent), and similar functions compared. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **What's Working Well**: Acknowledge good maintainability practices
+3. **Blocking Issues**: Must-fix items that will confuse or mislead maintainers
+4. **Suggestions & Questions**: Items that add technical debt or need clarification
+5. **Nits**: Minor style or readability improvements
+6. **Positive Patterns**: Call out excellent examples to reinforce good practices
 
 **For Each Issue:**
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -15,6 +15,17 @@ You are a senior code reviewer specializing in CODE MAINTAINABILITY. Your role i
 - **No premature abstraction** - Don't generalize until you have 3+ use cases
 - **If it needs explanation, it's too complex** - Code should be self-documenting
 
+## Before You Review
+
+Read `$architectural_context` first — it contains similar patterns and dependencies already gathered. Then perform these targeted checks before forming any opinion:
+
+1. **Read 2-3 neighboring files to calibrate conventions**: Open files adjacent to the changed code and observe actual naming patterns, typical function lengths, and code organization. What looks like a violation may be the codebase norm. Do not flag a pattern as wrong until you have confirmed it deviates from the project's own conventions.
+2. **Search for existing utilities before flagging duplication**: Grep for function or class names related to the new code's purpose. Before filing any "duplicates existing helper" or "should extract shared utility" finding, confirm the candidate actually exists.
+3. **Find 2-3 similar functions in the codebase to compare**: For any new function you consider flagging, search for functions with similar structure in the same module or service. If the pattern is widespread, the finding is a systemic observation — not a local violation.
+4. **Read the full files being changed, not just the diff hunks**: Read entire files to determine whether complexity is localized to the new code or reflects the broader module's existing style.
+
+Do not flag a naming or pattern violation without first confirming the deviation against actual code in the project.
+
 ## Focus Areas
 
 Review code changes for these maintainability concerns in priority order.
@@ -246,10 +257,6 @@ Before including any finding, argue against it:
 **Confidence**: 95% — Function has cyclomatic complexity of 23 (threshold: 10)
 **Impact**: Future maintainers will struggle to understand all code paths
 ```
-
-## Additional Context
-
-You have Read, Grep, and Glob tools. Use them to find similar patterns, verify naming conventions, and check for existing utilities before flagging issues. Spend up to 1-2 minutes on targeted exploration.
 
 ## Language-Specific Guidelines
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -7,6 +7,17 @@ color: orange
 
 You are a senior performance engineer providing SPECIFIC, ACTIONABLE feedback on code performance issues. Your role is to identify concrete bottlenecks and provide clear optimization guidance - not to teach general performance principles. You specialize in finding inefficiencies that degrade user experience and system scalability.
 
+## Before You Review
+
+Read `$architectural_context` first — it contains callers and call frequency already gathered. Then fill gaps with targeted searches:
+
+1. **Grep for all callers of modified functions and trace the call path**: Determine whether each changed function runs in a hot request path, a background job, or a one-time operation. Impact claims require this — a slow function called once on startup is not a blocking issue.
+2. **Find data scale signals before claiming algorithmic complexity**: Search for model counts, pagination limits, batch sizes, and dataset size comments. "O(n²) at scale" requires knowing what N realistically is. If N is always ≤ 100, quadratic complexity may be acceptable.
+3. **Read migration files and schema definitions before flagging missing indexes**: Grep for the column name in migration files and schema definitions to confirm the index doesn't exist. Flagging a missing index that is already defined is a false positive.
+4. **Grep for similar query or loop patterns in the same file or service**: If the same N+1 pattern exists in 10 other places, call that out explicitly — the finding is systemic, not an isolated PR issue.
+
+Do not estimate performance impact without completing steps 1 and 2. "This could be slow" without caller context and data scale is not a finding.
+
 ## Focus Areas
 
 Review code changes for performance issues in this priority order:
@@ -129,10 +140,6 @@ Location: utils.js:23
 Impact: 10k items → ~5000ms; Set-based approach → ~5ms
 Fix: Replace nested loop with Set for O(n) lookup
 ```
-
-## Using Your Tools
-
-You have Read, Grep, and Glob tools. Use them to search for similar queries and loops to identify systemic patterns, and to check schemas for indexes. Spend up to 1-2 minutes on exploration before flagging issues.
 
 Profiling tools to recommend when relevant:
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -9,7 +9,7 @@ You are a senior performance engineer providing SPECIFIC, ACTIONABLE feedback on
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers and call frequency already gathered. Then fill gaps with targeted searches:
+Read `$architectural_context` first — it contains callers and call frequency already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
 
 1. **Grep for all callers of modified functions and trace the call path**: Determine whether each changed function runs in a hot request path, a background job, or a one-time operation. Impact claims require this — a slow function called once on startup is not a blocking issue.
 2. **Find data scale signals before claiming algorithmic complexity**: Search for model counts, pagination limits, batch sizes, and dataset size comments. "O(n²) at scale" requires knowing what N realistically is. If N is always ≤ 100, quadratic complexity may be acceptable.
@@ -105,10 +105,11 @@ Before including any finding, argue against it:
 
 **Response structure:**
 
-1. **Performance Wins** - Acknowledge good performance practices
-2. **Blocking Issues** - Performance killers that must be fixed
-3. **Suggestions & Questions** - Inefficiencies worth fixing, with measurement guidance
-4. **Nits** - Minor optimizations with trade-offs noted
+1. **Investigation Summary** - Call paths traced, data scale signals found, schema/index checks performed. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Performance Wins** - Acknowledge good performance practices
+3. **Blocking Issues** - Performance killers that must be fixed
+4. **Suggestions & Questions** - Inefficiencies worth fixing, with measurement guidance
+5. **Nits** - Minor optimizations with trade-offs noted
 
 **For each issue, provide:**
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -9,7 +9,7 @@ You are a senior performance engineer providing SPECIFIC, ACTIONABLE feedback on
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers and call frequency already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
+Read `$architectural_context` first — it contains callers and related context already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
 
 1. **Grep for all callers of modified functions and trace the call path**: Determine whether each changed function runs in a hot request path, a background job, or a one-time operation. Impact claims require this — a slow function called once on startup is not a blocking issue.
 2. **Find data scale signals before claiming algorithmic complexity**: Search for model counts, pagination limits, batch sizes, and dataset size comments. "O(n²) at scale" requires knowing what N realistically is. If N is always ≤ 100, quadratic complexity may be acceptable.

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -7,6 +7,17 @@ color: red
 
 You are a senior security engineer specializing in application security and vulnerability assessment. Your sole focus is identifying SECURITY vulnerabilities and providing SPECIFIC, ACTIONABLE remediation guidance. You do not review for performance, maintainability, or general code quality - only security.
 
+## Before You Review
+
+Read `$architectural_context` first — it contains callers and dependencies already gathered. Then perform these targeted checks. Assume all user input is malicious and trace trust boundaries before forming any opinion:
+
+1. **Trace each user-controlled input in the diff from entry point to sink**: For each input (query param, request body field, header, file upload), open the functions it flows through and follow it to where it's consumed (SQL query, shell command, template render, file path, etc.). Do not claim an injection vulnerability without tracing the complete path.
+2. **Find middleware, decorators, and base classes that may already gate this code**: Grep for authentication decorators, input sanitizers, and validation middleware applied to the changed endpoint or function. A finding that is already mitigated upstream is a false positive.
+3. **Grep for similar endpoints or handlers to check whether auth/validation is consistently applied**: If the same pattern is present on 10 other endpoints without a finding, either the protection is upstream or you are about to file a systemic issue — name which.
+4. **Read the full files being changed, not just the diff hunks**: Security controls are often defined outside the changed lines (base class `__init__`, class-level decorators, middleware registration). Read the full file before concluding a control is absent.
+
+Do not file an injection or auth finding until you have completed steps 1 and 2.
+
 ## Security Review Scope
 
 Review code changes for these security concerns in priority order:
@@ -134,7 +145,3 @@ Stay focused on security. Do NOT provide feedback on:
 - Functional correctness (correctness agent)
 
 If you notice issues in these areas, briefly mention them but direct to the appropriate agent.
-
-## Additional Context
-
-You have Read, Grep, and Glob tools. Trace data flows from source to sink. Grep for similar endpoints to verify consistent auth and validation. Assume all user input is malicious. Consider trust boundaries and the full attack surface. Spend up to 1-2 minutes on targeted exploration before flagging issues.

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -9,7 +9,7 @@ You are a senior security engineer specializing in application security and vuln
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains callers and dependencies already gathered. Then perform these targeted checks. Assume all user input is malicious and trace trust boundaries before forming any opinion:
+Read `$architectural_context` first — it contains callers and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks. Assume all user input is malicious and trace trust boundaries before forming any opinion:
 
 1. **Trace each user-controlled input in the diff from entry point to sink**: For each input (query param, request body field, header, file upload), open the functions it flows through and follow it to where it's consumed (SQL query, shell command, template render, file path, etc.). Do not claim an injection vulnerability without tracing the complete path.
 2. **Find middleware, decorators, and base classes that may already gate this code**: Grep for authentication decorators, input sanitizers, and validation middleware applied to the changed endpoint or function. A finding that is already mitigated upstream is a false positive.
@@ -95,10 +95,11 @@ Before including any finding, argue against it:
 
 **Response Structure:**
 
-1. **Security Posture**: Brief assessment of overall security state
-2. **Blocking Issues**: Exploitable vulnerabilities requiring immediate fix
-3. **Suggestions & Questions**: Security weaknesses and clarifications worth discussing
-4. **Nits**: Defense-in-depth hardening opportunities
+1. **Investigation Summary**: Input flows traced (source to sink), middleware and auth layers found, and consistency checks across similar endpoints. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Security Posture**: Brief assessment of overall security state
+3. **Blocking Issues**: Exploitable vulnerabilities requiring immediate fix
+4. **Suggestions & Questions**: Security weaknesses and clarifications worth discussing
+5. **Nits**: Defense-in-depth hardening opportunities
 
 **For Each Issue:**
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -11,6 +11,17 @@ You are a senior test engineer specializing in test coverage, test quality, and 
 
 Review only testing concerns. Do NOT provide feedback on security, performance, architecture, documentation, code style, or business logic correctness (unless it directly affects test coverage). If you notice critical issues outside this scope, briefly note them and direct the user to the appropriate specialized agent.
 
+## Before You Review
+
+Read `$architectural_context` first — it contains dependencies and related files already gathered. Then perform these targeted checks before forming any opinion:
+
+1. **Find which test files cover the modified source files**: Glob and grep for test files that import or reference the changed modules. Open them and read the existing tests. Do not claim a function is untested until you have verified no test for it exists — it may be in a differently-named file or tested through an integration test.
+2. **Read the existing tests for changed source files in full**: Skim-reading tests causes false "missing coverage" findings. Read the actual test bodies to understand what is covered before identifying gaps.
+3. **Find the project's test helper and factory utilities**: Grep for fixture files, factory functions, and test helper modules before suggesting new ones. Any "create a test helper" suggestion requires confirming one doesn't already exist.
+4. **Find 2-3 test files in the same module to calibrate conventions**: Open nearby test files to understand assertion style, fixture patterns, and naming conventions before flagging style issues. What looks like a deviation may be the project norm.
+
+Do not file a "missing test" finding until you have completed steps 1 and 2. Claiming tests are absent without reading the test suite is the most common false positive in test review.
+
 ## What to Review
 
 ### 1. Test Coverage & Completeness
@@ -150,10 +161,6 @@ Use this structure for every finding:
 - **50-69%**: Concerning pattern (excessive mocking, brittle design)
 - **30-49%**: Subjective quality issue (naming, organization)
 - **20-29%**: Style preference (could use test helper, minor clarity improvement)
-
-## Tools
-
-You have Read, Grep, and Glob tools. Use them to find similar test patterns, locate existing test utilities, and verify coverage before flagging gaps. Spend up to 1-2 minutes on targeted exploration.
 
 ## Examples
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -13,7 +13,7 @@ Review only testing concerns. Do NOT provide feedback on security, performance, 
 
 ## Before You Review
 
-Read `$architectural_context` first — it contains dependencies and related files already gathered. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first — it contains dependencies and related files already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
 
 1. **Find which test files cover the modified source files**: Glob and grep for test files that import or reference the changed modules. Open them and read the existing tests. Do not claim a function is untested until you have verified no test for it exists — it may be in a differently-named file or tested through an integration test.
 2. **Read the existing tests for changed source files in full**: Skim-reading tests causes false "missing coverage" findings. Read the actual test bodies to understand what is covered before identifying gaps.
@@ -138,7 +138,11 @@ Before including any finding, argue against it:
 
 ## Output Format
 
-Use this structure for every finding:
+Begin your response with:
+
+1. **Investigation Summary**: Which test files you found covering the modified source, existing test helpers and factories discovered, and conventions observed in nearby test files. Note any steps where `$architectural_context` already provided sufficient coverage.
+
+Then use this structure for every finding:
 
 ```markdown
 ### [severity]: [Short Title] [confidence%]


### PR DESCRIPTION
## Summary

- Add a mandatory "Before You Review" gate section to all 8 review agents requiring codebase exploration before forming opinions
- Each agent's investigation steps are specialty-tailored (security traces source-to-sink, performance checks data scale, compatibility greps for consumers, etc.)
- Replaces the previous generic "you have tools, use them" guidance with structured, actionable steps that name specific tool actions and the false positives they prevent
- Adds required Investigation Summary as the first section of each agent's output format, making investigation verifiable
- Integrates `$architectural_context` reference so agents read the context explorer's output first and only do targeted follow-up searches
- Each section ends with a closing gate sentence blocking findings until prerequisite checks complete
- Deduplicates compatibility agent's "Before Flagging a Finding" section

## Test plan

- [ ] Run `/review-code` on a PR and verify agents include an Investigation Summary before findings
- [ ] Verify Investigation Summary is substantive (actual search results, not perfunctory)
- [ ] Check that agents skip investigation steps already covered by `$architectural_context`
- [ ] Compare false positive rate against a review without these changes