### PR TITLE
Add per-chunk architecture analysis for chunked reviews

### DIFF
--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -276,7 +276,7 @@ All functions are no-ops when `REVIEW_CODE_DEBUG` is not set to `1`.
 
 Currently integrated into:
 
-- ✅ `lib/review-orchestrator.sh` - Main orchestration, timing, final output (stages 00-07)
+- ✅ `scripts/review-orchestrator.sh` - Main orchestration, timing, final output (stages 00-07)
 - ✅ `handlers/review.md` - Claude-side stages via `debug-artifact-writer.sh` (stages 08-11)
 - ✅ Core helper functions tested
 - 🔄 Diff pipeline (future: detailed before/after diffs)

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -69,6 +69,10 @@ When DEBUG mode is enabled, review-code creates a session directory containing:
     ├── 03-language-detection/    # Language/framework detection
     ├── 04-context-loading/       # Context files loaded
     ├── 07-final-output/          # Final JSON output to Claude
+    ├── 08-context-explorer/      # Architectural context exploration (Claude-side)
+    ├── 09-per-chunk-analysis/    # Per-chunk analysis (Claude-side, chunked only)
+    ├── 10-agent-dispatch/        # Review agent prompts and results (Claude-side)
+    ├── 11-synthesis/             # Finding merge and corroboration (Claude-side)
     ├── timing.ndjson             # Timing data for each stage
     └── README.md                 # Human-readable summary
 ```
@@ -272,7 +276,8 @@ All functions are no-ops when `REVIEW_CODE_DEBUG` is not set to `1`.
 
 Currently integrated into:
 
-- ✅ `lib/review-orchestrator.sh` - Main orchestration, timing, final output
+- ✅ `lib/review-orchestrator.sh` - Main orchestration, timing, final output (stages 00-07)
+- ✅ `handlers/review.md` - Claude-side stages via `debug-artifact-writer.sh` (stages 08-11)
 - ✅ Core helper functions tested
 - 🔄 Diff pipeline (future: detailed before/after diffs)
 - 🔄 Context loading (future: which files loaded)

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -301,7 +301,32 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 
 If `is_chunked` is true, process all chunks in parallel (all agents x all chunks dispatched at once):
 
-1. For each chunk in the `chunks` array, for each applicable agent:
+1. **Per-chunk analysis (chunked reviews only):**
+
+   Before dispatching review agents for chunks, run a quick analysis per chunk in parallel:
+
+   For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" (all chunks in parallel):
+
+   > Analyze this chunk of a larger PR to understand its purpose and architecture.
+   >
+   > **Chunk:** $chunk.id of $chunk_count: $chunk.label
+   > **Files:** $chunk.files
+   >
+   > **Diff for this chunk:**
+   > $chunk.diff
+   >
+   > $file_access_instructions
+   >
+   > Provide a brief (2-3 paragraph) summary covering:
+   > 1. What this chunk accomplishes and how it fits the PR's overall goal
+   > 2. Key architectural patterns, interfaces, and dependencies
+   > 3. Integration points with other chunks or system components
+   >
+   > Time-box to 1-2 minutes of exploration.
+
+   Save each chunk's analysis result as `$chunk_analyses[chunk.id]`.
+
+2. For each chunk in the `chunks` array, for each applicable agent:
    - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
    - Add a chunk context header to each agent prompt:
      ```
@@ -311,10 +336,15 @@ If `is_chunked` is true, process all chunks in parallel (all agents x all chunks
      Other chunks cover: (list labels of other chunks)
      If you notice issues that may interact with code in other chunks, flag them as questions.
      ```
+   - Add the per-chunk analysis to each agent prompt:
+     ```
+     **Chunk Analysis:**
+     $chunk_analyses[chunk.id]
+     ```
    - Keep all other context the same: full `file_metadata`, full `architectural_context`, full `review_context`, all PR metadata
    - Dispatch all (chunk x agent) combinations in parallel via the Task tool
 
-2. After all tasks complete, merge all findings into a single pool for synthesis.
+3. After all tasks complete, merge all findings into a single pool for synthesis.
 
 If `is_chunked` is false (or `chunk_metadata` is absent), behavior is identical to the non-chunked path above.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -313,6 +313,9 @@ If `is_chunked` is true:
    > **Chunk:** $chunk.id of $chunk_count: $chunk.label
    > **Files:** $chunk.files
    >
+   > **File Metadata:**
+   > $file_metadata
+   >
    > **Diff for this chunk:**
    > $chunk.diff
    >

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -307,35 +307,37 @@ If `is_chunked` is true:
 
    For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" (all chunks in parallel):
 
-   > Analyze this chunk of a larger PR to understand its purpose and implementation details.
-   >
-   > **PR:** #$pr_number - $pr_title
-   > **Chunk:** $chunk.id of $chunk_count: $chunk.label
-   > **Files:** $chunk.files
-   >
-   > **File Metadata:**
-   > $file_metadata
-   >
-   > **Diff for this chunk:**
-   > $chunk.diff
-   >
-   > $file_access_instructions
-   >
-   > **Context from full-diff analysis (already gathered):**
-   > $architectural_context
-   >
-   > Build on this context. Focus on chunk-specific details not covered above.
-   >
-   > Provide a brief (2-3 paragraph) summary covering:
-   > 1. What this chunk accomplishes and how it fits the PR's overall goal
-   > 2. Chunk-specific implementation details: data flow, error handling, edge cases
-   > 3. Integration points with other system components
-   >
-   > Time-box to 1-2 minutes of exploration.
+   ```markdown
+   Analyze this chunk of a larger PR to understand its purpose and implementation details.
+
+   **PR:** #$pr_number - $pr_title
+   **Chunk:** $chunk.id of $chunk_count: $chunk.label
+   **Files:** $chunk.files
+
+   **File Metadata:**
+   $file_metadata
+
+   **Diff for this chunk:**
+   $chunk.diff
+
+   $file_access_instructions
+
+   **Context from full-diff analysis (already gathered):**
+   $architectural_context
+
+   Build on this context. Focus on chunk-specific details not covered above.
+
+   Provide a brief (2-3 paragraph) summary covering:
+   1. What this chunk accomplishes and how it fits the PR's overall goal
+   2. Chunk-specific implementation details: data flow, error handling, edge cases
+   3. Integration points with other system components
+
+   Time-box to 1-2 minutes of exploration.
+   ```
 
    Save each chunk's analysis result as `$chunk_analyses[chunk.id]`.
 
-2. For each chunk in the `chunks` array, for each applicable agent:
+2. After all per-chunk analyses complete, for each chunk in the `chunks` array, for each applicable agent:
    - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
    - Add a chunk context header to each agent prompt:
      ```

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -70,6 +70,44 @@ From the session file JSON, extract these fields for building agent context:
 - `file_ref`: (optional) git ref for reading PR files when on a different branch
 - `chunks`: (optional) array of chunk objects when the diff was split
 - `chunk_metadata`: (optional) object with `chunked`, `reason`, `chunk_count`
+- `debug_session_dir`: (optional) path to debug session directory when debug mode is enabled
+
+### Debug Mode Setup
+
+Extract `debug_session_dir` from the session JSON. If it is a non-empty string, debug mode is active for this review. Store it as `$debug_session_dir`.
+
+When `$debug_session_dir` is set, write debug artifacts at key stages by calling the bridge script. Each write is a single Bash call. Debug writes must never block or fail the review: if a write fails, ignore the error and continue.
+
+**Helper pattern for debug writes:**
+
+To save content:
+```bash
+echo '{"action":"save","debug_dir":"$debug_session_dir","stage":"<stage>","filename":"<name>","content":"<text>"}' | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
+```
+
+To record timing:
+```bash
+echo '{"action":"time","debug_dir":"$debug_session_dir","stage":"<stage>","event":"start"}' | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
+```
+
+To write stats:
+```bash
+echo '{"action":"stats","debug_dir":"$debug_session_dir","stage":"<stage>","data":{"key":"value"}}' | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
+```
+
+For content with special characters (quotes, newlines), use jq to build the JSON safely:
+```bash
+jq -n --arg dir "$debug_session_dir" --arg content "$variable_with_content" \
+  '{"action":"save","debug_dir":$dir,"stage":"08-context-explorer","filename":"result.md","content":$content}' \
+  | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
+```
+
+**Stages to instrument (when `$debug_session_dir` is set):**
+
+- **08-context-explorer**: Record timing (start/end). Save the explorer prompt as `prompt.md` and the result (`$architectural_context`) as `result.md`.
+- **09-per-chunk-analysis** (chunked reviews only): Record timing (start/end). For each chunk, save the prompt as `chunk-{id}-prompt.md` and result as `chunk-{id}-result.md`.
+- **10-agent-dispatch**: Record timing (start/end). For each agent (or chunk x agent combination), save the prompt as `{agent}-prompt.md` (or `chunk-{id}-{agent}-prompt.md`) and result as `{agent}-result.md` (or `chunk-{id}-{agent}-result.md`). Save stats with agent count.
+- **11-synthesis**: Record timing (start/end). Save the merged findings as `merged-findings.md` and corroboration results as `corroboration.md`.
 
 **Check for chunked diff:**
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -299,9 +299,9 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 ### Collect and Synthesize Results
 **Chunked review dispatch:**
 
-If `is_chunked` is true, process all chunks in parallel (all agents x all chunks dispatched at once):
+If `is_chunked` is true:
 
-1. **Per-chunk analysis (chunked reviews only):**
+1. **Per-chunk analysis:**
 
    Before dispatching review agents for chunks, run a quick analysis per chunk in parallel:
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -335,7 +335,7 @@ If `is_chunked` is true:
    Time-box to 1-2 minutes of exploration.
    ```
 
-   Save each chunk's analysis result as `$chunk_analyses[chunk.id]`.
+   Save each chunk's analysis result as `$chunk_analyses[$chunk.id]`.
 
 2. After all per-chunk analyses complete, for each chunk in the `chunks` array, for each applicable agent:
    - Replace `$diff` in the agent context with the chunk's `diff` field (the subset of changes for this chunk)
@@ -350,7 +350,7 @@ If `is_chunked` is true:
    - Add the per-chunk analysis to each agent prompt:
      ```
      **Chunk Analysis:**
-     $chunk_analyses[chunk.id]
+     $chunk_analyses[$chunk.id]
      ```
    - Keep all other context the same: full `file_metadata`, full `architectural_context`, full `review_context`, all PR metadata
    - Dispatch all (chunk x agent) combinations in parallel via the Task tool

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -307,8 +307,9 @@ If `is_chunked` is true:
 
    For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" (all chunks in parallel):
 
-   > Analyze this chunk of a larger PR to understand its purpose and architecture.
+   > Analyze this chunk of a larger PR to understand its purpose and implementation details.
    >
+   > **PR:** #$pr_number - $pr_title
    > **Chunk:** $chunk.id of $chunk_count: $chunk.label
    > **Files:** $chunk.files
    >
@@ -317,10 +318,15 @@ If `is_chunked` is true:
    >
    > $file_access_instructions
    >
+   > **Context from full-diff analysis (already gathered):**
+   > $architectural_context
+   >
+   > Build on this context. Focus on chunk-specific details not covered above.
+   >
    > Provide a brief (2-3 paragraph) summary covering:
    > 1. What this chunk accomplishes and how it fits the PR's overall goal
-   > 2. Key architectural patterns, interfaces, and dependencies
-   > 3. Integration points with other chunks or system components
+   > 2. Chunk-specific implementation details: data flow, error handling, edge cases
+   > 3. Integration points with other system components
    >
    > Time-box to 1-2 minutes of exploration.
 

--- a/skills/review-code/scripts/chunk-diff.sh
+++ b/skills/review-code/scripts/chunk-diff.sh
@@ -321,12 +321,20 @@ main() {
                     # Calculate chunk size
                     ($chunk_diff | length / 1024 | floor) as $size_kb |
 
-                    # Generate label from most common top-level directory
-                    ([$chunk.files[] | split("/")[0]] | group_by(.) | sort_by(-length) | .[0][0] // "root") as $top_dir |
+                    # Generate label from top-level directory distribution
+                    # If top dir covers >= 70% of files, use single label; otherwise show top 2
+                    ([$chunk.files[] | split("/")[0]] | group_by(.) | sort_by(-length)) as $dir_groups |
+                    ($chunk.files | length) as $total_files |
+                    ($dir_groups[0] | length) as $top_count |
+                    (if ($top_count * 10 >= $total_files * 7) then
+                        ($dir_groups[0][0] // "root")
+                    else
+                        ($dir_groups[0][0] // "root") + " + " + ($dir_groups[1][0] // "other")
+                    end) as $label_prefix |
 
                     {
                         "id": ($idx + 1),
-                        "label": ($top_dir + " (" + ($chunk.files | length | tostring) + " files)"),
+                        "label": ($label_prefix + " (" + ($chunk.files | length | tostring) + " files)"),
                         "files": $chunk.files,
                         "diff": $chunk_diff,
                         "size_kb": $size_kb

--- a/skills/review-code/scripts/debug-artifact-writer.sh
+++ b/skills/review-code/scripts/debug-artifact-writer.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# debug-artifact-writer.sh - Bridge script for Claude-side debug artifacts
+#
+# Reads JSON from stdin and writes debug artifacts to the session directory.
+# Used by review.md to capture Claude-side stages (context explorer, per-chunk
+# analysis, agent dispatch, synthesis) that run outside bash scripts.
+#
+# Usage:
+#   echo '{"action": "save", "debug_dir": "...", "stage": "...", "filename": "...", "content": "..."}' | debug-artifact-writer.sh
+#
+# Actions:
+#   save  - Write content to {debug_dir}/{stage}/{filename}
+#   time  - Append ndjson timing event to {debug_dir}/timing.ndjson
+#   stats - Write stats JSON to {debug_dir}/{stage}/stats.json
+#
+# All errors are non-fatal: the script exits 0 even on failure to avoid
+# blocking the review.
+
+set -euo pipefail
+
+main() {
+    local input
+    input=$(cat) || {
+        echo "Warning: failed to read stdin" >&2
+        exit 0
+    }
+
+    # Parse common fields in a single jq call
+    local action debug_dir stage
+    read -r action debug_dir stage < <(
+        echo "${input}" | jq -r '[.action // "", .debug_dir // "", .stage // ""] | @tsv'
+    ) || {
+        echo "Warning: invalid JSON" >&2
+        exit 0
+    }
+
+    # Validate debug_dir: must be non-empty and under ~/.cache/review-code/debug/
+    if [[ -z "${debug_dir}" ]]; then
+        echo "Warning: empty debug_dir" >&2
+        exit 0
+    fi
+
+    local expected_prefix="${HOME}/.cache/review-code/debug/"
+    # Also allow REVIEW_CODE_DEBUG_PATH if set
+    local alt_prefix="${REVIEW_CODE_DEBUG_PATH:-}"
+
+    if [[ "${debug_dir}/" != "${expected_prefix}"* ]]; then
+        if [[ -n "${alt_prefix}" ]] && [[ "${debug_dir}/" == "${alt_prefix}/"* ]]; then
+            : # Valid alternative path
+        else
+            echo "Warning: debug_dir '${debug_dir}' is not under expected prefix" >&2
+            exit 0
+        fi
+    fi
+
+    # Validate debug_dir exists
+    if [[ ! -d "${debug_dir}" ]]; then
+        echo "Warning: debug_dir does not exist: ${debug_dir}" >&2
+        exit 0
+    fi
+
+    # Validate stage for path traversal (used by all actions that take a stage)
+    if [[ -n "${stage}" ]] && [[ "${stage}" == *".."* ]]; then
+        echo "Warning: invalid stage (path traversal)" >&2
+        exit 0
+    fi
+
+    case "${action}" in
+        save)
+            local filename
+            filename=$(echo "${input}" | jq -r '.filename // ""') || exit 0
+
+            if [[ -z "${stage}" ]] || [[ -z "${filename}" ]]; then
+                echo "Warning: save requires stage and filename" >&2
+                exit 0
+            fi
+
+            # Prevent path traversal in filename
+            if [[ "${filename}" == *".."* ]] || [[ "${filename}" == *"/"* ]]; then
+                echo "Warning: invalid filename (path traversal)" >&2
+                exit 0
+            fi
+
+            # Content needs separate extraction (can contain tabs/newlines)
+            local content
+            content=$(echo "${input}" | jq -r '.content // ""') || exit 0
+
+            local stage_dir="${debug_dir}/${stage}"
+            mkdir -p "${stage_dir}"
+            printf '%s' "${content}" > "${stage_dir}/${filename}"
+            ;;
+
+        time)
+            local event
+            event=$(echo "${input}" | jq -r '.event // ""') || exit 0
+
+            if [[ -z "${stage}" ]] || [[ -z "${event}" ]]; then
+                echo "Warning: time requires stage and event" >&2
+                exit 0
+            fi
+
+            local timestamp
+            timestamp=$(date +%s.%N)
+
+            jq -nc \
+                --arg stage "${stage}" \
+                --arg event "${event}" \
+                --arg timestamp "${timestamp}" \
+                '{stage: $stage, event: $event, timestamp: ($timestamp | tonumber)}' \
+                >> "${debug_dir}/timing.ndjson" || true
+            ;;
+
+        stats)
+            if [[ -z "${stage}" ]]; then
+                echo "Warning: stats requires stage" >&2
+                exit 0
+            fi
+
+            local stats_data
+            stats_data=$(echo "${input}" | jq -c '.data // {}') || exit 0
+
+            local stage_dir="${debug_dir}/${stage}"
+            mkdir -p "${stage_dir}"
+            echo "${stats_data}" | jq '.' > "${stage_dir}/stats.json" || true
+            ;;
+
+        "")
+            echo "Warning: no action specified" >&2
+            exit 0
+            ;;
+
+        *)
+            echo "Warning: unknown action '${action}'" >&2
+            exit 0
+            ;;
+    esac
+}
+
+main "$@"

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -408,10 +408,11 @@ build_review_data() {
     # Add mode-specific arguments
     jq_args+=("$@")
 
-    # Add force_mode, draft_mode, and self_mode to jq args
+    # Add force_mode, draft_mode, self_mode, and debug_session_dir to jq args
     jq_args+=(--arg force_mode "${force_mode}")
     jq_args+=(--arg draft_mode "${draft_mode}")
     jq_args+=(--arg self_mode "${self_mode}")
+    jq_args+=(--arg debug_session_dir "${DEBUG_SESSION_DIR:-}")
 
     # Single jq invocation with conditional pr field and chunk data
     final_output=$(jq "${jq_args[@]}" \
@@ -433,6 +434,7 @@ build_review_data() {
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $pr[0] != null then {pr: $pr[0], reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
+        + (if $debug_session_dir != "" then {debug_session_dir: $debug_session_dir} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"

--- a/tests/unit/test-chunk-diff.bats
+++ b/tests/unit/test-chunk-diff.bats
@@ -349,6 +349,99 @@ index abc..def 100644
     echo "$output" | jq -e '.chunks | all(.label | contains("files"))'
 }
 
+@test "chunk-diff: dominant directory (>= 70%) gets single-dir label" {
+    # Create 20 files: 8 aaa/ + 2 bbb/ + 10 zzz/
+    # Chunk 1 (sorted): aaa/* (8) + bbb/* (2) = 80% aaa → single label
+    local diff=""
+    for i in $(seq 1 8); do
+        diff="${diff}diff --git a/aaa/f${i}.py b/aaa/f${i}.py
+index abc..def 100644
+--- a/aaa/f${i}.py
++++ b/aaa/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+    for i in $(seq 1 2); do
+        diff="${diff}diff --git a/bbb/f${i}.py b/bbb/f${i}.py
+index abc..def 100644
+--- a/bbb/f${i}.py
++++ b/bbb/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+    for i in $(seq 1 10); do
+        diff="${diff}diff --git a/zzz/f${i}.py b/zzz/f${i}.py
+index abc..def 100644
+--- a/zzz/f${i}.py
++++ b/zzz/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+
+    local input
+    input=$(jq -n --arg diff "$diff" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 5, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 10}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+
+    # The chunk containing aaa/ files should have a single-dir label (no " + ")
+    local aaa_label
+    aaa_label=$(echo "$output" | jq -r '[.chunks[] | select(.files | any(startswith("aaa/")))] | .[0].label')
+    [[ "$aaa_label" == aaa\ * ]]
+    [[ "$aaa_label" != *" + "* ]]
+}
+
+@test "chunk-diff: mixed directory (< 70%) gets dual-dir label" {
+    # Create 20 files: 5 aaa/ + 5 bbb/ + 10 zzz/
+    # Chunk 1 (sorted): aaa/* (5) + bbb/* (5) = 50% each → dual label
+    local diff=""
+    for i in $(seq 1 5); do
+        diff="${diff}diff --git a/aaa/f${i}.py b/aaa/f${i}.py
+index abc..def 100644
+--- a/aaa/f${i}.py
++++ b/aaa/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+    for i in $(seq 1 5); do
+        diff="${diff}diff --git a/bbb/f${i}.py b/bbb/f${i}.py
+index abc..def 100644
+--- a/bbb/f${i}.py
++++ b/bbb/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+    for i in $(seq 1 10); do
+        diff="${diff}diff --git a/zzz/f${i}.py b/zzz/f${i}.py
+index abc..def 100644
+--- a/zzz/f${i}.py
++++ b/zzz/f${i}.py
+@@ -1,3 +1,4 @@
++line ${i}
+"
+    done
+
+    local input
+    input=$(jq -n --arg diff "$diff" \
+        '{"diff": $diff, "config": {"min_chunk_threshold_files": 5, "min_chunk_threshold_kb": 0, "max_files_per_chunk": 10}}')
+
+    run bash -c "printf '%s' '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.chunked == true'
+
+    # The chunk containing both aaa/ and bbb/ should have a dual-dir label with " + "
+    local mixed_label
+    mixed_label=$(echo "$output" | jq -r '[.chunks[] | select(.files | any(startswith("aaa/")))] | .[0].label')
+    [[ "$mixed_label" == *" + "* ]]
+}
+
 # =============================================================================
 # Reason string tests
 # =============================================================================

--- a/tests/unit/test-debug-artifact-writer.bats
+++ b/tests/unit/test-debug-artifact-writer.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+# Tests for debug-artifact-writer.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/debug-artifact-writer.sh"
+
+    # Create a temp directory that mimics the expected debug path
+    TEST_DEBUG_BASE="$BATS_TEST_TMPDIR/.cache/review-code/debug"
+    mkdir -p "$TEST_DEBUG_BASE"
+    TEST_DEBUG_DIR="$TEST_DEBUG_BASE/test-session-$$"
+    mkdir -p "$TEST_DEBUG_DIR"
+}
+
+# Helper: run the script with HOME overridden to match TEST_DEBUG_DIR's prefix
+_run_writer() {
+    run bash -c "export HOME='$BATS_TEST_TMPDIR'; $1"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "debug-artifact-writer: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+# =============================================================================
+# Save action tests
+# =============================================================================
+
+@test "debug-artifact-writer: save creates file at correct path" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"08-context-explorer\",\"filename\":\"result.md\",\"content\":\"# Explorer output\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DEBUG_DIR/08-context-explorer/result.md" ]
+    run cat "$TEST_DEBUG_DIR/08-context-explorer/result.md"
+    [[ "$output" == *"Explorer output"* ]]
+}
+
+@test "debug-artifact-writer: save creates stage directory if missing" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"09-per-chunk\",\"filename\":\"chunk-1-prompt.md\",\"content\":\"test content\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -d "$TEST_DEBUG_DIR/09-per-chunk" ]
+    [ -f "$TEST_DEBUG_DIR/09-per-chunk/chunk-1-prompt.md" ]
+}
+
+@test "debug-artifact-writer: save preserves content exactly" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' --arg content 'hello world' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"test-stage\",\"filename\":\"exact.txt\",\"content\":\$content}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    local saved
+    saved=$(cat "$TEST_DEBUG_DIR/test-stage/exact.txt")
+    [ "$saved" = "hello world" ]
+}
+
+# =============================================================================
+# Time action tests
+# =============================================================================
+
+@test "debug-artifact-writer: time appends to timing.ndjson" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"time\",\"debug_dir\":\$dir,\"stage\":\"08-context-explorer\",\"event\":\"start\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DEBUG_DIR/timing.ndjson" ]
+    run jq -e '.stage == "08-context-explorer" and .event == "start"' "$TEST_DEBUG_DIR/timing.ndjson"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: time appends multiple events" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"time\",\"debug_dir\":\$dir,\"stage\":\"10-agent-dispatch\",\"event\":\"start\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"time\",\"debug_dir\":\$dir,\"stage\":\"10-agent-dispatch\",\"event\":\"end\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    local line_count
+    line_count=$(wc -l < "$TEST_DEBUG_DIR/timing.ndjson" | tr -d ' ')
+    [ "$line_count" -eq 2 ]
+}
+
+@test "debug-artifact-writer: time event has numeric timestamp" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"time\",\"debug_dir\":\$dir,\"stage\":\"test\",\"event\":\"start\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+
+    run jq -e '.timestamp | type == "number"' "$TEST_DEBUG_DIR/timing.ndjson"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Stats action tests
+# =============================================================================
+
+@test "debug-artifact-writer: stats writes stats.json" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"stats\",\"debug_dir\":\$dir,\"stage\":\"10-agent-dispatch\",\"data\":{\"agent_count\":\"7\",\"chunk_count\":\"2\"}}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DEBUG_DIR/10-agent-dispatch/stats.json" ]
+    run jq -e '.agent_count == "7"' "$TEST_DEBUG_DIR/10-agent-dispatch/stats.json"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: stats with empty data writes empty object" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"stats\",\"debug_dir\":\$dir,\"stage\":\"test-stage\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -f "$TEST_DEBUG_DIR/test-stage/stats.json" ]
+    run jq -e '. == {}' "$TEST_DEBUG_DIR/test-stage/stats.json"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Validation tests
+# =============================================================================
+
+@test "debug-artifact-writer: rejects invalid debug_dir path" {
+    _run_writer "echo '{\"action\":\"save\",\"debug_dir\":\"/tmp/evil\",\"stage\":\"test\",\"filename\":\"test.txt\",\"content\":\"hack\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ ! -f "/tmp/evil/test/test.txt" ]
+}
+
+@test "debug-artifact-writer: rejects empty debug_dir" {
+    _run_writer "echo '{\"action\":\"save\",\"debug_dir\":\"\",\"stage\":\"test\",\"filename\":\"test.txt\",\"content\":\"data\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: rejects path traversal in stage" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"../../../etc\",\"filename\":\"passwd\",\"content\":\"bad\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DEBUG_DIR/../../../etc/passwd" ]
+}
+
+@test "debug-artifact-writer: rejects path traversal in filename" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"test\",\"filename\":\"../../etc/passwd\",\"content\":\"bad\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ ! -f "$TEST_DEBUG_DIR/../../etc/passwd" ]
+}
+
+@test "debug-artifact-writer: rejects nonexistent debug_dir" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_BASE/nonexistent-session' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"test\",\"filename\":\"test.txt\",\"content\":\"data\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Graceful handling tests
+# =============================================================================
+
+@test "debug-artifact-writer: handles missing action gracefully" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"debug_dir\":\$dir,\"stage\":\"test\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: handles unknown action gracefully" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"unknown\",\"debug_dir\":\$dir,\"stage\":\"test\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: save with missing stage exits gracefully" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"filename\":\"test.txt\",\"content\":\"data\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: save with missing filename exits gracefully" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"test\",\"content\":\"data\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: time with missing stage exits gracefully" {
+    _run_writer "jq -n --arg dir '$TEST_DEBUG_DIR' \
+        '{\"action\":\"time\",\"debug_dir\":\$dir,\"event\":\"start\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "debug-artifact-writer: accepts REVIEW_CODE_DEBUG_PATH prefix" {
+    local custom_dir="$BATS_TEST_TMPDIR/custom-debug/custom-session"
+    mkdir -p "$custom_dir"
+
+    _run_writer "export REVIEW_CODE_DEBUG_PATH='$BATS_TEST_TMPDIR/custom-debug'; \
+        jq -n --arg dir '$custom_dir' \
+        '{\"action\":\"save\",\"debug_dir\":\$dir,\"stage\":\"test\",\"filename\":\"ok.txt\",\"content\":\"works\"}' \
+        | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [ -f "$custom_dir/test/ok.txt" ]
+}


### PR DESCRIPTION
## Summary

- For chunked reviews, run Explore agents per chunk (in parallel) before dispatching review agents
- Each chunk gets a 2-3 paragraph analysis of its purpose, architecture, and integration points
- Analysis is included in each review agent's prompt as `**Chunk Analysis:**`
- Supplements (does not replace) the existing whole-diff architectural context

## Test plan

- [ ] Run `/review-code` on a large PR that triggers chunking and verify per-chunk analysis runs
- [ ] Verify chunk analysis appears in agent prompts alongside chunk context
- [ ] Verify non-chunked reviews skip the per-chunk analysis step