### PR TITLE
Add solution proportionality check to architecture reviews

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer-architecture
-description: "Use this agent when you need high-level design and architecture review of code changes. Focuses exclusively on necessity, simplicity, established patterns, and code reuse. Examples: Before adding new dependencies, when implementing new features, for refactoring efforts. Use this to question premises and suggest better approaches."
+description: "Use this agent when you need high-level design and architecture review of code changes. Focuses exclusively on necessity, simplicity, established patterns, code reuse, and solution proportionality. Examples: Before adding new dependencies, when implementing new features, for refactoring efforts. Use this to question premises and suggest better approaches."
 model: opus
 color: blue
 ---
@@ -145,6 +145,33 @@ Location: notifications/realtime.py
 - Actual usage: Notifications checked on login (~2x/day per user)
 - Simpler approach: Poll on login; push only for mobile
 - Question: Is real-time actually required here?
+```
+
+### 9. Solution Proportionality (Critical)
+
+Step back from individual code patterns. Sections 1 and 7 flag individual over-built pieces; this section flags the overall PR when those pieces, even if individually defensible, accumulate into a disproportionate whole. Unlike Section 8 (which questions whether the feature should exist), this section assumes the feature is correct and asks whether the implementation is proportionate to it.
+
+**Watch for:**
+- Infrastructure-to-logic ratio: the PR adds significantly more supporting code (types, helpers, configuration, registries, factories, base classes) than actual business logic. Estimate by line count: if lines of types, helpers, registries, factories, and base classes exceed lines of business logic by 3:1 or more, question why.
+- Indirection depth: count how many files or classes a single user action must pass through before reaching the actual logic. Three or more pass-through layers (e.g., handler calls service calls repository calls adapter) with each layer doing little more than delegating is a signal.
+- Layering for the sake of separation: a class or module with a single public method that exists only to call another class's single method, repeated across layers
+- Generalization without variation: generic or parameterized code where only one set of parameters is ever used in the codebase
+
+When flagging disproportionate solutions, include:
+1. A count of infrastructure lines vs. logic lines (e.g., "~453 lines of infrastructure, ~27 lines of logic")
+2. A concrete simpler alternative (e.g., "A single function with direct calls achieves the same result in ~40 lines")
+3. Acknowledgment of when the complexity IS justified: the PR description mentions upcoming extensions, the codebase already uses this level of architecture for similar features, or there is a known scaling requirement
+
+**Example finding:**
+```
+blocking: Solution disproportionate to task [75% confidence]
+Location: notifications/ (6 new files, 480 lines)
+- Adds: EventBus, NotificationStrategy (abstract), NotificationFactory, NotificationRegistry, EmailStrategy, SlackStrategy
+- Infrastructure: ~453 lines of registries, factories, and base classes
+- Actual logic: EmailStrategy sends an email (12 lines), SlackStrategy posts to a webhook (15 lines)
+- Infrastructure-to-logic ratio: ~16:1
+- Simpler alternative: Two functions (send_email_notification, send_slack_notification) called from a match/switch. ~60 lines total. A simple dict/map of channel->function handles extensibility without the class hierarchy.
+- Question for author: Are additional notification channels planned that would justify this architecture?
 ```
 
 ## Self-Challenge Gate

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -186,7 +186,7 @@ Invoke the appropriate agent(s) based on mode and area. If an area is specified,
 | maintainability | code-reviewer-maintainability | Readability, simplicity, long-term code health |
 | testing | code-reviewer-testing | Test coverage, quality, edge cases |
 | compatibility | code-reviewer-compatibility | Backwards compatibility with shipped code |
-| architecture | code-reviewer-architecture | Necessity, patterns, code reuse, simplicity |
+| architecture | code-reviewer-architecture | Necessity, patterns, code reuse, simplicity, solution proportionality |
 | *(frontend detected)* | code-reviewer-frontend | React/TS patterns, components, state, a11y |
 
 **Build the context to pass to each agent:**


### PR DESCRIPTION
## Summary

- Add a new "Solution Proportionality" section (Section 9) to the architecture reviewer that flags PRs where the implementation is disproportionate to the task
- Checks for: high infrastructure-to-logic ratios (3:1+), excessive indirection depth (3+ pass-through layers), layering for the sake of separation, and generalization without variation
- Includes guidance on estimating ratios, proposing concrete simpler alternatives, and recognizing when complexity is justified
- Updates the review handler's architecture description to mention solution proportionality

## Test plan

- [x] All 1103 existing tests pass
- [ ] Run `/review-code` on a PR with over-engineered code and verify the architecture reviewer flags proportionality issues
- [ ] Run `/review-code` on a PR with appropriately complex code and verify no false positives