### PR TITLE
Refine solution proportionality prompt

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -156,7 +156,7 @@ Evaluate whether the total implementation is proportionate to the problem being 
 - The codebase already uses this level of architecture for similar features (check with Grep/Glob)
 - There is a known scaling requirement or domain modeling need (e.g., a well-designed domain layer with value objects and aggregates may have a high infrastructure-to-logic ratio by deliberate design)
 
-If any justification applies, do not file a proportionality finding. If none apply, proceed.
+If any justification applies, either skip the finding or downgrade it to a question/suggestion that explicitly cites the justification. Only file a proportionality finding when the evidence is strong despite the justification. If none apply, proceed.
 
 **Watch for:**
 - Infrastructure-to-logic ratio: the PR adds significantly more supporting code (types, helpers, configuration, registries, factories, base classes) than actual business logic. Estimate by line count: if lines of types, helpers, registries, factories, and base classes exceed lines of business logic by 3:1 or more, question why.

--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -1,6 +1,6 @@
 ---
 name: code-reviewer-architecture
-description: "Use this agent when you need high-level design and architecture review of code changes. Focuses exclusively on necessity, simplicity, established patterns, code reuse, and solution proportionality. Examples: Before adding new dependencies, when implementing new features, for refactoring efforts. Use this to question premises and suggest better approaches."
+description: "Use this agent when you need high-level design and architecture review of code changes. Focuses exclusively on necessity, simplicity, established patterns, and code reuse. Examples: Before adding new dependencies, when implementing new features, for refactoring efforts. Use this to question premises and suggest better approaches."
 model: opus
 color: blue
 ---
@@ -149,18 +149,26 @@ Location: notifications/realtime.py
 
 ### 9. Solution Proportionality (Critical)
 
-Step back from individual code patterns. Sections 1 and 7 flag individual over-built pieces; this section flags the overall PR when those pieces, even if individually defensible, accumulate into a disproportionate whole. Unlike Section 8 (which questions whether the feature should exist), this section assumes the feature is correct and asks whether the implementation is proportionate to it.
+Evaluate whether the total implementation is proportionate to the problem being solved. Assume the feature is correct and necessary. Ask: does the amount of supporting code make sense for what the actual logic accomplishes?
+
+**Before flagging, check for justifications:**
+- The PR description or linked issues mention upcoming extensions that need this architecture
+- The codebase already uses this level of architecture for similar features (check with Grep/Glob)
+- There is a known scaling requirement or domain modeling need (e.g., a well-designed domain layer with value objects and aggregates may have a high infrastructure-to-logic ratio by deliberate design)
+
+If any justification applies, do not file a proportionality finding. If none apply, proceed.
 
 **Watch for:**
 - Infrastructure-to-logic ratio: the PR adds significantly more supporting code (types, helpers, configuration, registries, factories, base classes) than actual business logic. Estimate by line count: if lines of types, helpers, registries, factories, and base classes exceed lines of business logic by 3:1 or more, question why.
-- Indirection depth: count how many files or classes a single user action must pass through before reaching the actual logic. Three or more pass-through layers (e.g., handler calls service calls repository calls adapter) with each layer doing little more than delegating is a signal.
+- Indirection depth: count how many files or classes a single user action must pass through before reaching the actual logic. Three or more pass-through layers (e.g., handler calls service calls repository calls adapter) where each layer adds fewer than 5 lines of logic beyond the delegating call is a signal.
 - Layering for the sake of separation: a class or module with a single public method that exists only to call another class's single method, repeated across layers
 - Generalization without variation: generic or parameterized code where only one set of parameters is ever used in the codebase
 
 When flagging disproportionate solutions, include:
 1. A count of infrastructure lines vs. logic lines (e.g., "~453 lines of infrastructure, ~27 lines of logic")
 2. A concrete simpler alternative (e.g., "A single function with direct calls achieves the same result in ~40 lines")
-3. Acknowledgment of when the complexity IS justified: the PR description mentions upcoming extensions, the codebase already uses this level of architecture for similar features, or there is a known scaling requirement
+
+**Note:** Proportionality findings are inherently holistic. If you cannot point to specific code evidence (line counts, class counts, indirection depth), do not file a finding. The Self-Challenge Gate's "concrete alternative" requirement applies: you must propose a simpler implementation, not just observe that the current one feels heavy.
 
 **Example finding:**
 ```

--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -151,24 +151,22 @@ Location: notifications/realtime.py
 
 Evaluate whether the total implementation is proportionate to the problem being solved. Assume the feature is correct and necessary. Ask: does the amount of supporting code make sense for what the actual logic accomplishes?
 
-**Before flagging, check for justifications:**
-- The PR description or linked issues mention upcoming extensions that need this architecture
-- The codebase already uses this level of architecture for similar features (check with Grep/Glob)
-- There is a known scaling requirement or domain modeling need (e.g., a well-designed domain layer with value objects and aggregates may have a high infrastructure-to-logic ratio by deliberate design)
+**Before flagging, check for justifications using Grep/Glob:**
+- Does the PR description or a linked issue mention upcoming extensions that require this architecture?
+- Does the codebase already use this level of architecture for similar features?
+- Is there an explicit scaling requirement or deliberate domain modeling strategy (e.g., a DDD-style domain layer where a high infrastructure-to-logic ratio is intentional)?
 
-If any justification applies, either skip the finding or downgrade it to a question/suggestion that explicitly cites the justification. Only file a proportionality finding when the evidence is strong despite the justification. If none apply, proceed.
+Use justifications as follows:
+- **Strong justification** (explicit extension plans, codebase precedent): downgrade to a `question` that cites the justification, or skip entirely.
+- **Weak or absent justification**: file the finding as `blocking` or `suggestion` with concrete evidence.
 
 **Watch for:**
-- Infrastructure-to-logic ratio: the PR adds significantly more supporting code (types, helpers, configuration, registries, factories, base classes) than actual business logic. Estimate by line count: if lines of types, helpers, registries, factories, and base classes exceed lines of business logic by 3:1 or more, question why.
-- Indirection depth: count how many files or classes a single user action must pass through before reaching the actual logic. Three or more pass-through layers (e.g., handler calls service calls repository calls adapter) where each layer adds fewer than 5 lines of logic beyond the delegating call is a signal.
-- Layering for the sake of separation: a class or module with a single public method that exists only to call another class's single method, repeated across layers
-- Generalization without variation: generic or parameterized code where only one set of parameters is ever used in the codebase
+- Infrastructure-to-logic ratio: the PR adds significantly more supporting code (types, helpers, configuration, registries, factories, base classes) than actual business logic. Estimate by line count: if infrastructure lines exceed business logic lines by 3:1 or more, question why.
+- Indirection depth: count pass-through layers between a user action and the actual logic. Three or more layers (e.g., handler → service → repository → adapter) where each layer adds little beyond a delegating call is a signal.
+- Layering for the sake of separation: a class or module with a single public method that exists only to call another class's single method, repeated across layers.
+- Generalization without variation: generic or parameterized code where only one set of parameters is ever used in the codebase.
 
-When flagging disproportionate solutions, include:
-1. A count of infrastructure lines vs. logic lines (e.g., "~453 lines of infrastructure, ~27 lines of logic")
-2. A concrete simpler alternative (e.g., "A single function with direct calls achieves the same result in ~40 lines")
-
-**Note:** Proportionality findings are inherently holistic. If you cannot point to specific code evidence (line counts, class counts, indirection depth), do not file a finding. The Self-Challenge Gate's "concrete alternative" requirement applies: you must propose a simpler implementation, not just observe that the current one feels heavy.
+**Required to file a finding:** You must have specific code evidence — line counts, class counts, or a measurable indirection depth. If you can only say the implementation "feels heavy," do not file. You must also propose a concrete simpler alternative (see Self-Challenge Gate).
 
 **Example finding:**
 ```


### PR DESCRIPTION
## Summary

Reduce false positives across review agents by refining prompts for precision.

**Proportionality check (architecture agent):**
- Add justification checks as active verification questions before flagging
- Two-tier decision rule: strong justifications (codebase precedent, explicit plans) downgrade or skip; weak/absent justifications proceed with evidence
- Require concrete evidence (line counts, class counts, indirection depth) to file a finding
- Remove "solution proportionality" from the agent description since it's a secondary check, not a primary focus

**Overly prescriptive rules removed:**
- Error/Result Semantics tracing from context explorer and correctness agents
- "Allocations before early returns" from performance agent
- Mock-production fidelity configuration checking from testing agent

These rules were too specific and pattern-matched on normal code, generating noise rather than catching real issues.

## Test plan

- Run `/review-code` on a PR with heavy infrastructure and verify the agent checks for justifications before flagging
- Run on a well-proportioned PR and confirm no false positives
- Verify removed rules no longer appear in review output