### PR TITLE
Add error semantics tracing and mock fidelity checks to review agents

### DIFF
--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -22,6 +22,7 @@ For each file in the diff:
 - **Callers**: For each significantly modified function or method (especially those whose signature, return type, or error behavior changed), grep for call sites. Report the top 3-5 most relevant callers. Prioritize public API functions over private helpers.
 - **Similar Patterns**: Search for similar code patterns elsewhere in the codebase
 - **Related Tests**: Find test files that cover the modified code
+- **Error/Result Semantics**: When the diff branches on error or result variants, read the producing function and document every condition that yields each variant handled
 
 ### 3. Architectural Context
 
@@ -74,6 +75,7 @@ Focus on context that will help reviewers make better decisions. Be selective â€
 - **Dependencies**: Uses `EmailService` from `backend/services/email.py`
 - **Callers**: Called by signup flow in `backend/api/signup.py`
 - **Similar Patterns**: Password reset in `backend/api/password_reset.py` uses similar flow
+- **Error/Result Semantics**: `TokenStore.get()` returns `TokenNotFound` for both expired tokens and missing tokens â€” callers treating it as "invalid token" will reject expired-but-renewable tokens
 
 ### Architectural Context
 - **Existing Patterns**: Other verification endpoints follow this sequence:

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -93,63 +93,7 @@ Impact: Writes succeed, reads fail silently (falls back to PostgreSQL)
 Fix: Use pickle encoding like insert_flags_for_team_in_redis
 ```
 
-### 3. Error and Result Semantics (Critical)
-
-**Trace into the producing function to understand ALL conditions that yield the variant the diff handles.**
-
-A handler that treats `CacheMiss` as "item not found" is wrong if the producer also returns `CacheMiss` for timeouts or deserialization failures. The handler's assumed meaning must match the producer's full set of return conditions.
-
-**For each error/result branch in the diff:**
-1. Read the function that produces the error/result type
-2. Enumerate ALL conditions that yield the variant being handled
-3. Compare the handler's assumed meaning against the full set of conditions
-4. Flag when the handler assumes a narrow meaning but the type covers broader failures
-
-**Red Flags:**
-- Handler treats an error as "not found" but the producer also returns it for transient failures (timeouts, connection errors)
-- Handler writes to a negative cache on error, but the error may signal a transient failure rather than a definitive absence
-- Comment says "X means Y" but the implementation shows X also means Z
-
-**Error Variant Reuse:**
-
-When new code returns an existing error variant, verify the variant's semantics fit the new context:
-
-- Does the error's name/message accurately describe what happened in the new code path?
-- Will downstream handlers that match on this variant behave correctly, and will logs/metrics be accurate? (e.g., "Row not found in postgres" surfacing from a path that never touches Postgres)
-
-**Example:**
-```text
-❌ Error variant has broader meaning than handler assumes [90% confidence]
-Location: flag_service.rs:122-125
-
-Handler assumes:
-  HyperCacheError::CacheMiss  →  "token does not exist"
-
-But HyperCacheReader::get_with_source() returns CacheMiss for:
-  - Key genuinely not found in Redis or S3 (authoritative miss)
-  - Redis connection timeout or get error
-  - S3 timeout or download error
-  - JSON/pickle deserialization failure
-
-Impact: When skip_pg=true, a Redis timeout causes the token to be
-negative-cached for 300s. Valid requests fail even after cache recovers.
-
-Fix: Distinguish authoritative "not found" from transient cache failures.
-Return a retriable error for transient failures instead of treating all
-CacheMiss variants as "token invalid".
-
-⚠️ Error variant semantics don't match usage [80% confidence]
-Location: flag_service.rs:124
-- Code returns FlagError::RowNotFound when PG fallback is skipped
-- But RowNotFound's message is "Row not found in postgres"
-- This path never touches Postgres — it's a deliberate cache-only lookup
-- Downstream: is_token_not_found() matches RowNotFound → inserts into negative cache
-  (correct behavior, but misleading error identity in logs/metrics)
-- Fix: Add a dedicated error variant like TeamCacheMiss or TokenNotInCache
-  that is_token_not_found() also matches
-```
-
-### 4. Basic Logic Correctness (Critical)
+### 3. Basic Logic Correctness (Critical)
 
 **Does the code do what it's supposed to do within its own scope?**
 
@@ -184,9 +128,17 @@ Location: cache.rs:45
 - Fix: Use >= for boundary condition
 ```
 
-### 5. Cross-Function Correctness (Critical)
+### 4. Cross-Function Correctness (Critical)
 
 **A function may be locally correct but break invariants expected by other code.**
+
+**Return Value Semantics:**
+
+When code branches on a value from another function (error variants, enums, status codes, booleans), trace into the producer and enumerate ALL conditions that yield the value being handled. Flag when the handler assumes a narrower meaning than the producer actually returns.
+
+- Handler assumes "not found" but the producer also returns the same value for transient failures, timeouts, or deserialization errors
+- New code returns an existing variant in a context that doesn't match the variant's name, message, or downstream handler expectations
+- Handler takes an irreversible action (negative caching, deletion) on a value that can also signal a temporary condition
 
 **Optimization Safety:**
 
@@ -235,7 +187,7 @@ Location: cache_service.py:89
 - Fix: Either expand `warm_cache()` or handle cache misses in `get_cached_user()`
 ```
 
-### 6. Behavioral Change Analysis (Critical)
+### 5. Behavioral Change Analysis (Critical)
 
 **Every removed or modified line had a reason to exist. Verify the old behavior wasn't lost by accident.**
 
@@ -265,7 +217,7 @@ Location: cache_service.py:45
 - Question: Was removing the cache intentional? The PR description doesn't mention it.
 ```
 
-### 7. Utility Adoption (Important)
+### 6. Utility Adoption (Important)
 
 **When helpers exist, verify they're actually used.**
 

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -93,7 +93,63 @@ Impact: Writes succeed, reads fail silently (falls back to PostgreSQL)
 Fix: Use pickle encoding like insert_flags_for_team_in_redis
 ```
 
-### 3. Basic Logic Correctness (Critical)
+### 3. Error and Result Semantics (Critical)
+
+**Trace into the producing function to understand ALL conditions that yield the variant the diff handles.**
+
+A handler that treats `CacheMiss` as "item not found" is wrong if the producer also returns `CacheMiss` for timeouts or deserialization failures. The handler's assumed meaning must match the producer's full set of return conditions.
+
+**For each error/result branch in the diff:**
+1. Read the function that produces the error/result type
+2. Enumerate ALL conditions that yield the variant being handled
+3. Compare the handler's assumed meaning against the full set of conditions
+4. Flag when the handler assumes a narrow meaning but the type covers broader failures
+
+**Red Flags:**
+- Handler treats an error as "not found" but the producer also returns it for transient failures (timeouts, connection errors)
+- Handler writes to a negative cache on error, but the error may signal a transient failure rather than a definitive absence
+- Comment says "X means Y" but the implementation shows X also means Z
+
+**Error Variant Reuse:**
+
+When new code returns an existing error variant, verify the variant's semantics fit the new context:
+
+- Does the error's name/message accurately describe what happened in the new code path?
+- Will downstream handlers that match on this variant behave correctly, and will logs/metrics be accurate? (e.g., "Row not found in postgres" surfacing from a path that never touches Postgres)
+
+**Example:**
+```text
+❌ Error variant has broader meaning than handler assumes [90% confidence]
+Location: flag_service.rs:122-125
+
+Handler assumes:
+  HyperCacheError::CacheMiss  →  "token does not exist"
+
+But HyperCacheReader::get_with_source() returns CacheMiss for:
+  - Key genuinely not found in Redis or S3 (authoritative miss)
+  - Redis connection timeout or get error
+  - S3 timeout or download error
+  - JSON/pickle deserialization failure
+
+Impact: When skip_pg=true, a Redis timeout causes the token to be
+negative-cached for 300s. Valid requests fail even after cache recovers.
+
+Fix: Distinguish authoritative "not found" from transient cache failures.
+Return a retriable error for transient failures instead of treating all
+CacheMiss variants as "token invalid".
+
+⚠️ Error variant semantics don't match usage [80% confidence]
+Location: flag_service.rs:124
+- Code returns FlagError::RowNotFound when PG fallback is skipped
+- But RowNotFound's message is "Row not found in postgres"
+- This path never touches Postgres — it's a deliberate cache-only lookup
+- Downstream: is_token_not_found() matches RowNotFound → inserts into negative cache
+  (correct behavior, but misleading error identity in logs/metrics)
+- Fix: Add a dedicated error variant like TeamCacheMiss or TokenNotInCache
+  that is_token_not_found() also matches
+```
+
+### 4. Basic Logic Correctness (Critical)
 
 **Does the code do what it's supposed to do within its own scope?**
 
@@ -128,7 +184,7 @@ Location: cache.rs:45
 - Fix: Use >= for boundary condition
 ```
 
-### 4. Cross-Function Correctness (Critical)
+### 5. Cross-Function Correctness (Critical)
 
 **A function may be locally correct but break invariants expected by other code.**
 
@@ -179,7 +235,7 @@ Location: cache_service.py:89
 - Fix: Either expand `warm_cache()` or handle cache misses in `get_cached_user()`
 ```
 
-### 5. Behavioral Change Analysis (Critical)
+### 6. Behavioral Change Analysis (Critical)
 
 **Every removed or modified line had a reason to exist. Verify the old behavior wasn't lost by accident.**
 
@@ -209,7 +265,7 @@ Location: cache_service.py:45
 - Question: Was removing the cache intentional? The PR description doesn't mention it.
 ```
 
-### 6. Utility Adoption (Important)
+### 7. Utility Adoption (Important)
 
 **When helpers exist, verify they're actually used.**
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -53,6 +53,7 @@ Never reduce confidence because a query is in a conditional path. Ask: "What mak
 - Excessive object allocations in loops
 - String concatenation in loops instead of builders
 - Unbounded caches without eviction policies
+- Allocations or clones before conditional early returns — defer expensive work (`.to_string()`, `.clone()`, acquiring connections) until after the condition that guards whether it's needed
 
 ### 4. Async & Concurrency (Important)
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -34,6 +34,22 @@ Review only testing concerns. Do NOT provide feedback on security, performance, 
 - **Appropriate scope**: Mocks used for external dependencies, not internal logic
 - **Over-mocking**: Excessive mocking that obscures actual behavior or tests the mock instead of the code
 - **Balance**: Appropriate ratio of unit to integration tests
+- **Mock-production fidelity**: When tests use helper functions to create mocks or fakes, verify the helper matches the production configuration for the code path under test — right mode, key format, and namespace. A helper written for one subsystem (e.g., a feature-flag cache reader with `token_based=false`) reused for a different subsystem (e.g., a team-metadata reader requiring `token_based=true`) will pass while exercising the wrong behavior.
+
+**Example:**
+```text
+❌ Test helper creates wrong component configuration [90% confidence]
+Location: flag_service_tests.rs:312
+- Test uses setup_hypercache_reader_with_mock_redis() for team_hypercache_reader
+- But that helper configures a feature-flags HyperCache reader (token_based=false,
+  namespace: feature_flags/flags.json)
+- Production team token lookups use a team-metadata reader (token_based=true,
+  namespace: team_metadata/full_metadata.json)
+- Impact: Test passes but exercises the wrong cache key/namespace behavior.
+  Real cache mismatches won't be caught.
+- Fix: Create a setup_team_hypercache_reader() helper with the correct
+  team-metadata configuration (token_based=true)
+```
 
 ### 4. Test Reliability
 


### PR DESCRIPTION
## Summary

- **Correctness agent**: Add "Return Value Semantics" subsection to Cross-Function Correctness — when code branches on a value from another function, trace into the producer and verify the handler's assumptions match all conditions that yield that value. Generalized to cover error variants, enums, status codes, and booleans.
- **Context explorer agent**: Add "Error/Result Semantics" to pre-review context gathering, so review agents receive documentation of what conditions produce each variant the diff handles.
- **Testing agent**: Add "Mock-production fidelity" check that flags test helpers configured for one subsystem being reused for a different subsystem with incompatible settings.
- **Performance agent**: Add check for allocations/clones performed before conditional early returns on hot paths.

Addresses gaps identified by comparing our PR #51730 review output against Copilot's findings.

## Test plan

- [x] `bin/test` passes (1103 tests)
- [ ] Run `/review-code` on a PR with error-handling changes and verify the new checks fire