### PR TITLE
Add --overwrite and --append flags to skip review file prompt

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -43,6 +43,8 @@ Run specialized code review agent(s) with comprehensive context on local changes
 - `--force` or `-f` - Skip the pre-flight context clear prompt
 - `--draft` or `-d` - Create a pending GitHub review with inline comments (PR mode only). Automatically detects and adjusts for comment drift when the PR receives new commits between review generation and draft posting.
 - `--self` - Allow creating draft review on your own PR (for testing)
+- `--overwrite` - Replace existing review file without prompting
+- `--append` - Append to existing review file without prompting
 
 **Optional File Pattern:**
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -51,11 +51,14 @@ If user selects "Migrate and continue":
 
 **If `file_info.file_exists` is true** (a review file exists but neither of the above conditions apply):
 
-Use AskUserQuestion to ask what to do with the existing review:
-- Options:
-  1. "Overwrite": Replace the existing review
-  2. "Append": Add new findings to the existing review
-  3. "Cancel": Stop without reviewing
+First, check the session JSON for `overwrite` and `append` flags:
+- If `overwrite` is true: proceed as "Overwrite" (replace the existing review) without prompting.
+- If `append` is true: proceed as "Append" (add new findings to the existing review) without prompting.
+- Otherwise, use AskUserQuestion to ask what to do with the existing review:
+  - Options:
+    1. "Overwrite": Replace the existing review
+    2. "Append": Add new findings to the existing review
+    3. "Cancel": Stop without reviewing
 
 ### Extract Session Data
 

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -17,6 +17,8 @@ DRAFT_MODE="false"
 SELF_MODE="false"
 APPLY_MODE="false"
 LEARN_MODE="false"
+OVERWRITE_MODE="false"
+APPEND_MODE="false"
 remaining_args=()
 
 for arg_item in "$@"; do
@@ -28,6 +30,10 @@ for arg_item in "$@"; do
         SELF_MODE="true"
     elif [[ "${arg_item}" == "--apply" ]]; then
         APPLY_MODE="true"
+    elif [[ "${arg_item}" == "--overwrite" ]]; then
+        OVERWRITE_MODE="true"
+    elif [[ "${arg_item}" == "--append" ]]; then
+        APPEND_MODE="true"
     else
         remaining_args+=("${arg_item}")
     fi
@@ -183,6 +189,16 @@ build_json_output() {
         jq_args+=("--arg" "apply_mode" "true")
     fi
 
+    # Add overwrite_mode if enabled
+    if [[ "${OVERWRITE_MODE}" == "true" ]]; then
+        jq_args+=("--arg" "overwrite_mode" "true")
+    fi
+
+    # Add append_mode if enabled
+    if [[ "${APPEND_MODE}" == "true" ]]; then
+        jq_args+=("--arg" "append_mode" "true")
+    fi
+
     jq -nc "${jq_args[@]}" "${jq_filter}"
 }
 
@@ -208,6 +224,14 @@ validate_draft_mode() {
 validate_apply_mode() {
     if [[ "${APPLY_MODE}" == "true" ]] && [[ "${LEARN_MODE}" != "true" ]]; then
         build_json_error "--apply flag only works with learn mode. Use '/review-code learn --apply'"
+        exit 1
+    fi
+}
+
+# Helper: Validate overwrite and append are not both specified
+validate_overwrite_append_mode() {
+    if [[ "${OVERWRITE_MODE}" == "true" ]] && [[ "${APPEND_MODE}" == "true" ]]; then
+        build_json_error "--overwrite and --append are mutually exclusive. Use one or the other."
         exit 1
     fi
 }
@@ -491,6 +515,9 @@ detect_no_arg() {
 if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
     # Validate --apply flag is only used with learn mode (early check)
     validate_apply_mode
+
+    # Validate --overwrite and --append are mutually exclusive
+    validate_overwrite_append_mode
 
     # 0. Learn Mode (Highest Priority - before review modes)
     if detect_learn_mode; then

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -49,6 +49,10 @@ main() {
     draft_mode=$(echo "${parse_result}" | jq -r '.draft_mode // "false"')
     local self_mode
     self_mode=$(echo "${parse_result}" | jq -r '.self_mode // "false"')
+    local overwrite_mode
+    overwrite_mode=$(echo "${parse_result}" | jq -r '.overwrite_mode // "false"')
+    local append_mode
+    append_mode=$(echo "${parse_result}" | jq -r '.append_mode // "false"')
 
     # Extract org/repo early for git-based modes
     # Cache git org/repo to avoid redundant operations
@@ -408,10 +412,12 @@ build_review_data() {
     # Add mode-specific arguments
     jq_args+=("$@")
 
-    # Add force_mode, draft_mode, self_mode, and debug_session_dir to jq args
+    # Add force_mode, draft_mode, self_mode, overwrite_mode, append_mode, and debug_session_dir to jq args
     jq_args+=(--arg force_mode "${force_mode}")
     jq_args+=(--arg draft_mode "${draft_mode}")
     jq_args+=(--arg self_mode "${self_mode}")
+    jq_args+=(--arg overwrite_mode "${overwrite_mode}")
+    jq_args+=(--arg append_mode "${append_mode}")
     jq_args+=(--arg debug_session_dir "${DEBUG_SESSION_DIR:-}")
 
     # Single jq invocation with conditional pr field and chunk data
@@ -432,6 +438,8 @@ build_review_data() {
         + (if $force_mode == "true" then {force: true} else {} end)
         + (if $draft_mode == "true" then {draft: true} else {} end)
         + (if $self_mode == "true" then {self: true} else {} end)
+        + (if $overwrite_mode == "true" then {overwrite: true} else {} end)
+        + (if $append_mode == "true" then {append: true} else {} end)
         + (if $pr[0] != null then {pr: $pr[0], reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
         + (if $debug_session_dir != "" then {debug_session_dir: $debug_session_dir} else {} end)

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -638,3 +638,116 @@ reset_globals() {
     [ "$FIND_MODE" = "true" ]
     [ "$LEARN_MODE" = "false" ]
 }
+
+# =============================================================================
+# Overwrite / Append mode tests
+# =============================================================================
+
+@test "overwrite mode: OVERWRITE_MODE is false by default" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh"
+    [ "$OVERWRITE_MODE" = "false" ]
+}
+
+@test "append mode: APPEND_MODE is false by default" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh"
+    [ "$APPEND_MODE" = "false" ]
+}
+
+@test "overwrite mode: --overwrite sets OVERWRITE_MODE" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--overwrite" "123"
+    [ "$OVERWRITE_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "append mode: --append sets APPEND_MODE" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--append" "123"
+    [ "$APPEND_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "overwrite mode: --overwrite as second argument" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "123" "--overwrite"
+    [ "$OVERWRITE_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "append mode: --append as second argument" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "123" "--append"
+    [ "$APPEND_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "overwrite mode: build_json_output includes overwrite_mode when set" {
+    file_pattern=""
+    OVERWRITE_MODE="true"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"overwrite_mode":"true"'* ]]
+}
+
+@test "overwrite mode: build_json_output excludes overwrite_mode when false" {
+    file_pattern=""
+    OVERWRITE_MODE="false"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'"overwrite_mode"'* ]]
+}
+
+@test "append mode: build_json_output includes append_mode when set" {
+    file_pattern=""
+    APPEND_MODE="true"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"append_mode":"true"'* ]]
+}
+
+@test "append mode: build_json_output excludes append_mode when false" {
+    file_pattern=""
+    APPEND_MODE="false"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'"append_mode"'* ]]
+}
+
+@test "overwrite + append: mutually exclusive validation fails" {
+    OVERWRITE_MODE="true"
+    APPEND_MODE="true"
+    run validate_overwrite_append_mode
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"mutually exclusive"* ]]
+}
+
+@test "overwrite + append: validation passes with only overwrite" {
+    OVERWRITE_MODE="true"
+    APPEND_MODE="false"
+    run validate_overwrite_append_mode
+    [ "$status" -eq 0 ]
+}
+
+@test "overwrite + append: validation passes with only append" {
+    OVERWRITE_MODE="false"
+    APPEND_MODE="true"
+    run validate_overwrite_append_mode
+    [ "$status" -eq 0 ]
+}
+
+@test "overwrite + append: validation passes with neither" {
+    OVERWRITE_MODE="false"
+    APPEND_MODE="false"
+    run validate_overwrite_append_mode
+    [ "$status" -eq 0 ]
+}
+
+@test "overwrite mode: combines with --force" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--force" "--overwrite" "123"
+    [ "$FORCE_MODE" = "true" ]
+    [ "$OVERWRITE_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "append mode: combines with --draft" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--draft" "--append" "123"
+    [ "$DRAFT_MODE" = "true" ]
+    [ "$APPEND_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}


### PR DESCRIPTION
## Summary

- Adds `--overwrite` and `--append` CLI flags to the review-code skill
- When an existing review file is found, these flags skip the interactive prompt and proceed directly with the chosen action
- The flags are mutually exclusive; specifying both produces an error

## Test plan

- Run `/review-code --overwrite` on a PR with an existing review file — should overwrite without prompting
- Run `/review-code --append` on a PR with an existing review file — should append without prompting
- Run `/review-code --overwrite --append` — should error with "mutually exclusive" message
- Run `/review-code` on a PR with an existing review file without either flag — should prompt as before
- Run `bin/test` — all 813 tests pass