### PR TITLE
Add git history analysis to code review pipeline

### DIFF
--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -41,12 +41,12 @@ Gather only when relevant to the changes:
 ### 5. Git History Context
 
 Check `file_metadata` for files with `git_history.high_churn: true`. For each high-churn file:
-- Run `git log --oneline -5 <file>` to show recent changes
-- Note if recent commits show a pattern of fixes (stability concern) or if many different authors are modifying the file (coordination risk)
+- Run `git log --oneline -5 <file>` to surface recent changes
+- Classify the pattern: repeated fix commits (stability risk), many distinct authors (coordination risk), or neutral (feature build-up)
 
 For code that looks surprising or non-obvious during your investigation:
-- Run `git log -1 --format="%s%n%n%b" -S "<surprising_code_snippet>" -- <file>` to find the commit that introduced it and understand why it was written that way
-- Only include this context when it would help reviewers understand intent
+- Run `git log -1 --format="%s%n%n%b" -S "<surprising_code_snippet>" -- <file>` to find the commit that introduced it
+- Include the commit subject and body when they explain *why* the code is written the way it is — skip it when the commit message adds nothing beyond what the code says
 
 ## Output Format
 
@@ -68,8 +68,8 @@ For code that looks surprising or non-obvious during your investigation:
 [Database schema, API patterns, security context, etc. — only if relevant]
 
 ### Git History Context
-- **High-Churn Files**: Files with frequent recent changes and their recent commit summaries
-- **Notable History**: Commit messages explaining non-obvious code patterns
+- **High-Churn Files**: `path/to/file` — recent commit pattern (e.g., "5 of last 5 commits are bug fixes — stability risk")
+- **Surprising Code**: Commit that introduced `<snippet>` — subject and body if they explain intent
 
 ### Key Files for Review
 1. `path/to/file.py` — Modified file doing X
@@ -102,6 +102,10 @@ Focus on context that will help reviewers make better decisions. Be selective �
 
 ### Special Context
 **Security**: Three other endpoints validate email format using `EmailValidator.is_valid()`
+
+### Git History Context
+- **High-Churn Files**: `backend/api/auth.py` — 4 of last 5 commits are bug fixes ("Fix token expiry edge case", "Fix double-send on retry") — stability risk
+- **Surprising Code**: The `time.sleep(0.1)` in `send_verification_email` was added in "Throttle email sends to avoid SES rate limit" (2024-08) — intentional, not a performance bug
 
 ### Key Files for Review
 1. `backend/api/auth.py` — New verification endpoint

--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -38,6 +38,16 @@ Gather only when relevant to the changes:
 - **Security-Sensitive**: Find existing security patterns when auth or validation code changes
 - **Performance-Critical**: Find similar optimizations when queries or loops are modified
 
+### 5. Git History Context
+
+Check `file_metadata` for files with `git_history.high_churn: true`. For each high-churn file:
+- Run `git log --oneline -5 <file>` to show recent changes
+- Note if recent commits show a pattern of fixes (stability concern) or if many different authors are modifying the file (coordination risk)
+
+For code that looks surprising or non-obvious during your investigation:
+- Run `git log -1 --format="%s%n%n%b" -S "<surprising_code_snippet>" -- <file>` to find the commit that introduced it and understand why it was written that way
+- Only include this context when it would help reviewers understand intent
+
 ## Output Format
 
 ```markdown
@@ -56,6 +66,10 @@ Gather only when relevant to the changes:
 
 ### Special Context
 [Database schema, API patterns, security context, etc. — only if relevant]
+
+### Git History Context
+- **High-Churn Files**: Files with frequent recent changes and their recent commit summaries
+- **Notable History**: Commit messages explaining non-obvious code patterns
 
 ### Key Files for Review
 1. `path/to/file.py` — Modified file doing X

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -166,7 +166,8 @@ Explore the codebase to understand:
   (grep for function/method names, report top 3-5 callers per significantly modified function)
 - Existing patterns for similar functionality
 - Reusable utilities or conventions
-- Git history context for high-churn files (check `git_history` in file_metadata for `high_churn: true` flags, then run targeted git log commands)
+- Git history for high-churn files and surprising code
+  (check `git_history.high_churn` flags in file_metadata; run `git log` for flagged files and for any code whose purpose is non-obvious)
 
 Time-box yourself to 2-3 minutes of exploration.
 ```

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -166,6 +166,7 @@ Explore the codebase to understand:
   (grep for function/method names, report top 3-5 callers per significantly modified function)
 - Existing patterns for similar functionality
 - Reusable utilities or conventions
+- Git history context for high-churn files (check `git_history` in file_metadata for `high_churn: true` flags, then run targeted git log commands)
 
 Time-box yourself to 2-3 minutes of exploration.
 ```

--- a/skills/review-code/scripts/git-file-history.sh
+++ b/skills/review-code/scripts/git-file-history.sh
@@ -50,9 +50,9 @@ main() {
             continue
         fi
 
-        # Single git log call: author and date in one pass (tab-separated)
+        # Single git log call: author email and date in one pass (tab-separated)
         local log_output
-        log_output=$(git log --since="30 days ago" --format="%an%x09%as" -- "${file_path}" 2> /dev/null || echo "")
+        log_output=$(git log --since="30 days ago" --format="%ae%x09%as" -- "${file_path}" 2> /dev/null || echo "")
 
         local recent_commits=0
         local recent_authors=0

--- a/skills/review-code/scripts/git-file-history.sh
+++ b/skills/review-code/scripts/git-file-history.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# git-file-history.sh - Compute git history metrics for files
+#
+# Usage:
+#   echo -e "path/to/file1\npath/to/file2" | git-file-history.sh
+#
+# Input:
+#   Newline-delimited file paths on stdin
+#
+# Output (JSON):
+#   {
+#     "path/to/file1": {
+#       "recent_commits": 12,
+#       "recent_authors": 4,
+#       "last_modified": "2026-03-18",
+#       "high_churn": true
+#     }
+#   }
+#
+# Thresholds:
+#   high_churn = true when recent_commits >= 10 OR recent_authors >= 3
+#   History window: 30 days
+#   Max files: 50
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared helpers
+source "${SCRIPT_DIR}/helpers/git-helpers.sh"
+
+# Thresholds
+COMMIT_THRESHOLD=10
+AUTHOR_THRESHOLD=3
+MAX_FILES=50
+
+main() {
+    validate_git_repo
+
+    local file_count=0
+
+    # Build ndjson (one object per file), then merge into a single object
+    local ndjson=""
+
+    while IFS= read -r file_path; do
+        [[ -z "${file_path}" ]] && continue
+
+        file_count=$((file_count + 1))
+        if [[ ${file_count} -gt ${MAX_FILES} ]]; then
+            break
+        fi
+
+        # Single git log call: author and date in one pass (tab-separated)
+        local log_output
+        log_output=$(git log --since="30 days ago" --format="%an%x09%as" -- "${file_path}" 2> /dev/null || echo "")
+
+        local recent_commits=0
+        local recent_authors=0
+        local last_modified=""
+
+        if [[ -n "${log_output}" ]]; then
+            recent_commits=$(echo "${log_output}" | wc -l | tr -d ' ')
+            recent_authors=$(echo "${log_output}" | cut -f1 | sort -u | wc -l | tr -d ' ')
+            last_modified=$(echo "${log_output}" | head -1 | cut -f2)
+        fi
+
+        # For files dormant >30 days, fetch absolute last_modified
+        if [[ -z "${last_modified}" ]]; then
+            last_modified=$(git log -1 --format="%as" -- "${file_path}" 2> /dev/null || echo "")
+        fi
+
+        # Determine high churn
+        local high_churn=false
+        if [[ ${recent_commits} -ge ${COMMIT_THRESHOLD} ]] || [[ ${recent_authors} -ge ${AUTHOR_THRESHOLD} ]]; then
+            high_churn=true
+        fi
+
+        # Build JSON entry using jq for safe escaping
+        ndjson+=$(jq -nc \
+            --arg path "${file_path}" \
+            --argjson commits "${recent_commits}" \
+            --argjson authors "${recent_authors}" \
+            --arg modified "${last_modified}" \
+            --argjson churn "${high_churn}" \
+            '{($path): {recent_commits: $commits, recent_authors: $authors, last_modified: (if $modified == "" then null else $modified end), high_churn: $churn}}')
+        ndjson+=$'\n'
+
+    done
+
+    # Merge all per-file objects into one; empty input produces {}
+    if [[ -n "${ndjson}" ]]; then
+        echo "${ndjson}" | jq -s 'add'
+    else
+        echo "{}"
+    fi
+}
+
+# Only run main if script is executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/git-file-history.sh
+++ b/skills/review-code/scripts/git-file-history.sh
@@ -47,7 +47,7 @@ main() {
 
         file_count=$((file_count + 1))
         if [[ ${file_count} -gt ${MAX_FILES} ]]; then
-            break
+            continue
         fi
 
         # Single git log call: author and date in one pass (tab-separated)

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -274,6 +274,24 @@ build_review_data() {
     local file_metadata
     file_metadata=$(echo "${diff_content}" | "${SCRIPT_DIR}/pre-review-context.sh")
 
+    # Compute git history metrics for modified files
+    local git_history
+    git_history=$(echo "${file_metadata}" | jq -r '.modified_files[].path' | "${SCRIPT_DIR}/git-file-history.sh")
+
+    # Validate git_history is valid JSON (safety check)
+    if ! echo "${git_history}" | jq empty 2> /dev/null; then
+        error "Invalid JSON from git-file-history.sh"
+        exit 1
+    fi
+
+    # Merge git history into file_metadata
+    file_metadata=$(echo "${file_metadata}" | jq --argjson history "${git_history}" '
+        .modified_files |= map(
+            . + {git_history: ($history[.path] // {recent_commits: 0, recent_authors: 0, last_modified: null, high_churn: false})}
+        )
+        | . + {has_high_churn_files: ([.modified_files[] | select(.git_history.high_churn == true)] | length > 0)}
+    ')
+
     # Extract org/repo from git_context
     local org repo
     org=$(echo "${git_context}" | jq -r '.org')

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -274,14 +274,18 @@ build_review_data() {
     local file_metadata
     file_metadata=$(echo "${diff_content}" | "${SCRIPT_DIR}/pre-review-context.sh")
 
-    # Compute git history metrics for modified files
-    local git_history
-    git_history=$(echo "${file_metadata}" | jq -r '.modified_files[].path' | "${SCRIPT_DIR}/git-file-history.sh")
+    # Compute git history metrics for modified files (only when inside a git repo)
+    local git_history='{}'
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        git_history=$(echo "${file_metadata}" | jq -r '.modified_files[].path' | "${SCRIPT_DIR}/git-file-history.sh")
 
-    # Validate git_history is valid JSON (safety check)
-    if ! echo "${git_history}" | jq empty 2> /dev/null; then
-        error "Invalid JSON from git-file-history.sh"
-        exit 1
+        # Validate git_history is valid JSON (safety check)
+        if ! echo "${git_history}" | jq empty 2> /dev/null; then
+            error "Invalid JSON from git-file-history.sh"
+            exit 1
+        fi
+    else
+        debug_trace "build_review_data" "Not inside a git repository; skipping git history analysis"
     fi
 
     # Merge git history into file_metadata

--- a/tests/unit/test-git-file-history.bats
+++ b/tests/unit/test-git-file-history.bats
@@ -70,13 +70,15 @@ teardown() {
 }
 
 @test "git-file-history.sh: counts unique authors correctly" {
-    # Add commits from different authors
+    # Add commits from different authors (must change email since script uses %ae)
     git config user.name "Author Two"
+    git config user.email "author2@example.com"
     echo "change 2" >> file.txt
     git add file.txt
     git commit -m "Change by author 2"
 
     git config user.name "Author Three"
+    git config user.email "author3@example.com"
     echo "change 3" >> file.txt
     git add file.txt
     git commit -m "Change by author 3"
@@ -94,13 +96,15 @@ teardown() {
 # =============================================================================
 
 @test "git-file-history.sh: flags high churn at 3+ authors" {
-    # Add commits from 2 more authors (total 3)
+    # Add commits from 2 more authors (total 3, must change email since script uses %ae)
     git config user.name "Author Two"
+    git config user.email "author2@example.com"
     echo "change 2" >> file.txt
     git add file.txt
     git commit -m "Change by author 2"
 
     git config user.name "Author Three"
+    git config user.email "author3@example.com"
     echo "change 3" >> file.txt
     git add file.txt
     git commit -m "Change by author 3"

--- a/tests/unit/test-git-file-history.bats
+++ b/tests/unit/test-git-file-history.bats
@@ -46,7 +46,7 @@ teardown() {
     run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
     [ "$status" -eq 0 ]
 
-    echo "$output" | jq -e '."file.txt" | has("recent_commits", "recent_authors", "last_modified", "high_churn")' > /dev/null
+    echo "$output" | jq -e '."file.txt" | has("recent_commits") and has("recent_authors") and has("last_modified") and has("high_churn")' > /dev/null
 }
 
 # =============================================================================

--- a/tests/unit/test-git-file-history.bats
+++ b/tests/unit/test-git-file-history.bats
@@ -1,0 +1,202 @@
+#!/usr/bin/env bats
+# Tests for git-file-history.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    # Create a temporary git repository for testing
+    TEST_REPO=$(mktemp -d)
+    cd "$TEST_REPO"
+    git init
+    git config commit.gpgsign false
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+
+    # Create initial commit
+    echo "initial" > file.txt
+    git add file.txt
+    git commit -m "Initial commit"
+
+    # Add a remote to extract org/repo
+    git remote add origin "https://github.com/testorg/testrepo.git"
+}
+
+teardown() {
+    rm -rf "$TEST_REPO"
+}
+
+# =============================================================================
+# JSON output structure tests
+# =============================================================================
+
+@test "git-file-history.sh: outputs valid JSON" {
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.' > /dev/null
+}
+
+@test "git-file-history.sh: empty input produces empty JSON object" {
+    run bash -c 'echo "" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '. == {}' > /dev/null
+}
+
+@test "git-file-history.sh: includes expected fields" {
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    echo "$output" | jq -e '."file.txt" | has("recent_commits", "recent_authors", "last_modified", "high_churn")' > /dev/null
+}
+
+# =============================================================================
+# Commit counting tests
+# =============================================================================
+
+@test "git-file-history.sh: counts recent commits correctly" {
+    # Add 3 more commits to file.txt (total 4 including initial)
+    for i in 1 2 3; do
+        echo "change $i" >> file.txt
+        git add file.txt
+        git commit -m "Change $i"
+    done
+
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local count
+    count=$(echo "$output" | jq '."file.txt".recent_commits')
+    [ "$count" -eq 4 ]
+}
+
+@test "git-file-history.sh: counts unique authors correctly" {
+    # Add commits from different authors
+    git config user.name "Author Two"
+    echo "change 2" >> file.txt
+    git add file.txt
+    git commit -m "Change by author 2"
+
+    git config user.name "Author Three"
+    echo "change 3" >> file.txt
+    git add file.txt
+    git commit -m "Change by author 3"
+
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local authors
+    authors=$(echo "$output" | jq '."file.txt".recent_authors')
+    [ "$authors" -eq 3 ]
+}
+
+# =============================================================================
+# High churn threshold tests
+# =============================================================================
+
+@test "git-file-history.sh: flags high churn at 3+ authors" {
+    # Add commits from 2 more authors (total 3)
+    git config user.name "Author Two"
+    echo "change 2" >> file.txt
+    git add file.txt
+    git commit -m "Change by author 2"
+
+    git config user.name "Author Three"
+    echo "change 3" >> file.txt
+    git add file.txt
+    git commit -m "Change by author 3"
+
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local churn
+    churn=$(echo "$output" | jq '."file.txt".high_churn')
+    [ "$churn" = "true" ]
+}
+
+@test "git-file-history.sh: flags high churn at 10+ commits" {
+    # Add 9 more commits (total 10 including initial)
+    for i in $(seq 1 9); do
+        echo "change $i" >> file.txt
+        git add file.txt
+        git commit -m "Change $i"
+    done
+
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local churn
+    churn=$(echo "$output" | jq '."file.txt".high_churn')
+    [ "$churn" = "true" ]
+}
+
+@test "git-file-history.sh: no high churn below thresholds" {
+    # Just 1 commit, 1 author — below both thresholds
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local churn
+    churn=$(echo "$output" | jq '."file.txt".high_churn')
+    [ "$churn" = "false" ]
+}
+
+# =============================================================================
+# Edge case tests
+# =============================================================================
+
+@test "git-file-history.sh: handles file not in git history" {
+    run bash -c 'echo "nonexistent.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local commits
+    commits=$(echo "$output" | jq '."nonexistent.txt".recent_commits')
+    [ "$commits" -eq 0 ]
+
+    local churn
+    churn=$(echo "$output" | jq '."nonexistent.txt".high_churn')
+    [ "$churn" = "false" ]
+
+    local last_modified
+    last_modified=$(echo "$output" | jq '."nonexistent.txt".last_modified')
+    [ "$last_modified" = "null" ]
+}
+
+@test "git-file-history.sh: handles multiple files" {
+    echo "second" > second.txt
+    git add second.txt
+    git commit -m "Add second file"
+
+    run bash -c 'printf "file.txt\nsecond.txt\n" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    # Both files should be in output
+    echo "$output" | jq -e '."file.txt"' > /dev/null
+    echo "$output" | jq -e '."second.txt"' > /dev/null
+}
+
+@test "git-file-history.sh: last_modified is a date string for tracked files" {
+    run bash -c 'echo "file.txt" | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    local last_modified
+    last_modified=$(echo "$output" | jq -r '."file.txt".last_modified')
+    # Should be a date in YYYY-MM-DD format
+    [[ "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]
+}
+
+@test "git-file-history.sh: caps at 50 files" {
+    # Create 55 files
+    for i in $(seq 1 55); do
+        echo "content" > "file_${i}.txt"
+    done
+    git add .
+    git commit -m "Add many files"
+
+    # Send all 55 file paths
+    run bash -c 'for i in $(seq 1 55); do echo "file_${i}.txt"; done | "$PROJECT_ROOT/skills/review-code/scripts/git-file-history.sh"'
+    [ "$status" -eq 0 ]
+
+    # Should have at most 50 entries
+    local count
+    count=$(echo "$output" | jq 'keys | length')
+    [ "$count" -eq 50 ]
+}


### PR DESCRIPTION
## Summary
- Add per-file git churn metrics (commit count, author count, high-churn flag) to the review orchestrator, computed via new `git-file-history.sh` script
- Context explorer now gathers targeted `git log` for high-churn files and `git log -S` for surprising code, classifying churn patterns (stability risk, coordination risk, neutral)
- Remove unused `--overwrite` and `--append` flags from review argument parsing

## How it works
- `git-file-history.sh` reads file paths from stdin, runs `git log` per file (author email + date query), outputs JSON with `recent_commits`, `recent_authors`, `last_modified`, and `high_churn` (true when 10+ commits or 3+ authors in 30 days)
- Results are merged into `file_metadata` so all review agents see churn signals without additional git calls
- Context explorer uses the `high_churn` flags to decide where to run `git log --oneline -5` and classifies patterns for downstream agents
- Authors are counted by email (`%ae`) for reliable deduplication across name variants
- The 50-file processing cap uses `continue` (not `break`) to drain stdin and avoid SIGPIPE under `set -o pipefail`

## Test plan
- 12 new unit tests in `test-git-file-history.bats` covering JSON output, commit/author counting, churn thresholds, edge cases (nonexistent files, empty input), and 50-file cap
- Tests use distinct `user.email` values to match the script's email-based author counting
- All tests pass