### PR TITLE
Add Copilot CLI cross-model review and validation

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -397,19 +397,22 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 
 ### Copilot Cross-Model Review (Parallel)
 
-If `copilot_available` is true in the session data **and** `working_dir` is not null, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. Add this as an additional Bash tool call alongside the agent dispatches:
+If `copilot_available` is true in the session data, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. The diff is passed directly in the prompt (not via `--add-dir`) to stay within Copilot's context window. Add this as an additional Bash tool call alongside the agent dispatches:
 
 ```bash
-echo '{"repo_dir":"<working_dir>","timeout_seconds":180}' | ~/.claude/skills/review-code/scripts/copilot-review.sh
+jq -n --arg diff "$diff" --argjson timeout_seconds 180 '$ARGS.named' \
+  | ~/.claude/skills/review-code/scripts/copilot-review.sh
 ```
+
+Where `$diff` is the diff from the session data. Use `jq` to safely encode the diff as JSON (handles newlines, quotes, and special characters).
 
 Save the JSON output as `$copilot_review`. This runs concurrently with all Claude agents and should not block or delay them.
 
-**Skip conditions:** If `copilot_available` is false or absent, or if `working_dir` is null, skip this step entirely.
+**Skip conditions:** If `copilot_available` is false or absent, skip this step entirely.
 
 **Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore the Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error.
 
-If `$copilot_review` succeeds, record `copilot_review` in `$token_usage` with the `duration_ms` value from the output.
+If `$copilot_review` succeeds, record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
 
 ### Collect and Synthesize Results
 
@@ -589,7 +592,7 @@ Where `targets` contains `{"path": "<file>", "line": <number>}` objects, and `di
 
 ### Copilot Cross-Model Validation (Parallel)
 
-If `copilot_available` is true in the session data **and** `working_dir` is not null, also validate each blocking finding with Copilot **in parallel with** the Claude finding-validator dispatches above. For each blocking finding, dispatch a Bash tool call:
+If `copilot_available` is true in the session data, also validate each blocking finding with Copilot **in parallel with** the Claude finding-validator dispatches above. For each blocking finding, extract the relevant diff snippet for the finding's file (the hunk(s) containing the finding's line) and dispatch a Bash tool call:
 
 ```bash
 jq -n \
@@ -597,12 +600,14 @@ jq -n \
   --arg file "<file>" \
   --argjson line <line> \
   --arg proposed_fix "<proposed fix>" \
-  --arg repo_dir "<working_dir>" \
+  --arg diff_context "<relevant diff snippet for this file>" \
   --argjson timeout_seconds 90 \
   '$ARGS.named' | ~/.claude/skills/review-code/scripts/copilot-validate.sh
 ```
 
-Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-validate-{N}` with `duration_ms`.
+Where `diff_context` is the portion of the diff relevant to this finding's file and surrounding hunks. This keeps the prompt small and focused for Copilot's context window.
+
+Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-validate-{N}` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
 
 **Combine Claude validator and Copilot validator verdicts:**
 
@@ -614,7 +619,7 @@ Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-
 | DISMISSED | DISMISSED | Downgrade to `suggestion:` with strong confidence that this is not blocking. |
 | Any | INCONCLUSIVE | Ignore Copilot result. Use Claude validator verdict only. |
 
-**Skip conditions:** If `copilot_available` is false or absent, or if `working_dir` is null, skip Copilot validation entirely and use Claude validator results only.
+**Skip conditions:** If `copilot_available` is false or absent, skip Copilot validation entirely and use Claude validator results only.
 
 ### Compose the Review Document
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -75,6 +75,7 @@ From the session file JSON, extract these fields for building agent context:
 - `chunks`: (optional) array of chunk objects when the diff was split
 - `chunk_metadata`: (optional) object with `chunked`, `reason`, `chunk_count`
 - `debug_session_dir`: (optional) path to debug session directory when debug mode is enabled
+- `copilot_available`: (optional) boolean, true if Copilot CLI is installed
 
 ### Debug Mode Setup
 
@@ -111,7 +112,9 @@ jq -n --arg dir "$debug_session_dir" --arg content "$variable_with_content" \
 - **08-context-explorer**: Record timing (start/end). Save the explorer prompt as `prompt.md` and the result (`$architectural_context`) as `result.md`.
 - **09-per-chunk-analysis** (chunked reviews only): Record timing (start/end). For each chunk, save the prompt as `chunk-{id}-prompt.md` and result as `chunk-{id}-result.md`.
 - **10-agent-dispatch**: Record timing (start/end). For each agent (or chunk x agent combination), save the prompt as `{agent}-prompt.md` (or `chunk-{id}-{agent}-prompt.md`) and result as `{agent}-result.md` (or `chunk-{id}-{agent}-result.md`). Save stats with agent count.
+- **10b-copilot-review** (when Copilot available): Record timing (start/end). Save the raw Copilot output as `result.md` and the parsed JSON response as `response.json`.
 - **11-synthesis**: Record timing (start/end). Save the merged findings as `merged-findings.md` and corroboration results as `corroboration.md`.
+- **11b-copilot-validate** (when Copilot available): For each blocking finding validated by Copilot, save the result as `validate-{N}-result.json`.
 - **12-token-usage**: After the review is complete, save stats with per-agent token usage and aggregate totals (see "Track Token Usage" below).
 
 ### Track Token Usage
@@ -392,6 +395,22 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 - Update status if code changed
 - Mark findings as resolved if fixed
 
+### Copilot Cross-Model Review (Parallel)
+
+If `copilot_available` is true in the session data **and** `working_dir` is not null, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. Add this as an additional Bash tool call alongside the agent dispatches:
+
+```bash
+echo '{"repo_dir":"<working_dir>","timeout_seconds":180}' | ~/.claude/skills/review-code/scripts/copilot-review.sh
+```
+
+Save the JSON output as `$copilot_review`. This runs concurrently with all Claude agents and should not block or delay them.
+
+**Skip conditions:** If `copilot_available` is false or absent, or if `working_dir` is null, skip this step entirely.
+
+**Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore the Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error.
+
+If `$copilot_review` succeeds, record `copilot_review` in `$token_usage` with the `duration_ms` value from the output.
+
 ### Collect and Synthesize Results
 
 After all review agents complete, extract usage metadata from each agent's response and record in `$token_usage` keyed by agent type (e.g., `$token_usage["code-reviewer-security"]`). For chunked reviews, key by `chunk-{id}-{agent-type}`.
@@ -473,9 +492,28 @@ After all agent results are collected (including all chunks in chunked mode), ap
 
 This filter reduces noise before the expensive extended-thinking synthesis step. Line-level precision is handled later by the "Validate Findings Against the Diff" step.
 
+**Merge Copilot Findings**
+
+If `$copilot_review` exists and has `available: true`, `timed_out: false`, no `error` field, and a non-empty `raw_output`:
+
+1. **Parse Copilot's review.** Use extended thinking to extract findings from Copilot's free-form `raw_output` text. For each finding, identify: file path, line number (if present), type (blocking/suggestion/nit/question based on the severity language used), description, and a confidence estimate (your best judgment of how confident Copilot seemed).
+
+2. **Apply the same scope filter** to Copilot findings: drop any that reference files not in `IN_SCOPE_PATHS`.
+
+3. **Match against Claude findings.** For each surviving Copilot finding, check if a Claude finding references the same file within 10 lines and addresses the same logical concern. If matched:
+   - Mark the Claude finding as **cross-model corroborated**.
+   - Boost its confidence by 15 percentage points (capped at 95%).
+   - Append note: "*(corroborated by Copilot)*"
+
+4. **Add unmatched Copilot findings.** For Copilot findings that don't match any Claude finding, add them to the finding pool with `agent: "copilot"` and a note: "*(flagged by external model)*". These are subject to the same filtering thresholds as Claude findings.
+
+5. **Corroboration rule update:** Cross-model corroboration (any Claude agent + Copilot) counts as corroboration even if only one Claude agent flagged the issue. Different-model agreement is at least as strong as same-model multi-agent agreement.
+
+If `$copilot_review` is absent, unavailable, timed out, or errored, skip this section and proceed with Claude-only findings.
+
 Synthesize the remaining findings using extended thinking into a coherent, deduplicated review document. Apply confidence-based filtering and cross-agent corroboration before producing the final output.
 
-**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function.
+**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Cross-model corroboration (Claude + Copilot) also counts as corroboration.
 
 **Filtering rules:**
 - **Corroborated (2+ agents or chunks):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
@@ -548,6 +586,35 @@ Where `targets` contains `{"path": "<file>", "line": <number>}` objects, and `di
   - **Unreachable or errors**: keep the finding as-is.
 
 - **Otherwise** (non-blocking findings): Use the Read tool to verify the claim is accurate before including it.
+
+### Copilot Cross-Model Validation (Parallel)
+
+If `copilot_available` is true in the session data **and** `working_dir` is not null, also validate each blocking finding with Copilot **in parallel with** the Claude finding-validator dispatches above. For each blocking finding, dispatch a Bash tool call:
+
+```bash
+jq -n \
+  --arg finding_description "<finding description>" \
+  --arg file "<file>" \
+  --argjson line <line> \
+  --arg proposed_fix "<proposed fix>" \
+  --arg repo_dir "<working_dir>" \
+  --argjson timeout_seconds 90 \
+  '$ARGS.named' | ~/.claude/skills/review-code/scripts/copilot-validate.sh
+```
+
+Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-validate-{N}` with `duration_ms`.
+
+**Combine Claude validator and Copilot validator verdicts:**
+
+| Claude Validator | Copilot Validator | Action |
+|---|---|---|
+| CONFIRMED | CONFIRMED | Keep as `blocking:`. Append: "*(confirmed by adversarial review and cross-model validation)*" |
+| CONFIRMED | DISMISSED | Keep as `blocking:`. Append Copilot's counter-argument as context: "*(Note: alternative model disagreed: [copilot reasoning])*" |
+| DISMISSED | CONFIRMED | Keep as `suggestion:` (downgraded from blocking). Append: "*(Downgraded from blocking, but alternative model flagged as real: [copilot reasoning])*" |
+| DISMISSED | DISMISSED | Downgrade to `suggestion:` with strong confidence that this is not blocking. |
+| Any | INCONCLUSIVE | Ignore Copilot result. Use Claude validator verdict only. |
+
+**Skip conditions:** If `copilot_available` is false or absent, or if `working_dir` is null, skip Copilot validation entirely and use Claude validator results only.
 
 ### Compose the Review Document
 

--- a/skills/review-code/scripts/copilot-review.sh
+++ b/skills/review-code/scripts/copilot-review.sh
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
-# copilot-review.sh - Run Copilot CLI code review and return results as JSON
+# copilot-review.sh - Run Copilot CLI code review on a diff and return results as JSON
 #
 # Usage:
-#   echo '{"repo_dir": "/path/to/repo", "timeout_seconds": 180}' | copilot-review.sh
+#   echo '{"diff": "<diff text>", "timeout_seconds": 180}' | copilot-review.sh
 #
-# Input (stdin): JSON with repo_dir and optional timeout_seconds
+# Input (stdin): JSON with diff (required) and optional timeout_seconds
 # Output (stdout): JSON with available, timed_out, raw_output, duration_ms
 #
-# Copilot runs its own /review command with file access to the repo.
-# Output is raw text for the Claude orchestrator to parse during synthesis.
+# Passes the diff directly in the prompt instead of using --add-dir,
+# which avoids hitting Copilot's context window limits on large repos.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers/copilot-helpers.sh
 source "${SCRIPT_DIR}/helpers/copilot-helpers.sh"
+
+build_review_prompt() {
+    local diff="$1"
+
+    cat << PROMPT
+Review the following code diff. For each issue found, report:
+- File path and line number
+- Severity (blocking, suggestion, nit)
+- Description of the issue
+- Suggested fix if applicable
+
+Focus on bugs, security issues, correctness problems, and significant maintainability concerns. Skip trivial style issues.
+
+\`\`\`diff
+${diff}
+\`\`\`
+PROMPT
+}
 
 main() {
     # Check availability first
@@ -23,30 +41,39 @@ main() {
         return 0
     fi
 
-    # Parse input JSON from stdin
-    local input
+    # Parse input JSON from stdin (single jq call for all fields)
+    local input diff timeout_secs
     input=$(cat)
+    diff=$(jq -r '.diff // ""' <<< "${input}")
+    timeout_secs=$(jq -r '.timeout_seconds // "'"${COPILOT_REVIEW_TIMEOUT}"'"' <<< "${input}")
 
-    local repo_dir timeout_secs
-    repo_dir=$(echo "${input}" | jq -r '.repo_dir // "."')
-    timeout_secs=$(echo "${input}" | jq -r '.timeout_seconds // "'"${COPILOT_REVIEW_TIMEOUT}"'"')
-
-    # Validate repo_dir exists
-    if [[ ! -d "${repo_dir}" ]]; then
+    # Validate diff is not empty
+    if [[ -z "${diff}" ]]; then
         copilot_json_output true false \
             raw_output "" \
-            error "repo_dir does not exist: ${repo_dir}" \
+            error "diff is empty" \
             duration_ms 0
         return 0
     fi
 
-    # Run copilot review with timeout
+    # Skip if diff exceeds Copilot's practical limits
+    if [[ ${#diff} -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
+        copilot_json_output true false \
+            raw_output "" \
+            error "diff too large for copilot (${#diff} bytes, max ${COPILOT_MAX_DIFF_BYTES})" \
+            duration_ms 0
+        return 0
+    fi
+
+    # Build the review prompt with the diff embedded
+    local prompt
+    prompt=$(build_review_prompt "${diff}")
+
+    # Run copilot with timeout, passing diff in the prompt (no --add-dir)
     local raw_output="" duration_ms=0
     local run_result=0
     copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
-        -p "/review" \
-        --yolo \
-        --add-dir "${repo_dir}" \
+        -p "${prompt}" \
         --output-format json \
         --silent || run_result=$?
 
@@ -54,7 +81,7 @@ main() {
         0)
             # Success: parse the JSONL output to extract the review text
             local parsed_output
-            parsed_output=$(echo "${raw_output}" | copilot_parse_final_message)
+            parsed_output=$(copilot_parse_final_message <<< "${raw_output}")
             copilot_json_output true false \
                 raw_output "${parsed_output}" \
                 duration_ms "${duration_ms}"

--- a/skills/review-code/scripts/copilot-review.sh
+++ b/skills/review-code/scripts/copilot-review.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# copilot-review.sh - Run Copilot CLI code review and return results as JSON
+#
+# Usage:
+#   echo '{"repo_dir": "/path/to/repo", "timeout_seconds": 180}' | copilot-review.sh
+#
+# Input (stdin): JSON with repo_dir and optional timeout_seconds
+# Output (stdout): JSON with available, timed_out, raw_output, duration_ms
+#
+# Copilot runs its own /review command with file access to the repo.
+# Output is raw text for the Claude orchestrator to parse during synthesis.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/copilot-helpers.sh
+source "${SCRIPT_DIR}/helpers/copilot-helpers.sh"
+
+main() {
+    # Check availability first
+    if ! copilot_available; then
+        copilot_json_output false false raw_output "" duration_ms 0
+        return 0
+    fi
+
+    # Parse input JSON from stdin
+    local input
+    input=$(cat)
+
+    local repo_dir timeout_secs
+    repo_dir=$(echo "${input}" | jq -r '.repo_dir // "."')
+    timeout_secs=$(echo "${input}" | jq -r '.timeout_seconds // "'"${COPILOT_REVIEW_TIMEOUT}"'"')
+
+    # Validate repo_dir exists
+    if [[ ! -d "${repo_dir}" ]]; then
+        copilot_json_output true false \
+            raw_output "" \
+            error "repo_dir does not exist: ${repo_dir}" \
+            duration_ms 0
+        return 0
+    fi
+
+    # Run copilot review with timeout
+    local raw_output="" duration_ms=0
+    local run_result=0
+    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
+        -p "/review" \
+        --yolo \
+        --add-dir "${repo_dir}" \
+        --output-format json \
+        --silent || run_result=$?
+
+    case "${run_result}" in
+        0)
+            # Success: parse the JSONL output to extract the review text
+            local parsed_output
+            parsed_output=$(echo "${raw_output}" | copilot_parse_final_message)
+            copilot_json_output true false \
+                raw_output "${parsed_output}" \
+                duration_ms "${duration_ms}"
+            ;;
+        1)
+            # Timeout
+            copilot_json_output true true \
+                raw_output "" \
+                duration_ms "${duration_ms}"
+            ;;
+        *)
+            # Other error
+            copilot_json_output true false \
+                raw_output "" \
+                error "copilot exited with error" \
+                duration_ms "${duration_ms}"
+            ;;
+    esac
+}
+
+main "$@"

--- a/skills/review-code/scripts/copilot-review.sh
+++ b/skills/review-code/scripts/copilot-review.sh
@@ -57,10 +57,12 @@ main() {
     fi
 
     # Skip if diff exceeds Copilot's practical limits
-    if [[ ${#diff} -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
+    local diff_bytes
+    diff_bytes=$(printf '%s' "${diff}" | LC_ALL=C wc -c | tr -d '[:space:]')
+    if [[ "${diff_bytes}" -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
         copilot_json_output true false \
             raw_output "" \
-            error "diff too large for copilot (${#diff} bytes, max ${COPILOT_MAX_DIFF_BYTES})" \
+            error "diff too large for copilot (${diff_bytes} bytes, max ${COPILOT_MAX_DIFF_BYTES})" \
             duration_ms 0
         return 0
     fi

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -76,12 +76,13 @@ extract_reasoning() {
 }
 
 validate_json_output() {
-    local verdict="$1"
-    local reasoning="$2"
-    local duration_ms="$3"
+    local available="$1"
+    local verdict="$2"
+    local reasoning="$3"
+    local duration_ms="$4"
 
     jq -n \
-        --argjson available true \
+        --argjson available "${available}" \
         --arg verdict "${verdict}" \
         --arg reasoning "${reasoning}" \
         --argjson duration_ms "${duration_ms}" \
@@ -91,7 +92,7 @@ validate_json_output() {
 main() {
     # Check availability first
     if ! copilot_available; then
-        validate_json_output "INCONCLUSIVE" "copilot not installed" 0
+        validate_json_output false "INCONCLUSIVE" "copilot not installed" 0
         return 0
     fi
 
@@ -109,7 +110,7 @@ main() {
 
     # Return INCONCLUSIVE if no diff context to validate against
     if [[ -z "${diff_context}" ]]; then
-        validate_json_output "INCONCLUSIVE" "no diff context provided" 0
+        validate_json_output true "INCONCLUSIVE" "no diff context provided" 0
         return 0
     fi
 
@@ -135,15 +136,15 @@ main() {
             verdict=$(parse_verdict "${parsed_text}")
             reasoning=$(extract_reasoning "${parsed_text}")
 
-            validate_json_output "${verdict}" "${reasoning}" "${duration_ms}"
+            validate_json_output true "${verdict}" "${reasoning}" "${duration_ms}"
             ;;
         1)
             # Timeout
-            validate_json_output "INCONCLUSIVE" "copilot timed out after ${timeout_secs}s" "${duration_ms}"
+            validate_json_output true "INCONCLUSIVE" "copilot timed out after ${timeout_secs}s" "${duration_ms}"
             ;;
         *)
             # Other error
-            validate_json_output "INCONCLUSIVE" "copilot exited with error" "${duration_ms}"
+            validate_json_output true "INCONCLUSIVE" "copilot exited with error" "${duration_ms}"
             ;;
     esac
 }

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# copilot-validate.sh - Use Copilot CLI to adversarially validate a blocking finding
+#
+# Usage:
+#   echo '{"finding_description": "...", "file": "src/auth.ts", "line": 42,
+#          "proposed_fix": "...", "repo_dir": "/path/to/repo", "timeout_seconds": 90}' \
+#     | copilot-validate.sh
+#
+# Input (stdin): JSON with finding details and repo access info
+# Output (stdout): JSON with available, verdict (CONFIRMED|DISMISSED|INCONCLUSIVE), reasoning, duration_ms
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/copilot-helpers.sh
+source "${SCRIPT_DIR}/helpers/copilot-helpers.sh"
+
+build_validation_prompt() {
+    local finding_description="$1"
+    local file="$2"
+    local line="$3"
+    local proposed_fix="$4"
+
+    cat << PROMPT
+You are a skeptical senior engineer. A code reviewer flagged this blocking issue:
+
+**Finding:** ${finding_description}
+**File:** ${file}:${line}
+**Proposed fix:** ${proposed_fix}
+
+Read the file at ${file} (around line ${line}). Try to DISPROVE this finding.
+Look for guards, upstream checks, framework features, or misreadings that make it wrong.
+
+Your default posture is that the finding is wrong until proven otherwise. Consider:
+- Is the finding based on a misreading of the code?
+- Does the code handle this case correctly through a path the reviewer missed?
+- Is there a guard, check, middleware, or framework feature that prevents the issue?
+- Is the scenario purely theoretical with no realistic trigger?
+- Does the proposed fix introduce its own problems?
+
+Respond with exactly CONFIRMED or DISMISSED on the FIRST LINE, followed by your reasoning.
+Be concrete: cite file paths, line numbers, and code.
+PROMPT
+}
+
+parse_verdict() {
+    local text="$1"
+
+    # Extract the first non-empty line, strip markdown formatting and whitespace
+    local first_line
+    first_line=$(echo "${text}" | sed '/^[[:space:]]*$/d' | head -1 | tr -d '[:space:]*\`#')
+
+    case "${first_line}" in
+        CONFIRMED* | confirmed*)
+            echo "CONFIRMED"
+            ;;
+        DISMISSED* | dismissed*)
+            echo "DISMISSED"
+            ;;
+        *)
+            echo "INCONCLUSIVE"
+            ;;
+    esac
+}
+
+extract_reasoning() {
+    local text="$1"
+
+    # Skip leading blank lines and the verdict line, preserve paragraph structure
+    echo "${text}" | awk '/^[[:space:]]*$/ && !v {next} !v {v=1; next} 1'
+}
+
+main() {
+    # Check availability first
+    if ! copilot_available; then
+        jq -n '{available: false, verdict: "INCONCLUSIVE", reasoning: "copilot not installed", duration_ms: 0}'
+        return 0
+    fi
+
+    # Parse input JSON from stdin
+    local input
+    input=$(cat)
+
+    local finding_description file line proposed_fix repo_dir timeout_secs
+    finding_description=$(echo "${input}" | jq -r '.finding_description // ""')
+    file=$(echo "${input}" | jq -r '.file // ""')
+    line=$(echo "${input}" | jq -r '.line // 0')
+    proposed_fix=$(echo "${input}" | jq -r '.proposed_fix // "none provided"')
+    repo_dir=$(echo "${input}" | jq -r '.repo_dir // "."')
+    timeout_secs=$(echo "${input}" | jq -r '.timeout_seconds // "'"${COPILOT_VALIDATE_TIMEOUT}"'"')
+
+    # Build the validation prompt
+    local prompt
+    prompt=$(build_validation_prompt "${finding_description}" "${file}" "${line}" "${proposed_fix}")
+
+    # Run copilot with timeout
+    local raw_output="" duration_ms=0
+    local run_result=0
+    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
+        -p "${prompt}" \
+        --yolo \
+        --add-dir "${repo_dir}" \
+        --output-format json \
+        --silent || run_result=$?
+
+    case "${run_result}" in
+        0)
+            # Success: parse the output
+            local parsed_text
+            parsed_text=$(echo "${raw_output}" | copilot_parse_final_message)
+
+            local verdict reasoning
+            verdict=$(parse_verdict "${parsed_text}")
+            reasoning=$(extract_reasoning "${parsed_text}")
+
+            jq -n \
+                --argjson available true \
+                --arg verdict "${verdict}" \
+                --arg reasoning "${reasoning}" \
+                --argjson duration_ms "${duration_ms}" \
+                '$ARGS.named'
+            ;;
+        1)
+            # Timeout
+            jq -n \
+                --argjson available true \
+                --arg verdict "INCONCLUSIVE" \
+                --arg reasoning "copilot timed out after ${timeout_secs}s" \
+                --argjson duration_ms "${duration_ms}" \
+                '$ARGS.named'
+            ;;
+        *)
+            # Other error
+            jq -n \
+                --argjson available true \
+                --arg verdict "INCONCLUSIVE" \
+                --arg reasoning "copilot exited with error" \
+                --argjson duration_ms "${duration_ms}" \
+                '$ARGS.named'
+            ;;
+    esac
+}
+
+main "$@"

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -53,7 +53,7 @@ parse_verdict() {
 
     # Extract the first non-empty line, strip markdown formatting and whitespace
     local first_line
-    first_line=$(echo "${text}" | sed '/^[[:space:]]*$/d' | head -1 | tr -d '[:space:]*\`#')
+    first_line=$(echo "${text}" | sed '/^[[:space:]]*$/d' | head -1 | tr -d '[:space:]*`#')
 
     case "${first_line}" in
         CONFIRMED* | confirmed*)

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -3,10 +3,11 @@
 #
 # Usage:
 #   echo '{"finding_description": "...", "file": "src/auth.ts", "line": 42,
-#          "proposed_fix": "...", "repo_dir": "/path/to/repo", "timeout_seconds": 90}' \
+#          "proposed_fix": "...", "diff_context": "<relevant diff snippet>",
+#          "timeout_seconds": 90}' \
 #     | copilot-validate.sh
 #
-# Input (stdin): JSON with finding details and repo access info
+# Input (stdin): JSON with finding details and diff context
 # Output (stdout): JSON with available, verdict (CONFIRMED|DISMISSED|INCONCLUSIVE), reasoning, duration_ms
 
 set -euo pipefail
@@ -20,6 +21,7 @@ build_validation_prompt() {
     local file="$2"
     local line="$3"
     local proposed_fix="$4"
+    local diff_context="$5"
 
     cat << PROMPT
 You are a skeptical senior engineer. A code reviewer flagged this blocking issue:
@@ -28,10 +30,13 @@ You are a skeptical senior engineer. A code reviewer flagged this blocking issue
 **File:** ${file}:${line}
 **Proposed fix:** ${proposed_fix}
 
-Read the file at ${file} (around line ${line}). Try to DISPROVE this finding.
-Look for guards, upstream checks, framework features, or misreadings that make it wrong.
+Here is the relevant code from the diff:
 
-Your default posture is that the finding is wrong until proven otherwise. Consider:
+\`\`\`diff
+${diff_context}
+\`\`\`
+
+Try to DISPROVE this finding. Your default posture is that the finding is wrong until proven otherwise. Consider:
 - Is the finding based on a misreading of the code?
 - Does the code handle this case correctly through a path the reviewer missed?
 - Is there a guard, check, middleware, or framework feature that prevents the issue?
@@ -70,10 +75,23 @@ extract_reasoning() {
     echo "${text}" | awk '/^[[:space:]]*$/ && !v {next} !v {v=1; next} 1'
 }
 
+validate_json_output() {
+    local verdict="$1"
+    local reasoning="$2"
+    local duration_ms="$3"
+
+    jq -n \
+        --argjson available true \
+        --arg verdict "${verdict}" \
+        --arg reasoning "${reasoning}" \
+        --argjson duration_ms "${duration_ms}" \
+        '$ARGS.named'
+}
+
 main() {
     # Check availability first
     if ! copilot_available; then
-        jq -n '{available: false, verdict: "INCONCLUSIVE", reasoning: "copilot not installed", duration_ms: 0}'
+        validate_json_output "INCONCLUSIVE" "copilot not installed" 0
         return 0
     fi
 
@@ -81,25 +99,29 @@ main() {
     local input
     input=$(cat)
 
-    local finding_description file line proposed_fix repo_dir timeout_secs
-    finding_description=$(echo "${input}" | jq -r '.finding_description // ""')
-    file=$(echo "${input}" | jq -r '.file // ""')
-    line=$(echo "${input}" | jq -r '.line // 0')
-    proposed_fix=$(echo "${input}" | jq -r '.proposed_fix // "none provided"')
-    repo_dir=$(echo "${input}" | jq -r '.repo_dir // "."')
-    timeout_secs=$(echo "${input}" | jq -r '.timeout_seconds // "'"${COPILOT_VALIDATE_TIMEOUT}"'"')
+    local finding_description file line proposed_fix diff_context timeout_secs
+    finding_description=$(jq -r '.finding_description // ""' <<< "${input}")
+    file=$(jq -r '.file // ""' <<< "${input}")
+    line=$(jq -r '.line // 0' <<< "${input}")
+    proposed_fix=$(jq -r '.proposed_fix // "none provided"' <<< "${input}")
+    diff_context=$(jq -r '.diff_context // ""' <<< "${input}")
+    timeout_secs=$(jq -r '.timeout_seconds // "'"${COPILOT_VALIDATE_TIMEOUT}"'"' <<< "${input}")
+
+    # Return INCONCLUSIVE if no diff context to validate against
+    if [[ -z "${diff_context}" ]]; then
+        validate_json_output "INCONCLUSIVE" "no diff context provided" 0
+        return 0
+    fi
 
     # Build the validation prompt
     local prompt
-    prompt=$(build_validation_prompt "${finding_description}" "${file}" "${line}" "${proposed_fix}")
+    prompt=$(build_validation_prompt "${finding_description}" "${file}" "${line}" "${proposed_fix}" "${diff_context}")
 
-    # Run copilot with timeout
+    # Run copilot with timeout, passing diff context in the prompt (no --add-dir)
     local raw_output="" duration_ms=0
     local run_result=0
     copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
         -p "${prompt}" \
-        --yolo \
-        --add-dir "${repo_dir}" \
         --output-format json \
         --silent || run_result=$?
 
@@ -107,36 +129,21 @@ main() {
         0)
             # Success: parse the output
             local parsed_text
-            parsed_text=$(echo "${raw_output}" | copilot_parse_final_message)
+            parsed_text=$(copilot_parse_final_message <<< "${raw_output}")
 
             local verdict reasoning
             verdict=$(parse_verdict "${parsed_text}")
             reasoning=$(extract_reasoning "${parsed_text}")
 
-            jq -n \
-                --argjson available true \
-                --arg verdict "${verdict}" \
-                --arg reasoning "${reasoning}" \
-                --argjson duration_ms "${duration_ms}" \
-                '$ARGS.named'
+            validate_json_output "${verdict}" "${reasoning}" "${duration_ms}"
             ;;
         1)
             # Timeout
-            jq -n \
-                --argjson available true \
-                --arg verdict "INCONCLUSIVE" \
-                --arg reasoning "copilot timed out after ${timeout_secs}s" \
-                --argjson duration_ms "${duration_ms}" \
-                '$ARGS.named'
+            validate_json_output "INCONCLUSIVE" "copilot timed out after ${timeout_secs}s" "${duration_ms}"
             ;;
         *)
             # Other error
-            jq -n \
-                --argjson available true \
-                --arg verdict "INCONCLUSIVE" \
-                --arg reasoning "copilot exited with error" \
-                --argjson duration_ms "${duration_ms}" \
-                '$ARGS.named'
+            validate_json_output "INCONCLUSIVE" "copilot exited with error" "${duration_ms}"
             ;;
     esac
 }

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Shared helpers for Copilot CLI integration
+# Provides availability detection, timeout execution, and JSONL parsing
+
+# Timeouts (seconds)
+COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-180}"
+COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-90}"
+
+# Check if Copilot CLI is installed
+# Returns: 0 if available, 1 if not
+copilot_available() {
+    command -v copilot > /dev/null 2>&1
+}
+
+# Get current time in milliseconds
+current_time_ms() {
+    if command -v gdate > /dev/null 2>&1; then
+        echo $(($(gdate +%s%N) / 1000000))
+    elif command -v python3 > /dev/null 2>&1; then
+        python3 -c 'import time; print(int(time.time() * 1000))'
+    else
+        echo $(($(date +%s) * 1000))
+    fi
+}
+
+# Run copilot with a timeout, capturing output and timing
+# Usage: copilot_run_with_timeout <timeout_seconds> <output_var> <duration_var> <copilot_args...>
+# Sets the named variables via nameref. Returns 0 on success, 1 on timeout, 2 on error.
+copilot_run_with_timeout() {
+    local timeout_secs="$1"
+    local -n _output_ref="$2"
+    local -n _duration_ref="$3"
+    shift 3
+
+    local start_ms
+    start_ms=$(current_time_ms)
+
+    local tmpfile
+    tmpfile=$(mktemp)
+    trap 'rm -f "${tmpfile}"' RETURN
+
+    local exit_code=0
+    if command -v gtimeout > /dev/null 2>&1; then
+        gtimeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+    elif command -v timeout > /dev/null 2>&1; then
+        timeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+    else
+        # No timeout command available, run directly
+        copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+    fi
+
+    local end_ms
+    end_ms=$(current_time_ms)
+    _duration_ref=$((end_ms - start_ms))
+
+    _output_ref=$(cat "${tmpfile}")
+
+    # exit code 124 = timeout (GNU coreutils), 137 = killed
+    if [[ "${exit_code}" -eq 124 ]] || [[ "${exit_code}" -eq 137 ]]; then
+        return 1
+    elif [[ "${exit_code}" -ne 0 ]]; then
+        return 2
+    fi
+    return 0
+}
+
+# Extract the final assistant message text from Copilot JSONL output
+# Reads from stdin, writes extracted text to stdout
+# Copilot JSONL contains many event types; we want the content from assistant messages
+copilot_parse_final_message() {
+    local raw_jsonl
+    raw_jsonl=$(cat)
+
+    # Try to extract content from the last assistant message event
+    # Copilot JSONL format has events with "type" fields; the final assistant
+    # response content is what we want. Try several known patterns.
+    local result=""
+
+    # Extract content from the last matching JSON object, trying structured types first,
+    # then falling back to any object with a "content" field
+    result=$(echo "${raw_jsonl}" | jq -r '
+		if (.type == "result" or .type == "assistant.message" or .type == "message") then
+			(.data.content // .content // .message // .text // empty)
+		elif .content != null then
+			.content
+		else
+			empty
+		end
+	' 2> /dev/null | tail -1)
+
+    # Pattern 3: If still nothing, the output might be plain text (not JSONL)
+    if [[ -z "${result}" ]]; then
+        result="${raw_jsonl}"
+    fi
+
+    echo "${result}"
+}
+
+# Build a JSON output object for copilot script responses
+# Usage: copilot_json_output available timed_out [key value...]
+# Example: copilot_json_output true false raw_output "review text" duration_ms 1234
+copilot_json_output() {
+    local available="$1"
+    local timed_out="$2"
+    shift 2
+
+    local jq_args=(
+        --argjson available "${available}"
+        --argjson timed_out "${timed_out}"
+    )
+
+    while [[ $# -ge 2 ]]; do
+        local key="$1"
+        local value="$2"
+        shift 2
+        jq_args+=(--arg "${key}" "${value}")
+    done
+
+    # All variadic pairs are strings; convert _ms fields to numbers in jq
+    jq -n "${jq_args[@]}" '$ARGS.named | with_entries(if .key | endswith("_ms") then .value |= tonumber else . end)'
+}

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -6,6 +6,10 @@
 COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-180}"
 COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-90}"
 
+# Max diff size (bytes) to send to Copilot. Diffs larger than this exceed
+# both Copilot's context window and OS argument length limits (ARG_MAX).
+COPILOT_MAX_DIFF_BYTES="${COPILOT_MAX_DIFF_BYTES:-262144}"
+
 # Check if Copilot CLI is installed
 # Returns: 0 if available, 1 if not
 copilot_available() {
@@ -78,7 +82,7 @@ copilot_parse_final_message() {
 
     # Extract content from the last matching JSON object, trying structured types first,
     # then falling back to any object with a "content" field
-    result=$(echo "${raw_jsonl}" | jq -r '
+    result=$(printf '%s\n' "${raw_jsonl}" | jq -r '
 		if (.type == "result" or .type == "assistant.message" or .type == "message") then
 			(.data.content // .content // .message // .text // empty)
 		elif .content != null then
@@ -117,5 +121,5 @@ copilot_json_output() {
     done
 
     # All variadic pairs are strings; convert _ms fields to numbers in jq
-    jq -n "${jq_args[@]}" '$ARGS.named | with_entries(if .key | endswith("_ms") then .value |= tonumber else . end)'
+    jq -n "${jq_args[@]}" '$ARGS.named | with_entries(if .key | endswith("_ms") then .value |= (tonumber? // 0) else . end)'
 }

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -41,7 +41,6 @@ copilot_run_with_timeout() {
 
     local tmpfile
     tmpfile=$(mktemp)
-    trap 'rm -f "${tmpfile}"' RETURN
 
     local exit_code=0
     if command -v gtimeout > /dev/null 2>&1; then
@@ -58,6 +57,7 @@ copilot_run_with_timeout() {
     _duration_ref=$((end_ms - start_ms))
 
     _output_ref=$(cat "${tmpfile}")
+    rm -f "${tmpfile}"
 
     # exit code 124 = timeout (GNU coreutils), 137 = killed
     if [[ "${exit_code}" -eq 124 ]] || [[ "${exit_code}" -eq 137 ]]; then
@@ -82,15 +82,18 @@ copilot_parse_final_message() {
 
     # Extract content from the last matching JSON object, trying structured types first,
     # then falling back to any object with a "content" field
-    result=$(printf '%s\n' "${raw_jsonl}" | jq -r '
-		if (.type == "result" or .type == "assistant.message" or .type == "message") then
-			(.data.content // .content // .message // .text // empty)
-		elif .content != null then
-			.content
-		else
-			empty
-		end
-	' 2> /dev/null | tail -1)
+    result=$(printf '%s\n' "${raw_jsonl}" | jq -s -r '
+		[ .[] |
+			if (.type == "result" or .type == "assistant.message" or .type == "message") then
+				(.data.content // .content // .message // .text // empty)
+			elif .content != null then
+				.content
+			else
+				empty
+			end
+			| select(. != null and . != "")
+		] | .[-1] // empty
+	' 2> /dev/null)
 
     # Pattern 3: If still nothing, the output might be plain text (not JSONL)
     if [[ -z "${result}" ]]; then

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -25,6 +25,8 @@ set -euo pipefail
 
 # shellcheck source=lib/helpers/gh-wrapper.sh
 source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+# shellcheck source=lib/helpers/copilot-helpers.sh
+source "${SCRIPT_DIR}/helpers/copilot-helpers.sh"
 
 # Main orchestration function
 main() {
@@ -498,6 +500,13 @@ build_review_data() {
     jq_args+=(--argjson diff_tokens "${diff_tokens}")
     jq_args+=(--arg commit_messages "${commit_messages}")
 
+    # Check if Copilot CLI is available for cross-model review
+    local copilot_is_available="false"
+    if copilot_available; then
+        copilot_is_available="true"
+    fi
+    jq_args+=(--arg copilot_available "${copilot_is_available}")
+
     # Single jq invocation with conditional pr field and chunk data
     final_output=$(jq "${jq_args[@]}" \
         '{
@@ -523,6 +532,7 @@ build_review_data() {
         + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
         + (if $debug_session_dir != "" then {debug_session_dir: $debug_session_dir} else {} end)
         + (if $commit_messages != "" then {commit_messages: $commit_messages} else {} end)
+        + (if $copilot_available == "true" then {copilot_available: true} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"


### PR DESCRIPTION
## Summary

- Integrate GitHub Copilot CLI as a parallel second model during code reviews for cross-model corroboration and adversarial validation of blocking findings
- Add three new scripts: `copilot-review.sh` (parallel review), `copilot-validate.sh` (adversarial validation of blocking findings), and `copilot-helpers.sh` (shared utilities for availability detection, timeout handling, and JSON output)
- Update the review handler to merge Copilot findings with Claude findings, boost confidence for cross-model agreement, and use a validation matrix to decide blocking vs suggestion status
- Add `diff_tokens` tracking and a centralized `token-usage.jsonl` log for usage analytics across reviews

## Design decisions

- **Graceful degradation**: If Copilot CLI is not installed, timed out, or errors, the review continues with Claude-only findings. Copilot never blocks or degrades the review.
- **Cross-model corroboration**: When both Claude and Copilot flag the same issue, confidence is boosted by 15 percentage points. Single-Claude-agent findings corroborated by Copilot count as fully corroborated.
- **Adversarial validation**: Each blocking finding is validated by both a Claude validator agent and Copilot in parallel. A 2x2 verdict matrix determines whether findings stay blocking, get downgraded to suggestions, or gain additional context.

## Test plan

- [x] All 858 tests pass
- [ ] Test with Copilot CLI installed: verify parallel review runs and findings merge correctly
- [ ] Test without Copilot CLI: verify graceful skip with no errors
- [ ] Test Copilot timeout scenario: verify review completes with Claude-only findings