### PR TITLE
Add commit message context to review exploration phase

### DIFF
--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -49,7 +49,16 @@ When the PR description, commit message, or code comments indicate the changes a
 
 When code is being ported, the original implementation is the specification. Review agents need it to verify correctness. Spend no more than 60 seconds on this section; focus on entry points and public API rather than reading every helper.
 
-### 6. Git History Context
+### 6. Commit Messages
+
+If **Commit Messages** are provided in the prompt, use them to understand the author's intent behind the changes. Commit messages explain *why* changes were made and can reveal:
+- The purpose of a port, migration, or refactor
+- Bug context (e.g., "Fix race condition when...")
+- Intentional design decisions that might otherwise look like mistakes
+
+Include relevant commit message context in your output when it helps explain the changes.
+
+### 7. Git History Context
 
 Check `file_metadata` for files with `git_history.high_churn: true`. For each high-churn file:
 - Run `git log --oneline -5 <file>` to surface recent changes

--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -38,7 +38,18 @@ Gather only when relevant to the changes:
 - **Security-Sensitive**: Find existing security patterns when auth or validation code changes
 - **Performance-Critical**: Find similar optimizations when queries or loops are modified
 
-### 5. Git History Context
+### 5. Reference Implementations
+
+When the PR description, commit message, or code comments indicate the changes are a **port, migration, or rewrite** of existing code (e.g., "port from Python to Rust", "migrate from Django", "rewrite of X"):
+
+- **Locate the original implementation** in the codebase. Search for the original module, class, or function names mentioned in the description or visible in the diff (e.g., imported types, similar function names in a different language directory).
+- **Read the original code** and document its key behaviors: input validation, error handling, edge cases, return values, and side effects.
+- **Note behavioral differences** between the original and the new implementation visible in the diff. Flag anything that looks like an unintentional divergence.
+- **Include the original code path** in the "Key Files for Review" section so review agents can cross-reference.
+
+When code is being ported, the original implementation is the specification. Review agents need it to verify correctness. Spend no more than 60 seconds on this section; focus on entry points and public API rather than reading every helper.
+
+### 6. Git History Context
 
 Check `file_metadata` for files with `git_history.high_churn: true`. For each high-churn file:
 - Run `git log --oneline -5 <file>` to surface recent changes
@@ -66,6 +77,12 @@ For code that looks surprising or non-obvious during your investigation:
 
 ### Special Context
 [Database schema, API patterns, security context, etc. — only if relevant]
+
+### Reference Implementation
+[Only if the changes are a port, migration, or rewrite]
+- **Original:** `path/to/original/module.py` — [purpose and key behaviors]
+- **Key Behaviors:** [list of behaviors the port should preserve]
+- **Potential Divergences:** [any differences spotted between original and port]
 
 ### Git History Context
 - **High-Churn Files**: `path/to/file` — recent commit pattern (e.g., "5 of last 5 commits are bug fixes — stability risk")
@@ -103,12 +120,18 @@ Focus on context that will help reviewers make better decisions. Be selective �
 ### Special Context
 **Security**: Three other endpoints validate email format using `EmailValidator.is_valid()`
 
+### Reference Implementation
+- **Original:** `backend/api/auth_legacy.py` — Django email verification with token generation, Redis storage, and retry throttling
+- **Key Behaviors:** Validates email format before generating token; catches `OverflowError` from date parsing; rate-limits to 3 verification emails per hour per user
+- **Potential Divergences:** New implementation doesn't appear to include the rate-limiting check present in the original
+
 ### Git History Context
 - **High-Churn Files**: `backend/api/auth.py` — 4 of last 5 commits are bug fixes ("Fix token expiry edge case", "Fix double-send on retry") — stability risk
 - **Surprising Code**: The `time.sleep(0.1)` in `send_verification_email` was added in "Throttle email sends to avoid SES rate limit" (2024-08) — intentional, not a performance bug
 
 ### Key Files for Review
 1. `backend/api/auth.py` — New verification endpoint
-2. `backend/api/password_reset.py` — Existing similar pattern
-3. `backend/services/token_generator.py` — Should be reused
+2. `backend/api/auth_legacy.py` — Original Django implementation (reference for port)
+3. `backend/api/password_reset.py` — Existing similar pattern
+4. `backend/services/token_generator.py` — Should be reused
 ```

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -167,6 +167,36 @@ Invoke the Task tool with subagent_type "Explore" and prompt:
 ```markdown
 Gather architectural context for this code review.
 
+{For PR mode:}
+**PR:** #$pr_number - $pr_title
+**Description:**
+$pr_body
+
+{If pr.linked_issues is not empty:}
+**Linked Issues:**
+{For each issue in pr.linked_issues:}
+- #$issue.number: $issue.title
+{End for}
+
+{For branch mode with associated PR:}
+**Branch:** $branch vs $base_branch
+**Associated PR:** #$pr_number - $pr_title
+**Description:**
+$pr_body
+
+{For branch mode without PR:}
+**Branch:** $branch vs $base_branch
+
+{For commit mode:}
+**Commit:** $commit
+
+{For range mode:}
+**Range:** $range
+
+{For local mode:}
+**Local changes** (unstaged/staged)
+
+{For all modes:}
 **File Metadata:**
 $file_metadata
 
@@ -182,6 +212,7 @@ Explore the codebase to understand:
   (grep for function/method names, report top 3-5 callers per significantly modified function)
 - Existing patterns for similar functionality
 - Reusable utilities or conventions
+- Reference implementations (if the description indicates a port, migration, or rewrite)
 - Git history for high-churn files and surprising code
   (check `git_history.high_churn` flags in file_metadata; run `git log` for flagged files and for any code whose purpose is non-obvious)
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -71,6 +71,7 @@ From the session file JSON, extract these fields for building agent context:
 - `languages`: detected languages
 - `file_info.file_path`: where to save the review
 - `file_ref`: (optional) git ref for reading PR files when on a different branch
+- `commit_messages`: (optional) commit messages for the reviewed changes (subject + body, truncated to 8KB)
 - `chunks`: (optional) array of chunk objects when the diff was split
 - `chunk_metadata`: (optional) object with `chunked`, `reason`, `chunk_count`
 - `debug_session_dir`: (optional) path to debug session directory when debug mode is enabled
@@ -197,6 +198,10 @@ $pr_body
 **Local changes** (unstaged/staged)
 
 {For all modes:}
+{If commit_messages is not empty:}
+**Commit Messages:**
+$commit_messages
+
 **File Metadata:**
 $file_metadata
 
@@ -291,6 +296,10 @@ Reviewing branch: $branch vs $base_branch
 Reviewing range: $range
 
 {For all modes:}
+{If commit_messages is not empty:}
+**Commit Messages:**
+$commit_messages
+
 **Code Changes:**
 $diff
 

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -318,7 +318,7 @@ build_review_data() {
                 cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
                 cm_base=$(echo "${mode_args_json}" | jq -r '.mode_base_branch // ""')
                 if [[ -n "${cm_branch}" && -n "${cm_base}" ]]; then
-                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
                 fi
                 ;;
             "pr")
@@ -330,7 +330,7 @@ build_review_data() {
                     local cm_base
                     cm_base=$(echo "${pr_context}" | jq -r '.base_ref // ""')
                     if [[ -n "${cm_base}" ]]; then
-                        commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_head_ref}" 2> /dev/null | head -c 8192 || true)
+                        commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_head_ref}" 2> /dev/null | head -c 8192 || true)
                     fi
                 fi
                 ;;
@@ -338,14 +338,14 @@ build_review_data() {
                 local cm_commit
                 cm_commit=$(echo "${mode_args_json}" | jq -r '.mode_commit // ""')
                 if [[ -n "${cm_commit}" ]]; then
-                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null | head -c 8192 || true)
                 fi
                 ;;
             "range")
                 local cm_range
                 cm_range=$(echo "${mode_args_json}" | jq -r '.mode_range // ""')
                 if [[ -n "${cm_range}" ]]; then
-                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 || true)
                 fi
                 ;;
         esac

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -318,7 +318,7 @@ build_review_data() {
                 cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
                 cm_base=$(echo "${mode_args_json}" | jq -r '.mode_base_branch // ""')
                 if [[ -n "${cm_branch}" && -n "${cm_base}" ]]; then
-                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
                 fi
                 ;;
             "pr")
@@ -330,7 +330,7 @@ build_review_data() {
                     local cm_base
                     cm_base=$(echo "${pr_context}" | jq -r '.base_ref // ""')
                     if [[ -n "${cm_base}" ]]; then
-                        commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_head_ref}" 2> /dev/null | head -c 8192 || true)
+                        commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_head_ref}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
                     fi
                 fi
                 ;;
@@ -338,14 +338,14 @@ build_review_data() {
                 local cm_commit
                 cm_commit=$(echo "${mode_args_json}" | jq -r '.mode_commit // ""')
                 if [[ -n "${cm_commit}" ]]; then
-                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
                 fi
                 ;;
             "range")
                 local cm_range
                 cm_range=$(echo "${mode_args_json}" | jq -r '.mode_range // ""')
                 if [[ -n "${cm_range}" ]]; then
-                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 || true)
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
                 fi
                 ;;
         esac

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -322,13 +322,15 @@ build_review_data() {
                 fi
                 ;;
             "pr")
-                local cm_branch
+                local cm_branch cm_file_ref cm_head_ref
                 cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
-                if [[ -n "${cm_branch}" && -n "${pr_context}" ]]; then
+                cm_file_ref=$(echo "${mode_args_json}" | jq -r '.mode_file_ref // ""')
+                cm_head_ref="${cm_file_ref:-${cm_branch}}"
+                if [[ -n "${cm_head_ref}" && -n "${pr_context}" ]]; then
                     local cm_base
                     cm_base=$(echo "${pr_context}" | jq -r '.base_ref // ""')
                     if [[ -n "${cm_base}" ]]; then
-                        commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
+                        commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_head_ref}" 2> /dev/null | head -c 8192 || true)
                     fi
                 fi
                 ;;

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -278,9 +278,15 @@ build_review_data() {
     local file_metadata
     file_metadata=$(echo "${diff_content}" | "${SCRIPT_DIR}/pre-review-context.sh")
 
+    # Check once if we're inside a git repo (used by history and commit message gathering)
+    local in_git_repo=false
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        in_git_repo=true
+    fi
+
     # Compute git history metrics for modified files (only when inside a git repo)
     local git_history='{}'
-    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    if [[ "${in_git_repo}" == "true" ]]; then
         git_history=$(echo "${file_metadata}" | jq -r '.modified_files[].path' | "${SCRIPT_DIR}/git-file-history.sh")
 
         # Validate git_history is valid JSON (safety check)
@@ -305,7 +311,7 @@ build_review_data() {
     local mode_args_json
     mode_args_json=$(jq -n "$@" '$ARGS.named' 2> /dev/null || echo '{}')
     local commit_messages=""
-    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+    if [[ "${in_git_repo}" == "true" ]]; then
         case "${mode}" in
             "branch")
                 local cm_branch cm_base
@@ -330,7 +336,7 @@ build_review_data() {
                 local cm_commit
                 cm_commit=$(echo "${mode_args_json}" | jq -r '.mode_commit // ""')
                 if [[ -n "${cm_commit}" ]]; then
-                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null || true)
+                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null | head -c 8192 || true)
                 fi
                 ;;
             "range")
@@ -407,9 +413,8 @@ build_review_data() {
     diff_tokens=$((${#diff_content} / 4))
 
     # Build summary for user confirmation
-    # Extract mode-specific fields to avoid passing large args to jq
-    local mode_fields
-    mode_fields=$(jq -n "$@" '$ARGS.named')
+    # Reuse mode_args_json (already parsed from "$@" above)
+    local mode_fields="${mode_args_json}"
     local summary
     summary=$(build_summary "${mode}" "${diff_content}" "${git_context}" "${mode_fields}" "${pr_context}")
 

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -300,6 +300,49 @@ build_review_data() {
         | . + {has_high_churn_files: ([.modified_files[] | select(.git_history.high_churn == true)] | length > 0)}
     ')
 
+    # Gather commit messages for context (mode-dependent)
+    # Parse mode-specific jq args to extract values we need
+    local mode_args_json
+    mode_args_json=$(jq -n "$@" '$ARGS.named' 2> /dev/null || echo '{}')
+    local commit_messages=""
+    if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        case "${mode}" in
+            "branch")
+                local cm_branch cm_base
+                cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
+                cm_base=$(echo "${mode_args_json}" | jq -r '.mode_base_branch // ""')
+                if [[ -n "${cm_branch}" && -n "${cm_base}" ]]; then
+                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
+                fi
+                ;;
+            "pr")
+                local cm_branch
+                cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
+                if [[ -n "${cm_branch}" && -n "${pr_context}" ]]; then
+                    local cm_base
+                    cm_base=$(echo "${pr_context}" | jq -r '.base_ref // ""')
+                    if [[ -n "${cm_base}" ]]; then
+                        commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 || true)
+                    fi
+                fi
+                ;;
+            "commit")
+                local cm_commit
+                cm_commit=$(echo "${mode_args_json}" | jq -r '.mode_commit // ""')
+                if [[ -n "${cm_commit}" ]]; then
+                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" -1 "${cm_commit}" 2> /dev/null || true)
+                fi
+                ;;
+            "range")
+                local cm_range
+                cm_range=$(echo "${mode_args_json}" | jq -r '.mode_range // ""')
+                if [[ -n "${cm_range}" ]]; then
+                    commit_messages=$(git log --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 || true)
+                fi
+                ;;
+        esac
+    fi
+
     # Extract org/repo from git_context
     local org repo
     org=$(echo "${git_context}" | jq -r '.org')
@@ -446,6 +489,7 @@ build_review_data() {
     jq_args+=(--arg append_mode "${append_mode}")
     jq_args+=(--arg debug_session_dir "${DEBUG_SESSION_DIR:-}")
     jq_args+=(--argjson diff_tokens "${diff_tokens}")
+    jq_args+=(--arg commit_messages "${commit_messages}")
 
     # Single jq invocation with conditional pr field and chunk data
     final_output=$(jq "${jq_args[@]}" \
@@ -471,6 +515,7 @@ build_review_data() {
         + (if $pr[0] != null then {pr: $pr[0], reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
         + (if $debug_session_dir != "" then {debug_session_dir: $debug_session_dir} else {} end)
+        + (if $commit_messages != "" then {commit_messages: $commit_messages} else {} end)
         + ($ARGS.named | with_entries(select(.key | startswith("mode_"))) | with_entries(.key |= sub("^mode_"; "")) | with_entries(select(.value != "")))')
     debug_save_json "07-final-output" "output.json" <<< "${final_output}"
     debug_time "07-final-output" "end"


### PR DESCRIPTION
## Summary

- **Commit messages as review context**: Gather `git log` messages for branch, PR, commit, and range modes and pass them to the context explorer and review agents. Gives reviewers the author's intent behind changes, especially useful for ports, migrations, and multi-commit branches where the diff alone doesn't explain "why."
- **Reference implementation exploration**: Teach the context explorer to locate and read original implementations when changes are a port, migration, or rewrite, so review agents can cross-reference for correctness.
- **Token usage tracking**: Add `diff_tokens` to session data and log per-review token usage to a central JSONL file for tracking costs over time.

## Test plan

- [x] All 1131 unit tests pass
- [x] All 12 integration tests pass
- [x] `bin/fmt` produces no changes
- [ ] Run `/review-code` on a multi-commit branch and verify commit messages appear in the context explorer output
- [ ] Run `/review-code` on a single commit and verify the commit message is included
- [ ] Verify local mode (no commits) does not include a commit_messages field