### PR TITLE
Add scope classification to reduce review token usage

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -714,7 +714,7 @@ diff_tokens: <diff_tokens from session data>
 -->
 ```
 
-The `token_usage` block records per-agent token consumption and the aggregate total. For chunked reviews, sum tokens by agent type across chunks (e.g., all `chunk-*-code-reviewer-security` entries become a single `code-reviewer-security` total). Always include the `total` field as the sum of all agents.
+The `token_usage` block records per-step token consumption (agents, context explorer, validators, and other steps) and the aggregate total. For chunked reviews, sum tokens by agent type across chunks (e.g., all `chunk-*-code-reviewer-security` entries become a single `code-reviewer-security` total). Always include the `total` field as the sum of all steps in `$token_usage`.
 
 This metadata is used by the learning system to determine when the review was created. The `review_commit` field records the PR's HEAD SHA at review time, enabling drift detection when creating draft reviews later. The `diff_tokens` field is an estimated token count of the diff (~4 chars per token).
 Save the complete review to `$review_file` and inform the user with a clickable file link:
@@ -740,7 +740,7 @@ Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `
 jq -n --argjson agents '<JSON object with per-agent {total_tokens, tool_uses, duration_ms}>' \
   --arg total '<total_tokens sum>' --arg count '<step_count>' \
   --arg dir "$debug_session_dir" \
-  '{"action":"stats","debug_dir":$dir,"stage":"12-token-usage","data":{"agents":$agents,"total_tokens":($total|tonumber),"step_count":($count|tonumber)}}' \
+  '{"action":"stats","debug_dir":$dir,"stage":"12-token-usage","data":{"agents":$agents,"total_tokens":($total|tonumber),"step_count":($count|tonumber),"agent_count":($count|tonumber)}}' \
   | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
 ```
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -77,6 +77,31 @@ From the session file JSON, extract these fields for building agent context:
 - `debug_session_dir`: (optional) path to debug session directory when debug mode is enabled
 - `copilot_available`: (optional) boolean, true if Copilot CLI is installed
 
+### Classify Review Scope
+
+Run the scope classifier to determine exploration depth and agent selection based on diff size and file characteristics:
+
+```bash
+~/.claude/skills/review-code/scripts/classify-review-scope.sh "$SESSION_FILE"
+```
+
+Parse the JSON output and store:
+- `$exploration_depth`: "minimal", "standard", or "thorough"
+- `$selected_agents`: array of agent area names to invoke (e.g., ["correctness", "security", "testing"])
+- `$skipped_agents`: array of agents that will not run
+- `$classification_reasoning`: human-readable explanation
+
+**Override rules:**
+- If the user specified an `area` (e.g., `/review-code pr 123 security`), ignore the classifier output and use only that area's agent. Set `$exploration_depth` to "standard" for area-specific reviews.
+- If the classifier errors, fall back to all 7 agents and "thorough" exploration.
+
+If agents are being skipped, briefly note this to the user:
+
+```
+Scope: $classification_reasoning
+Skipping: $skipped_agents (join with ", ")
+```
+
 ### Debug Mode Setup
 
 Extract `debug_session_dir` from the session JSON. If it is a non-empty string, debug mode is active for this review. Store it as `$debug_session_dir`.
@@ -109,6 +134,7 @@ jq -n --arg dir "$debug_session_dir" --arg content "$variable_with_content" \
 
 **Stages to instrument (when `$debug_session_dir` is set):**
 
+- **07-scope-classification**: Save the classifier output as `classification.json` (the full JSON from `classify-review-scope.sh`).
 - **08-context-explorer**: Record timing (start/end). Save the explorer prompt as `prompt.md` and the result (`$architectural_context`) as `result.md`.
 - **09-per-chunk-analysis** (chunked reviews only): Record timing (start/end). For each chunk, save the prompt as `chunk-{id}-prompt.md` and result as `chunk-{id}-result.md`.
 - **10-agent-dispatch**: Record timing (start/end). For each agent (or chunk x agent combination), save the prompt as `{agent}-prompt.md` (or `chunk-{id}-{agent}-prompt.md`) and result as `{agent}-result.md` (or `chunk-{id}-{agent}-result.md`). Save stats with agent count.
@@ -213,6 +239,20 @@ $diff
 
 $file_access_instructions
 
+{If exploration_depth == "minimal":}
+Time-box yourself to 30 seconds. Focus on understanding what changed:
+- Read only the modified files to understand their purpose and the change
+- Skip caller search, pattern search, git history, and reference implementations
+
+{If exploration_depth == "standard":}
+Time-box yourself to 1-2 minutes. Explore:
+- Full context of modified files
+- Related code and dependencies
+- Callers of modified functions (who calls the changed code and might be affected?)
+  (grep for function/method names, report top 3-5 callers per significantly modified function)
+- Skip pattern search, reference implementations, and git history
+
+{If exploration_depth == "thorough":}
 Explore the codebase to understand:
 - Full context of modified files
 - Related code and dependencies
@@ -231,7 +271,7 @@ Save the explorer's output as `$architectural_context`. Extract usage metadata f
 
 ### Invoke Specialized Review Agents
 
-Invoke the appropriate agent(s) based on mode and area. If an area is specified, invoke only that agent. Otherwise, invoke all 7 core agents in parallel (plus the frontend agent if `languages.has_frontend` is true).
+Invoke the agents determined by the scope classification. If an area was specified, invoke only that agent. Otherwise, invoke all agents in `$selected_agents` in parallel (plus the frontend agent if `languages.has_frontend` is true and "frontend" is in `$selected_agents`).
 
 **Agent selection:**
 
@@ -633,14 +673,14 @@ Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-
 | Range | `Range Review: $range` |
 | Local | `Code Review: (org/repo) - (branch) (uncommitted)` |
 
-**For comprehensive reviews**, include a section for each area:
-- Security Review
-- Performance Review
-- Correctness Review
-- Maintainability Review
-- Testing Review
-- Compatibility Review
-- Architecture Review
+**For comprehensive reviews**, include a section for each agent that ran (from `$selected_agents`):
+- Security Review (if "security" in `$selected_agents`)
+- Performance Review (if "performance" in `$selected_agents`)
+- Correctness Review (if "correctness" in `$selected_agents`)
+- Maintainability Review (if "maintainability" in `$selected_agents`)
+- Testing Review (if "testing" in `$selected_agents`)
+- Compatibility Review (if "compatibility" in `$selected_agents`)
+- Architecture Review (if "architecture" in `$selected_agents`)
 
 **For area-specific reviews**, include only that area's findings.
 
@@ -660,6 +700,11 @@ pr_number: <pr_number if applicable>
 org: <org>
 repo: <repo>
 review_commit: <pr.head_sha if PR mode, omit otherwise>
+scope:
+  exploration_depth: <exploration_depth>
+  agents_run: <$selected_agents as comma-separated list>
+  agents_skipped: <$skipped_agents as comma-separated list, or "none">
+  reasoning: <$classification_reasoning>
 token_usage:
   <agent_name>: <total_tokens>
   ...
@@ -683,7 +728,7 @@ Review saved to: $review_file
 
 You can open it directly: file://$review_file
 
-Token usage: ~$total_tokens tokens across $agent_count agents
+Token usage: ~$total_tokens tokens across $agent_count agents ($exploration_depth exploration)
 ```
 
 Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `$agent_count` is the number of entries.
@@ -715,7 +760,7 @@ token_usage_log="$(dirname "$(dirname "$(dirname "$review_file")")")/token-usage
 Each line is a JSON object:
 
 ```json
-{"reviewed_at": "<ISO 8601 timestamp>", "org": "<org>", "repo": "<repo>", "mode": "<mode>", "identifier": "<pr_number or branch name>", "diff_tokens": <diff_tokens>, "files_changed": <number>, "lines_added": <number>, "lines_removed": <number>}
+{"reviewed_at": "<ISO 8601 timestamp>", "org": "<org>", "repo": "<repo>", "mode": "<mode>", "identifier": "<pr_number or branch name>", "diff_tokens": <diff_tokens>, "files_changed": <number>, "lines_added": <number>, "lines_removed": <number>, "exploration_depth": "<exploration_depth>", "agents_run": <number of agents run>, "agents_skipped": <number of agents skipped>}
 ```
 
 Extract these values from the session data:
@@ -739,6 +784,9 @@ jq -nc \
   --argjson files_changed <files_changed> \
   --argjson lines_added <lines_added> \
   --argjson lines_removed <lines_removed> \
+  --arg exploration_depth "<exploration_depth>" \
+  --argjson agents_run <number of agents run> \
+  --argjson agents_skipped <number of agents skipped> \
   '$ARGS.named' >> "$token_usage_log"
 ```
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -729,10 +729,10 @@ Review saved to: $review_file
 
 You can open it directly: file://$review_file
 
-Token usage: ~$total_tokens tokens across $agent_count agents ($exploration_depth exploration)
+Token usage: ~$total_tokens tokens across $agent_count steps ($exploration_depth exploration)
 ```
 
-Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `$agent_count` is the number of entries.
+Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `$agent_count` is the number of entries (includes agents, context explorer, validators, and other steps).
 
 **Write token usage debug artifacts (when `$debug_session_dir` is set):** Build a JSON object from `$token_usage` and save via the debug bridge:
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -729,18 +729,18 @@ Review saved to: $review_file
 
 You can open it directly: file://$review_file
 
-Token usage: ~$total_tokens tokens across $agent_count steps ($exploration_depth exploration)
+Token usage: ~$total_tokens tokens across $step_count steps ($exploration_depth exploration)
 ```
 
-Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `$agent_count` is the number of entries (includes agents, context explorer, validators, and other steps).
+Where `$total_tokens` is the sum of all `total_tokens` from `$token_usage` and `$step_count` is the number of entries (includes agents, context explorer, validators, and other steps).
 
 **Write token usage debug artifacts (when `$debug_session_dir` is set):** Build a JSON object from `$token_usage` and save via the debug bridge:
 
 ```bash
 jq -n --argjson agents '<JSON object with per-agent {total_tokens, tool_uses, duration_ms}>' \
-  --arg total '<total_tokens sum>' --arg count '<agent_count>' \
+  --arg total '<total_tokens sum>' --arg count '<step_count>' \
   --arg dir "$debug_session_dir" \
-  '{"action":"stats","debug_dir":$dir,"stage":"12-token-usage","data":{"agents":$agents,"total_tokens":($total|tonumber),"agent_count":($count|tonumber)}}' \
+  '{"action":"stats","debug_dir":$dir,"stage":"12-token-usage","data":{"agents":$agents,"total_tokens":($total|tonumber),"step_count":($count|tonumber)}}' \
   | ~/.claude/skills/review-code/scripts/debug-artifact-writer.sh
 ```
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -92,8 +92,8 @@ Parse the JSON output and store:
 - `$classification_reasoning`: human-readable explanation
 
 **Override rules:**
-- If the user specified an `area` (e.g., `/review-code pr 123 security`), ignore the classifier output and use only that area's agent. Set `$exploration_depth` to "standard" for area-specific reviews.
-- If the classifier errors, fall back to all 7 agents and "thorough" exploration.
+- If the user specified an `area` (e.g., `/review-code pr 123 security`), ignore the classifier output and use only that area's agent. Set `$selected_agents` to `["$area"]`, `$skipped_agents` to all other agents, `$classification_reasoning` to `"Area override: user requested area '$area'"`, and `$exploration_depth` to "standard" for area-specific reviews.
+- If the classifier errors, fall back to all 7 core agents (+ frontend if applicable) and "thorough" exploration.
 
 If agents are being skipped, briefly note this to the user:
 
@@ -681,6 +681,7 @@ Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-
 - Testing Review (if "testing" in `$selected_agents`)
 - Compatibility Review (if "compatibility" in `$selected_agents`)
 - Architecture Review (if "architecture" in `$selected_agents`)
+- Frontend Review (if "frontend" in `$selected_agents`)
 
 **For area-specific reviews**, include only that area's findings.
 

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -22,17 +22,21 @@ if [[ ! -f "${session_file}" ]]; then
     exit 1
 fi
 
-# Extract classification inputs from session JSON (single jq invocation)
-eval "$(jq -r '
-    (.file_metadata.modified_files // []) as $files |
-    @sh "diff_tokens=\(.diff_tokens // 0 | floor)",
-    @sh "file_count=\(.file_metadata.file_count // 0)",
-    @sh "has_frontend=\(.languages.has_frontend // false)",
-    @sh "source_count=\([$files[] | select(.type == "source")] | length)",
-    @sh "test_count=\([$files[] | select(.type == "test" or .is_test == true)] | length)",
-    @sh "config_count=\([$files[] | select(.type == "config")] | length)",
-    @sh "migration_count=\([$files[] | select(.type == "migration")] | length)"
-' "${session_file}")"
+# Extract classification inputs from session JSON (single jq invocation, no eval)
+read -r diff_tokens file_count has_frontend source_count test_count config_count migration_count < <(
+    jq -r '
+        (.file_metadata.modified_files // []) as $files |
+        [
+            (.diff_tokens // 0 | floor),
+            (.file_metadata.file_count // 0),
+            (.languages.has_frontend // false),
+            ([$files[] | select(.type == "source")] | length),
+            ([$files[] | select((.type == "test") or (.is_test == true))] | length),
+            ([$files[] | select(.type == "config")] | length),
+            ([$files[] | select(.type == "migration")] | length)
+        ] | @tsv
+    ' "${session_file}"
+)
 
 # All 7 core agents
 all_agents=("security" "performance" "correctness" "maintainability" "testing" "compatibility" "architecture")
@@ -49,15 +53,21 @@ fi
 agents=()
 reasoning=""
 
-# For medium+ diffs, always run all agents
+# For medium+ diffs, or when file metadata is absent (e.g., deletions-only PRs where
+# pre-review-context.sh only parses added files), always run all agents
 if [[ "${diff_tokens}" -ge 2000 ]]; then
     agents=("${all_agents[@]}")
     reasoning="Medium or large diff (${diff_tokens} diff tokens, ${file_count} files): running all agents"
+elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
+    # No file metadata (likely a deletions-only PR) - run all core agents to avoid under-reviewing
+    agents=("${all_agents[@]}")
+    reasoning="No file metadata (${diff_tokens} diff tokens, possible deletions-only change): running all agents"
 # For tiny/small diffs, select agents based on file composition
-elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]]; then
-    # Config/docs only
+elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]] && [[ "${file_count}" -gt 0 ]]; then
+    # Config-only (note: .md/docs files are classified as source, so this branch only matches
+    # changes that contain config files and no source, test, or migration files)
     agents=("correctness" "compatibility")
-    reasoning="Config/docs-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
+    reasoning="Config-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
 elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -gt 0 ]]; then
     # Test-only changes
     agents=("testing" "correctness" "maintainability")

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# classify-review-scope.sh - Determine exploration depth and agent selection
+# based on diff size and file characteristics.
+#
+# Usage:
+#   classify-review-scope.sh <session_file>
+#
+# Output (JSON):
+#   {
+#     "exploration_depth": "minimal|standard|thorough",
+#     "agents": ["correctness", "security", ...],
+#     "skipped_agents": ["performance", ...],
+#     "reasoning": "Short explanation of classification"
+#   }
+
+set -euo pipefail
+
+session_file="${1:?Usage: classify-review-scope.sh <session_file>}"
+
+if [[ ! -f "${session_file}" ]]; then
+    echo '{"error": "Session file not found"}' >&2
+    exit 1
+fi
+
+# Extract classification inputs from session JSON (single jq invocation)
+eval "$(jq -r '
+    (.file_metadata.modified_files // []) as $files |
+    @sh "diff_tokens=\(.diff_tokens // 0 | floor)",
+    @sh "file_count=\(.file_metadata.file_count // 0)",
+    @sh "has_frontend=\(.languages.has_frontend // false)",
+    @sh "source_count=\([$files[] | select(.type == "source")] | length)",
+    @sh "test_count=\([$files[] | select(.type == "test" or .is_test == true)] | length)",
+    @sh "config_count=\([$files[] | select(.type == "config")] | length)",
+    @sh "migration_count=\([$files[] | select(.type == "migration")] | length)"
+' "${session_file}")"
+
+# All 7 core agents
+all_agents=("security" "performance" "correctness" "maintainability" "testing" "compatibility" "architecture")
+
+# Determine exploration depth
+exploration_depth="thorough"
+if [[ "${diff_tokens}" -lt 500 ]]; then
+    exploration_depth="minimal"
+elif [[ "${diff_tokens}" -lt 2000 ]]; then
+    exploration_depth="standard"
+fi
+
+# Determine agent selection
+agents=()
+reasoning=""
+
+# For medium+ diffs, always run all agents
+if [[ "${diff_tokens}" -ge 2000 ]]; then
+    agents=("${all_agents[@]}")
+    reasoning="Medium or large diff (${diff_tokens} diff tokens, ${file_count} files): running all agents"
+# For tiny/small diffs, select agents based on file composition
+elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]]; then
+    # Config/docs only
+    agents=("correctness" "compatibility")
+    reasoning="Config/docs-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
+elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -gt 0 ]]; then
+    # Test-only changes
+    agents=("testing" "correctness" "maintainability")
+    reasoning="Test-only change (${diff_tokens} diff tokens, ${test_count} test files): testing + correctness + maintainability"
+elif [[ "${migration_count}" -gt 0 ]] && [[ "${source_count}" -eq 0 ]]; then
+    # Migration-only
+    agents=("correctness" "compatibility" "security")
+    reasoning="Migration-only change (${diff_tokens} diff tokens, ${migration_count} migration files): correctness + compatibility + security"
+elif [[ "${diff_tokens}" -lt 500 ]]; then
+    # Tiny source change: core agents only
+    agents=("correctness" "security" "testing" "architecture")
+    reasoning="Tiny source change (${diff_tokens} diff tokens, ${file_count} files): core agents"
+else
+    # Small source change: most agents
+    agents=("correctness" "security" "testing" "architecture" "maintainability")
+    # Add compatibility if there are public-facing files
+    if [[ "${config_count}" -gt 0 ]] || [[ "${migration_count}" -gt 0 ]]; then
+        agents+=("compatibility")
+    fi
+    reasoning="Small source change (${diff_tokens} diff tokens, ${file_count} files): focused agents"
+fi
+
+# Add frontend agent if applicable and not already gated out by tiny diff
+if [[ "${has_frontend}" == "true" ]]; then
+    if [[ "${diff_tokens}" -ge 500 ]]; then
+        agents+=("frontend")
+    else
+        # Track that frontend was skipped due to tiny diff
+        frontend_skipped=true
+    fi
+fi
+
+# Compute skipped agents (core agents not selected)
+declare -A selected_set
+for agent in "${agents[@]}"; do
+    selected_set["${agent}"]=1
+done
+
+skipped_agents=()
+for agent in "${all_agents[@]}"; do
+    if [[ -z "${selected_set[${agent}]+x}" ]]; then
+        skipped_agents+=("${agent}")
+    fi
+done
+if [[ "${frontend_skipped:-false}" == "true" ]]; then
+    skipped_agents+=("frontend")
+fi
+
+# Build JSON output
+agents_joined=$(
+    IFS=$'\n'
+    echo "${agents[*]}"
+)
+skipped_joined=$(
+    IFS=$'\n'
+    echo "${skipped_agents[*]}"
+)
+
+jq -nc \
+    --arg depth "${exploration_depth}" \
+    --arg reasoning "${reasoning}" \
+    --arg agents_raw "${agents_joined}" \
+    --arg skipped_raw "${skipped_joined}" \
+    '{
+        exploration_depth: $depth,
+        agents: ($agents_raw | split("\n") | map(select(. != ""))),
+        skipped_agents: ($skipped_raw | split("\n") | map(select(. != ""))),
+        reasoning: $reasoning
+    }'

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -64,16 +64,16 @@ elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
     agents=("${all_agents[@]}")
     reasoning="No file metadata (${diff_tokens} diff tokens, possible deletions-only change): running all agents"
 # For tiny/small diffs, select agents based on file composition
-elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]] && [[ "${file_count}" -gt 0 ]]; then
+elif [[ "${config_count}" -gt 0 ]] && [[ "${config_count}" -eq "${file_count}" ]]; then
     # Config-only (note: .md/docs files are classified as source, so this branch only matches
-    # changes that contain config files and no source, test, or migration files)
+    # changes where all modified files are config files)
     agents=("correctness" "compatibility")
     reasoning="Config-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
-elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -gt 0 ]] && [[ "${config_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]]; then
+elif [[ "${test_count}" -gt 0 ]] && [[ "${test_count}" -eq "${file_count}" ]]; then
     # Test-only changes
     agents=("testing" "correctness" "maintainability")
     reasoning="Test-only change (${diff_tokens} diff tokens, ${test_count} test files): testing + correctness + maintainability"
-elif [[ "${migration_count}" -gt 0 ]] && [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${config_count}" -eq 0 ]]; then
+elif [[ "${migration_count}" -gt 0 ]] && [[ "${migration_count}" -eq "${file_count}" ]]; then
     # Migration-only
     agents=("correctness" "compatibility" "security")
     reasoning="Migration-only change (${diff_tokens} diff tokens, ${migration_count} migration files): correctness + compatibility + security"

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -19,19 +19,20 @@ set -euo pipefail
 session_file="${1:?Usage: classify-review-scope.sh <session_file>}"
 
 if [[ ! -f "${session_file}" ]]; then
-    echo '{"error": "Session file not found"}' >&2
+    error_json='{"error": "Session file not found"}'
+    echo "${error_json}"
+    echo "${error_json}" >&2
     exit 1
 fi
 
 # Extract classification inputs from session JSON (single jq invocation, no eval)
-read -r diff_tokens file_count has_frontend source_count test_count config_count migration_count < <(
+read -r diff_tokens file_count has_frontend test_count config_count migration_count < <(
     jq -r '
         (.file_metadata.modified_files // []) as $files |
         [
             (.diff_tokens // 0 | floor),
             (.file_metadata.file_count // 0),
             (.languages.has_frontend // false),
-            ([$files[] | select(.type == "source")] | length),
             ([$files[] | select((.type == "test") or (.is_test == true))] | length),
             ([$files[] | select(.type == "config")] | length),
             ([$files[] | select(.type == "migration")] | length)

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # classify-review-scope.sh - Determine exploration depth and agent selection
 # based on diff size and file characteristics.
+# Requires: bash 4+ (uses declare -A associative arrays)
 #
 # Usage:
 #   classify-review-scope.sh <session_file>
@@ -68,11 +69,11 @@ elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${migra
     # changes that contain config files and no source, test, or migration files)
     agents=("correctness" "compatibility")
     reasoning="Config-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
-elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -gt 0 ]]; then
+elif [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -gt 0 ]] && [[ "${config_count}" -eq 0 ]] && [[ "${migration_count}" -eq 0 ]]; then
     # Test-only changes
     agents=("testing" "correctness" "maintainability")
     reasoning="Test-only change (${diff_tokens} diff tokens, ${test_count} test files): testing + correctness + maintainability"
-elif [[ "${migration_count}" -gt 0 ]] && [[ "${source_count}" -eq 0 ]]; then
+elif [[ "${migration_count}" -gt 0 ]] && [[ "${source_count}" -eq 0 ]] && [[ "${test_count}" -eq 0 ]] && [[ "${config_count}" -eq 0 ]]; then
     # Migration-only
     agents=("correctness" "compatibility" "security")
     reasoning="Migration-only change (${diff_tokens} diff tokens, ${migration_count} migration files): correctness + compatibility + security"


### PR DESCRIPTION
## Summary

- Adds a `classify-review-scope.sh` script that deterministically selects which review agents to run and how deep the context explorer should investigate, based on diff size and file characteristics
- For tiny/small diffs, skips irrelevant agents (e.g., config-only changes skip performance/security/testing) and reduces explorer time-box from 2-3 minutes to 30 seconds
- Estimated 45-75% token reduction for small diffs (e.g., 521-token config change: 219K -> 60-80K tokens)

## Changes

- **New:** `skills/review-code/scripts/classify-review-scope.sh` - deterministic classifier with rules for config-only, test-only, migration-only, tiny source, small source, and medium+ diffs
- **Updated:** `skills/review-code/handlers/review.md` - scope classification step, depth-conditional explorer instructions, selective agent dispatch, scope metadata in review output and token usage log

## Test plan

- [x] `bin/test` passes (1131 unit tests + 12 integration tests)
- [x] `bin/fmt` passes
- [x] Classifier tested with tiny config, small source, test-only, and large diff scenarios
- [ ] Run `/review-code` on a tiny PR and verify reduced agent count and exploration depth in review metadata
- [ ] Run `/review-code` on a large PR and verify all 7 agents still run with thorough exploration
- [ ] Run `/review-code pr <N> security` and verify area override bypasses classification