### PR TITLE
Fix SIGPIPE crash in git-file-history.sh

### DIFF
--- a/skills/review-code/scripts/git-file-history.sh
+++ b/skills/review-code/scripts/git-file-history.sh
@@ -61,7 +61,7 @@ main() {
         if [[ -n "${log_output}" ]]; then
             recent_commits=$(echo "${log_output}" | wc -l | tr -d ' ')
             recent_authors=$(echo "${log_output}" | cut -f1 | sort -u | wc -l | tr -d ' ')
-            last_modified=$(echo "${log_output}" | head -1 | cut -f2)
+            last_modified=$(cut -f2 <<< "${log_output%%$'\n'*}")
         fi
 
         # For files dormant >30 days, fetch absolute last_modified


### PR DESCRIPTION
## Summary

- Fix SIGPIPE crash when `log_output` is large (e.g., files with 23k+ commits in 30 days)
- Replace `echo "$log_output" | head -1 | cut -f2` with bash parameter expansion (`${log_output%%$'\n'*}`) to extract the first line without a pipe, avoiding signal 13 under `set -euo pipefail`

## Test plan

- Run `bin/test` (all 1131 unit tests + 12 integration tests pass)
- Pipe a file with large git history (e.g., `state.yaml` with ~23k commits) through `git-file-history.sh` and confirm it completes without silent failure