### PR TITLE
Add infrastructure config review agent

### DIFF
--- a/agents/code-reviewer-infra-config.md
+++ b/agents/code-reviewer-infra-config.md
@@ -1,0 +1,208 @@
+---
+name: code-reviewer-infra-config
+description: "Use this agent for infrastructure config review: Helm values, Kubernetes manifests, Terraform, ArgoCD configs, CI/CD pipelines. Focuses on cross-environment consistency, route/service correctness, operational safety, and config validation."
+model: opus
+color: cyan
+---
+
+You are a senior infrastructure engineer specializing in deployment configuration review. Your role is to verify that infrastructure config changes are correct, consistent across environments, and operationally safe. You focus on Helm values, Kubernetes manifests, Terraform, ArgoCD, Contour/Envoy routing, and CI/CD pipelines.
+
+## Core Philosophy
+
+**Infrastructure config errors cause outages. Verify consistency, validate references, assess operational impact.**
+
+Other agents check application code for bugs, security, and performance. You check whether **deployment and infrastructure config is correct and safe**. This means:
+
+- **Cross-environment consistency** - Are changes applied to all required environments?
+- **Reference correctness** - Do service names, paths, ports, and selectors point to real things?
+- **Operational safety** - Could this change cause traffic disruption or service outages?
+- **Config structure validity** - Is the YAML/HCL/JSON well-formed and using correct field names?
+
+## Before You Review
+
+Read `$architectural_context` first. Then perform these targeted checks before forming any opinion:
+
+1. **Read all modified files in full**: Understand the complete context of each changed file, not just the diff hunks.
+2. **Find cross-environment counterparts**: For each modified file, search for parallel files in other environments (dev, staging, prod, regional variants). Compare whether the same logical change is present. Use patterns like the directory name with different env suffixes, or grep for the file basename across the repo.
+3. **Verify service and resource references**: For service names, deployment names, or resource references in the diff, grep the repo to confirm they exist. Check for typos by comparing against similar names in the same directory or config structure.
+4. **Read the PR description and extract each claim**: List what the PR says it does. Verify each claim is reflected in the config changes.
+
+Do not flag a missing cross-environment change until you have searched for the counterpart files.
+
+## Focus Areas
+
+Review infrastructure config changes for these concerns in priority order:
+
+### 1. Cross-Environment Consistency (Critical)
+
+**Changes that should apply across environments must be present in all of them.**
+
+When a config change appears in one environment file (e.g., `values.prod-us.yaml`), check whether the same logical change exists in:
+- Other environment files (dev, staging, prod-eu, prod-us)
+- Other regional variants
+- Base/default values that environments inherit from
+
+**What to check:**
+- Route changes present in all environment-specific ingress configs
+- Environment variable additions present across all deployment configs
+- Resource limit changes applied consistently (or with documented per-env differences)
+- Feature flag or mode changes propagated to all environments
+
+**When differences are intentional:**
+- Dev-only testing configs
+- Region-specific values (endpoints, resource sizing)
+- Staged rollouts (one region first)
+
+If the PR description explains that a difference is intentional (e.g., "deploying to prod-us first"), note it but don't flag it.
+
+**Example:**
+```text
+❌ Missing cross-environment change [90% confidence]
+Location: argocd/contour-ingress/values/values.prod-eu.yaml
+- Route for `/flags/definitions` updated in values.prod-us.yaml and values.dev.yaml
+- But values.prod-eu.yaml still points to the old service
+- PR description says "all 3 envs" but only 2 are updated
+- Fix: Add the same route change to values.prod-eu.yaml
+```
+
+### 2. Route and Service Correctness (Critical)
+
+**Service names, paths, ports, and selectors must reference real entities.**
+
+For Contour/Envoy HTTPProxy routes, Kubernetes Service references, and similar:
+- Verify service names match actual deployed services (grep for the service name in the repo)
+- Check that route paths are syntactically correct and don't conflict with existing routes
+- Verify port numbers match the target service's exposed ports
+- Check selector labels match pod labels
+
+**Common mistakes:**
+- Typos in service names (e.g., `posthog-feature-flag` vs `posthog-feature-flags`)
+- Wrong port number for a service
+- Route path conflicts (two routes matching the same prefix)
+- Missing trailing slash consistency
+
+**Example:**
+```text
+⚠️ Service name may be incorrect [70% confidence]
+Location: argocd/contour-ingress/values/values.prod-us.yaml:45
+- Route points to service `posthog-feature-flags-definition`
+- But other configs reference `posthog-feature-flags-definitions` (plural)
+- No service definition found matching the singular form
+- Fix: Use `posthog-feature-flags-definitions`
+```
+
+### 3. Operational Safety (Critical)
+
+**Assess whether the change could cause traffic disruption or service outages.**
+
+**High-risk changes to flag:**
+- Removing or redirecting traffic routes (could cause 404s or traffic loss)
+- Changing replica counts or resource limits (could cause capacity issues)
+- Modifying health check paths or timeouts (could cause rolling restart failures)
+- Changing rollout strategies (could affect zero-downtime deploys)
+- Adding `SERVICE_MODE` or similar flags that restrict service behavior
+- Removing environment variables that services depend on
+
+**What to verify:**
+- Route changes don't orphan existing traffic
+- Resource changes are within reasonable bounds
+- Health check changes won't cause false failures
+- Rollout strategy changes preserve availability
+
+**Example:**
+```text
+⚠️ Traffic routing change [85% confidence]
+Location: argocd/contour-ingress/values/values.prod-us.yaml:23
+- Route for `/flags/definitions` moved from `posthog-feature-flags` to `posthog-feature-flags-definitions`
+- This redirects all definition traffic to the new fleet
+- Question: Is the `posthog-feature-flags-definitions` fleet deployed and healthy before this route change takes effect?
+- If the fleet isn't ready, this causes 503s for all `/flags/definitions` requests
+```
+
+### 4. Config Structure and Value Correctness (Important)
+
+**Verify the config is well-formed and uses correct field names for the target system.**
+
+- YAML indentation and structure (especially Helm values nesting)
+- Correct Kubernetes API field names (e.g., `containerPort` not `container_port`)
+- Correct Helm values paths (matching what the chart templates expect)
+- Correct Terraform resource types and argument names
+- Boolean vs string values (e.g., `"true"` vs `true`)
+- Correct data types for numeric values (string ports vs integer ports)
+
+### 5. Helm and Template Correctness (Important)
+
+**For Helm values and templates:**
+- Values referenced by templates actually exist in values files
+- Template syntax is correct (`{{ }}` properly formed)
+- Chart dependency versions are compatible
+- Values override the correct defaults (check `values.yaml` base)
+
+### 6. Terraform Specifics (Important)
+
+**For Terraform changes:**
+- Resource naming follows conventions
+- State implications (will resources be destroyed and recreated?)
+- Destructive changes flagged (e.g., changing a resource name causes replacement)
+- Dependency ordering (resources created before their dependents)
+- Module version pinning
+
+### 7. CI/CD Pipeline Correctness (Important)
+
+**For GitHub Actions, GitLab CI, Jenkinsfile, and other pipeline configs:**
+- Step ordering (dependencies run before dependents)
+- Secret handling (no hardcoded secrets, correct secret reference names)
+- Trigger conditions (correct branch patterns, event types)
+- Action/image version pinning (avoid `@latest` or `@main`)
+- Job dependency graph (needs/depends_on correct)
+- Environment variable availability (defined before use)
+
+## Self-Challenge
+
+Before including any finding, argue against it:
+
+1. **Is this intentionally different?** Cross-env differences may be deliberate. Check the PR description.
+2. **Did you verify the reference?** Don't assume a service name is wrong; grep for it first.
+3. **Is the operational risk real?** Consider deployment ordering, feature flags, and gradual rollouts.
+4. **Could this be a staged rollout?** Many teams deploy to one region first intentionally.
+
+**Drop non-blocking findings if** you can't cite specific evidence, or the concern is speculative. **For `blocking:` findings**, report them with your confidence level.
+
+## Feedback Format
+
+**Response Structure:**
+
+1. **Investigation Summary**: What cross-environment files you found, what service references you verified, and claims extracted from the PR description. Note any steps where `$architectural_context` already provided sufficient coverage.
+2. **Cross-Environment Assessment**: Are changes consistent across environments?
+3. **Blocking Issues**: Misconfigurations, missing env changes, or operational risks that could cause outages
+4. **Suggestions & Questions**: Likely issues or operational concerns worth discussing
+5. **Nits**: Minor config style or convention issues
+6. **What's Working**: Acknowledge correctly implemented changes
+
+**For Each Issue:**
+
+- **Location**: File and line number (or line range)
+- **Confidence Level**: 20-100% based on certainty
+- **What's Wrong**: Specific description of the config issue
+- **Evidence**: How you determined this is wrong (found counterpart files, grepped for service name, etc.)
+- **Impact**: What will happen at deploy time if not fixed
+- **Fix**: Concrete YAML/HCL snippet showing the correction
+
+**Confidence Scoring Guidelines:**
+
+- **90-100%**: Definite misconfiguration, verified by cross-referencing files
+- **70-89%**: Very likely issue, found inconsistency with other environment files
+- **50-69%**: Probable issue, but could be intentional
+- **30-49%**: Possible concern, worth verifying with the author
+- **20-29%**: Minor suspicion, flagging for awareness
+
+## What NOT to Review
+
+Stay focused on infrastructure config correctness. Do NOT provide feedback on:
+- Application code logic (correctness agent)
+- Security vulnerabilities in application code (security agent)
+- Performance of application code (performance agent)
+- Test coverage (testing agent)
+- Code style or formatting (maintainability agent)
+
+If you notice application-level issues visible in config (e.g., a suspicious environment variable value), briefly mention them but direct to the appropriate agent.

--- a/bin/setup
+++ b/bin/setup
@@ -204,6 +204,7 @@ install_agents() {
         "code-reviewer-compatibility"
         "code-reviewer-architecture"
         "code-reviewer-frontend"
+        "code-reviewer-infra-config"
     )
 
     # Create agents directory

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -37,7 +37,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 - `compatibility` - Backwards compatibility with shipped code only (local changes)
 - `architecture` - High-level design, patterns, and necessity only (local changes)
 - `infra-config` - Infrastructure config review: Helm, Terraform, K8s, ArgoCD, CI/CD (local changes)
-- (no argument) - Run ALL 7 specialized agents in parallel on local changes (default)
+- (no argument) - Run the 7 core agents in parallel on local changes; also runs `infra-config` and `frontend` when the diff contains those file types (default)
 
 **Optional Flags:**
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -36,6 +36,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 - `testing` - Test coverage, quality, and patterns only (local changes)
 - `compatibility` - Backwards compatibility with shipped code only (local changes)
 - `architecture` - High-level design, patterns, and necessity only (local changes)
+- `infra-config` - Infrastructure config review: Helm, Terraform, K8s, ArgoCD, CI/CD (local changes)
 - (no argument) - Run ALL 7 specialized agents in parallel on local changes (default)
 
 **Optional Flags:**

--- a/skills/review-code/context/orgs/posthog/repos/charts.md
+++ b/skills/review-code/context/orgs/posthog/repos/charts.md
@@ -1,0 +1,68 @@
+# PostHog/charts Repository Guidelines
+
+## Repository Overview
+
+This repository contains Helm charts and Kubernetes deployment configurations for PostHog's infrastructure, managed via ArgoCD.
+
+## Environment Structure
+
+<!-- TODO: Fill in environment details -->
+
+PostHog deploys across multiple environments:
+- **dev** - Development/staging environment
+- **prod-us** - US production region
+- **prod-eu** - EU production region
+
+Most changes should be applied consistently across all three environments unless intentionally staged.
+
+## Directory Layout
+
+<!-- TODO: Verify and expand directory structure -->
+
+```
+argocd/
+  <service>/
+    values/
+      values.yaml          # Base/shared values
+      values.dev.yaml      # Dev-specific overrides
+      values.prod-us.yaml  # US production overrides
+      values.prod-eu.yaml  # EU production overrides
+  contour-ingress/
+    values/
+      values.dev.yaml      # Dev ingress routing
+      values.prod-us.yaml  # US production routing
+      values.prod-eu.yaml  # EU production routing
+```
+
+## Contour Ingress Patterns
+
+<!-- TODO: Fill in Contour/HTTPProxy conventions -->
+
+Contour is used as the ingress controller with Envoy as the data plane. Route changes in `argocd/contour-ingress/values/` affect traffic routing.
+
+Key considerations:
+- Route changes should typically be applied to all 3 environment files
+- `num-trusted-hops: 1` is configured for proper client IP extraction
+- Routes map URL paths to Kubernetes services
+
+## Fleet and Service Naming
+
+<!-- TODO: Fill in fleet/service naming conventions -->
+
+Services follow the naming pattern `posthog-<service-name>`. Examples:
+- `posthog-feature-flags`
+- `posthog-feature-flags-definitions`
+
+## Common Environment Variables
+
+<!-- TODO: Document common env vars -->
+
+- `SERVICE_MODE` - Controls which routes a service registers (e.g., `"flags"` for flags-only mode)
+
+## Cross-Environment Consistency
+
+When reviewing changes:
+1. Verify route changes are present in all 3 environment files (dev, prod-us, prod-eu)
+2. Check that service names reference actual deployed services
+3. Confirm environment variable additions are propagated to all relevant deployments
+4. Note any intentional per-environment differences (e.g., staged rollouts)

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -239,7 +239,15 @@ $diff
 
 $file_access_instructions
 
-{If exploration_depth == "minimal":}
+{If exploration_depth == "minimal" and "infra-config" is the only agent in $selected_agents:}
+Time-box yourself to 30 seconds. This is an infrastructure config review (Helm values, K8s manifests, Terraform, ArgoCD, CI/CD).
+Focus on:
+- Read the modified files to understand what each configures (service, route, resource)
+- Find cross-environment counterparts (dev/staging/prod variants of the same file)
+- Note service and resource names referenced in the config
+Do NOT search for code callers, function patterns, or application architecture.
+
+{If exploration_depth == "minimal" (non-infra):}
 Time-box yourself to 30 seconds. Focus on understanding what changed:
 - Read only the modified files to understand their purpose and the change
 - Skip caller search, pattern search, git history, and reference implementations
@@ -284,6 +292,7 @@ Invoke the agents determined by the scope classification. If an area was specifi
 | testing | code-reviewer-testing | Test coverage, quality, edge cases |
 | compatibility | code-reviewer-compatibility | Backwards compatibility with shipped code |
 | architecture | code-reviewer-architecture | Necessity, patterns, code reuse, simplicity, solution proportionality |
+| infra-config | code-reviewer-infra-config | Cross-env consistency, route/service correctness, operational safety, config validation |
 | *(frontend detected)* | code-reviewer-frontend | React/TS patterns, components, state, a11y |
 
 **Build the context to pass to each agent:**
@@ -681,6 +690,7 @@ Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-
 - Testing Review (if "testing" in `$selected_agents`)
 - Compatibility Review (if "compatibility" in `$selected_agents`)
 - Architecture Review (if "architecture" in `$selected_agents`)
+- Infra-Config Review (if "infra-config" in `$selected_agents`)
 - Frontend Review (if "frontend" in `$selected_agents`)
 
 **For area-specific reviews**, include only that area's findings.

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -56,9 +56,16 @@ fi
 agents=()
 reasoning=""
 
+# Infra-config-only changes always use the infra-config agent regardless of diff size.
+# This branch must come before the diff_tokens >= 2000 check to avoid being shadowed.
+if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file_count}" ]]; then
+    # Infra-config only (Helm, Terraform, ArgoCD, K8s, CI/CD)
+    agents=("infra-config")
+    exploration_depth="minimal"
+    reasoning="Infra-config-only change (${diff_tokens} diff tokens, ${infra_config_count} infra config files): infra-config agent"
 # For medium+ diffs, or when file metadata is absent (e.g., deletions-only PRs where
 # pre-review-context.sh only parses added files), always run all agents
-if [[ "${diff_tokens}" -ge 2000 ]]; then
+elif [[ "${diff_tokens}" -ge 2000 ]]; then
     agents=("${all_agents[@]}")
     reasoning="Medium or large diff (${diff_tokens} diff tokens, ${file_count} files): running all agents"
 elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
@@ -66,11 +73,6 @@ elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
     agents=("${all_agents[@]}")
     reasoning="No file metadata (${diff_tokens} diff tokens, possible deletions-only change): running all agents"
 # For tiny/small diffs, select agents based on file composition
-elif [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file_count}" ]]; then
-    # Infra-config only (Helm, Terraform, ArgoCD, K8s, CI/CD)
-    agents=("infra-config")
-    exploration_depth="minimal"
-    reasoning="Infra-config-only change (${diff_tokens} diff tokens, ${infra_config_count} infra config files): infra-config agent"
 elif [[ "${config_count}" -gt 0 ]] && [[ "${config_count}" -eq "${file_count}" ]]; then
     # Config-only (note: .md/docs files are classified as source, so this branch only matches
     # changes where all modified files are config files)

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -26,7 +26,7 @@ if [[ ! -f "${session_file}" ]]; then
 fi
 
 # Extract classification inputs from session JSON (single jq invocation, no eval)
-read -r diff_tokens file_count has_frontend test_count config_count migration_count < <(
+read -r diff_tokens file_count has_frontend test_count config_count migration_count infra_config_count < <(
     jq -r '
         (.file_metadata.modified_files // []) as $files |
         [
@@ -35,12 +35,13 @@ read -r diff_tokens file_count has_frontend test_count config_count migration_co
             (.languages.has_frontend // false),
             ([$files[] | select((.type == "test") or (.is_test == true))] | length),
             ([$files[] | select(.type == "config")] | length),
-            ([$files[] | select(.type == "migration")] | length)
+            ([$files[] | select(.type == "migration")] | length),
+            ([$files[] | select(.is_infra_config == true)] | length)
         ] | @tsv
     ' "${session_file}"
 )
 
-# All 7 core agents
+# All 7 core agents (infra-config and frontend are conditional, not core)
 all_agents=("security" "performance" "correctness" "maintainability" "testing" "compatibility" "architecture")
 
 # Determine exploration depth
@@ -65,6 +66,11 @@ elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
     agents=("${all_agents[@]}")
     reasoning="No file metadata (${diff_tokens} diff tokens, possible deletions-only change): running all agents"
 # For tiny/small diffs, select agents based on file composition
+elif [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file_count}" ]]; then
+    # Infra-config only (Helm, Terraform, ArgoCD, K8s, CI/CD)
+    agents=("infra-config")
+    exploration_depth="minimal"
+    reasoning="Infra-config-only change (${diff_tokens} diff tokens, ${infra_config_count} infra config files): infra-config agent"
 elif [[ "${config_count}" -gt 0 ]] && [[ "${config_count}" -eq "${file_count}" ]]; then
     # Config-only (note: .md/docs files are classified as source, so this branch only matches
     # changes where all modified files are config files)
@@ -92,6 +98,11 @@ else
     reasoning="Small source change (${diff_tokens} diff tokens, ${file_count} files): focused agents"
 fi
 
+# Add infra-config agent for mixed changes (infra + non-infra files)
+if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -lt "${file_count}" ]]; then
+    agents+=("infra-config")
+fi
+
 # Add frontend agent if applicable and not already gated out by tiny diff
 if [[ "${has_frontend}" == "true" ]]; then
     if [[ "${diff_tokens}" -ge 500 ]]; then
@@ -116,6 +127,10 @@ for agent in "${all_agents[@]}"; do
 done
 if [[ "${frontend_skipped:-false}" == "true" ]]; then
     skipped_agents+=("frontend")
+fi
+# Report infra-config as skipped only when infra files were present but agent wasn't selected
+if [[ "${infra_config_count}" -gt 0 ]] && [[ -z "${selected_set["infra-config"]+x}" ]]; then
+    skipped_agents+=("infra-config")
 fi
 
 # Build JSON output

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -104,8 +104,10 @@ else
     reasoning="Small source change (${diff_tokens} diff tokens, ${file_count} files): focused agents"
 fi
 
-# Add infra-config agent for mixed changes (infra + non-infra files)
-if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -lt "${file_count}" ]]; then
+# Add infra-config agent when infra files are present but the infra-config-only shortcut wasn't
+# taken. That covers two cases: mixed infra + non-infra modified files, and infra-only modified
+# files that have accompanying deletions (deleted_count > 0 caused the shortcut to be skipped).
+if [[ "${infra_config_count}" -gt 0 ]] && { [[ "${infra_config_count}" -lt "${file_count}" ]] || [[ "${deleted_count}" -gt 0 ]]; }; then
     agents+=("infra-config")
 fi
 

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -26,7 +26,7 @@ if [[ ! -f "${session_file}" ]]; then
 fi
 
 # Extract classification inputs from session JSON (single jq invocation, no eval)
-read -r diff_tokens file_count has_frontend test_count config_count migration_count infra_config_count < <(
+read -r diff_tokens file_count has_frontend test_count config_count migration_count infra_config_count deleted_count < <(
     jq -r '
         (.file_metadata.modified_files // []) as $files |
         [
@@ -36,7 +36,8 @@ read -r diff_tokens file_count has_frontend test_count config_count migration_co
             ([$files[] | select((.type == "test") or (.is_test == true))] | length),
             ([$files[] | select(.type == "config")] | length),
             ([$files[] | select(.type == "migration")] | length),
-            ([$files[] | select(.is_infra_config == true)] | length)
+            ([$files[] | select(.is_infra_config == true)] | length),
+            (.file_metadata.deleted_file_count // 0)
         ] | @tsv
     ' "${session_file}"
 )
@@ -58,7 +59,10 @@ reasoning=""
 
 # Infra-config-only changes always use the infra-config agent regardless of diff size.
 # This branch must come before the diff_tokens >= 2000 check to avoid being shadowed.
-if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file_count}" ]]; then
+# Guard against deleted_count > 0: pre-review-context.sh only parses added/modified files,
+# so deleted source files won't appear in modified_files. If deletions are present alongside
+# infra-config modifications, fall through to normal agent selection to ensure deletions get reviewed.
+if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file_count}" ]] && [[ "${deleted_count}" -eq 0 ]]; then
     # Infra-config only (Helm, Terraform, ArgoCD, K8s, CI/CD)
     agents=("infra-config")
     exploration_depth="minimal"

--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -31,7 +31,7 @@ read -r diff_tokens file_count has_frontend test_count config_count migration_co
         (.file_metadata.modified_files // []) as $files |
         [
             (.diff_tokens // 0 | floor),
-            (.file_metadata.file_count // 0),
+            ((.file_metadata.file_count // null) // ($files | length)),
             (.languages.has_frontend // false),
             ([$files[] | select((.type == "test") or (.is_test == true))] | length),
             ([$files[] | select(.type == "config")] | length),

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -59,7 +59,7 @@ if [[ "${arg}" == "learn" ]] && [[ "${FIND_MODE}" != "true" ]]; then
 fi
 
 # Special keywords for area-specific reviews
-AREA_KEYWORDS=("security" "performance" "maintainability" "testing" "compatibility" "architecture" "frontend")
+AREA_KEYWORDS=("security" "performance" "maintainability" "testing" "compatibility" "architecture" "frontend" "infra-config")
 
 # Helper: Check if argument is in array
 contains() {

--- a/skills/review-code/scripts/pre-review-context.sh
+++ b/skills/review-code/scripts/pre-review-context.sh
@@ -15,13 +15,15 @@
 #         "type": "source",
 #         "language": "python",
 #         "is_test": false,
+#         "is_infra_config": false,
 #         "likely_test_path": "backend/api/test_auth.py"
 #       }
 #     ],
 #     "file_count": 5,
 #     "has_tests": true,
 #     "has_migrations": false,
-#     "has_config": false
+#     "has_config": false,
+#     "has_infra_config": false
 #   }
 
 set -euo pipefail
@@ -88,9 +90,32 @@ file_metadata_ndjson=$(while IFS= read -r file; do
     fi
 
     # Check for config files
+    is_infra_config=false
     if [[ "${basename}" =~ \.(json|yaml|yml|toml|ini|env|config)$ ]] \
         || [[ "${basename}" =~ ^(package\.json|tsconfig|Cargo\.toml|pyproject\.toml|setup\.py|Gemfile|composer\.json)$ ]]; then
         file_type="config"
+    fi
+
+    # Files that are always both config and infra-config
+    if [[ "${basename}" =~ \.tf$ ]] \
+        || [[ "${basename}" =~ ^(Dockerfile|Jenkinsfile)$ ]] \
+        || [[ "${basename}" =~ ^(docker-compose)\.ya?ml$ ]] \
+        || [[ "${basename}" =~ ^\.gitlab-ci\.yml$ ]]; then
+        file_type="config"
+        is_infra_config=true
+    fi
+
+    # Check remaining infra-config patterns for files already classified as config
+    if [[ "${file_type}" = "config" ]] && [[ "${is_infra_config}" = false ]]; then
+        # Detect by directory path patterns
+        if [[ "${dirname}" =~ (^|/)(argocd|helm|charts|k8s|kubernetes|terraform|infra|deploy|kustomize)(/|$) ]] \
+            || [[ "${dirname}" =~ (^|/)\.github/workflows(/|$) ]]; then
+            is_infra_config=true
+        fi
+        # Detect by filename patterns (Helm/K8s specific)
+        if [[ "${basename}" =~ ^(Chart|values|helmfile|kustomization)\.ya?ml$ ]]; then
+            is_infra_config=true
+        fi
     fi
 
     # Generate likely test path if this is a source file
@@ -137,8 +162,8 @@ file_metadata_ndjson=$(while IFS= read -r file; do
     safe_path=$(printf '%s' "${file}" | sed 's/\\/\\\\/g; s/"/\\"/g')
     safe_test_path=$(printf '%s' "${likely_test_path}" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
-    printf '{"path":"%s","type":"%s","language":"%s","is_test":%s,"likely_test_path":"%s"}\n' \
-        "${safe_path}" "${file_type}" "${language}" "${is_test}" "${safe_test_path}"
+    printf '{"path":"%s","type":"%s","language":"%s","is_test":%s,"is_infra_config":%s,"likely_test_path":"%s"}\n' \
+        "${safe_path}" "${file_type}" "${language}" "${is_test}" "${is_infra_config}" "${safe_test_path}"
 
 done <<< "${file_paths}")
 
@@ -149,5 +174,6 @@ echo "${file_metadata_ndjson}" | jq -s '{
     file_count: length,
     has_tests: (map(select(.is_test == true)) | length > 0),
     has_migrations: (map(select(.type == "migration")) | length > 0),
-    has_config: (map(select(.type == "config")) | length > 0)
+    has_config: (map(select(.type == "config")) | length > 0),
+    has_infra_config: (map(select(.is_infra_config == true)) | length > 0)
 }'

--- a/skills/review-code/scripts/pre-review-context.sh
+++ b/skills/review-code/scripts/pre-review-context.sh
@@ -20,6 +20,7 @@
 #       }
 #     ],
 #     "file_count": 5,
+#     "deleted_file_count": 0,
 #     "has_tests": true,
 #     "has_migrations": false,
 #     "has_config": false,
@@ -34,6 +35,9 @@ diff_content=$(cat)
 # Extract file paths from diff
 # Format: +++ b/path/to/file.ext
 file_paths=$(echo "${diff_content}" | { grep -E "^\+\+\+ b/" || test $? = 1; } | sed 's/^+++ b\///')
+
+# Count deleted files (diff entries where the target is /dev/null)
+deleted_file_count=$(echo "${diff_content}" | { grep -cE "^\+\+\+ /dev/null" || test $? = 1; })
 
 # Detect file type and generate metadata
 # Output newline-delimited JSON, capture for single jq processing
@@ -169,9 +173,10 @@ done <<< "${file_paths}")
 
 # Build final JSON output with single jq call
 # Convert newline-delimited JSON to array and calculate metadata
-echo "${file_metadata_ndjson}" | jq -s '{
+echo "${file_metadata_ndjson}" | jq -s --argjson deleted_count "${deleted_file_count}" '{
     modified_files: .,
     file_count: length,
+    deleted_file_count: $deleted_count,
     has_tests: (map(select(.is_test == true)) | length > 0),
     has_migrations: (map(select(.type == "migration")) | length > 0),
     has_config: (map(select(.type == "config")) | length > 0),

--- a/skills/review-code/scripts/pre-review-context.sh
+++ b/skills/review-code/scripts/pre-review-context.sh
@@ -97,7 +97,7 @@ file_metadata_ndjson=$(while IFS= read -r file; do
     fi
 
     # Files that are always both config and infra-config
-    if [[ "${basename}" =~ \.tf$ ]] \
+    if [[ "${basename}" =~ \.tf(vars)?$ ]] \
         || [[ "${basename}" =~ ^(Dockerfile|Jenkinsfile)$ ]] \
         || [[ "${basename}" =~ ^(docker-compose)\.ya?ml$ ]] \
         || [[ "${basename}" =~ ^\.gitlab-ci\.yml$ ]]; then

--- a/tests/unit/test-classify-review-scope.bats
+++ b/tests/unit/test-classify-review-scope.bats
@@ -128,3 +128,32 @@ ENDJSON
     # Should not crash and should not select infra-config
     echo "$result" | jq -e '.agents | contains(["infra-config"]) | not'
 }
+
+@test "infra-config + deleted source file does not use infra-config-only shortcut" {
+    # Simulates: 2 infra-config files modified + 1 source file deleted.
+    # pre-review-context.sh only captures modified files, so deleted_file_count must be
+    # set explicitly here to reflect what the script would produce from the diff.
+    session_file="$TMPDIR/session.json"
+    cat > "$session_file" <<ENDJSON
+{
+    "diff_tokens": 400,
+    "file_metadata": {
+        "modified_files": [
+            {"path":"argocd/contour-ingress/values/values.prod-us.yaml","type":"config","is_infra_config":true,"is_test":false},
+            {"path":"argocd/contour-ingress/values/values.prod-eu.yaml","type":"config","is_infra_config":true,"is_test":false}
+        ],
+        "file_count": 2,
+        "deleted_file_count": 1
+    },
+    "languages": {
+        "has_frontend": false
+    }
+}
+ENDJSON
+
+    result=$("$SCRIPT" "$session_file")
+    # Should NOT select infra-config-only (deletions must be reviewed by core agents)
+    echo "$result" | jq -e '.agents == ["infra-config"] | not'
+    # Should include correctness to catch the source deletion
+    echo "$result" | jq -e '.agents | contains(["correctness"])'
+}

--- a/tests/unit/test-classify-review-scope.bats
+++ b/tests/unit/test-classify-review-scope.bats
@@ -1,0 +1,118 @@
+#!/usr/bin/env bats
+# Unit tests for classify-review-scope.sh
+
+setup() {
+    TEST_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    PROJECT_ROOT="$(cd "$TEST_DIR/../.." && pwd)"
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/classify-review-scope.sh"
+    TMPDIR="$(mktemp -d)"
+}
+
+teardown() {
+    rm -rf "$TMPDIR"
+}
+
+# Helper to create a session file with given parameters
+create_session() {
+    local diff_tokens="${1:-100}"
+    local files_json="${2:-[]}"
+    local has_frontend="${3:-false}"
+
+    cat > "$TMPDIR/session.json" <<ENDJSON
+{
+    "diff_tokens": $diff_tokens,
+    "file_metadata": {
+        "modified_files": $files_json,
+        "file_count": $(echo "$files_json" | jq 'length')
+    },
+    "languages": {
+        "has_frontend": $has_frontend
+    }
+}
+ENDJSON
+    echo "$TMPDIR/session.json"
+}
+
+@test "classify-review-scope.sh exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "infra-config-only selects infra-config agent with minimal exploration" {
+    session=$(create_session 200 '[
+        {"path":"argocd/contour-ingress/values/values.prod-us.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"argocd/contour-ingress/values/values.prod-eu.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"argocd/contour-ingress/values/values.dev.yaml","type":"config","is_infra_config":true,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.exploration_depth == "minimal"'
+    echo "$result" | jq -e '.agents == ["infra-config"]'
+    echo "$result" | jq -e '.reasoning | contains("Infra-config-only")'
+}
+
+@test "regular config-only still selects correctness + compatibility" {
+    session=$(create_session 200 '[
+        {"path":"package.json","type":"config","is_infra_config":false,"is_test":false},
+        {"path":"tsconfig.json","type":"config","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents | contains(["correctness", "compatibility"])'
+    echo "$result" | jq -e '.agents | contains(["infra-config"]) | not'
+}
+
+@test "mixed infra + source includes infra-config agent" {
+    session=$(create_session 800 '[
+        {"path":"argocd/service/values/values.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"backend/api.py","type":"source","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents | contains(["infra-config"])'
+    echo "$result" | jq -e '.agents | contains(["correctness"])'
+}
+
+@test "large diff with infra files includes infra-config alongside all agents" {
+    session=$(create_session 3000 '[
+        {"path":"argocd/service/values/values.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"backend/api.py","type":"source","is_infra_config":false,"is_test":false},
+        {"path":"backend/models.py","type":"source","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents | contains(["infra-config"])'
+    echo "$result" | jq -e '.agents | contains(["correctness", "security"])'
+    echo "$result" | jq -e '.exploration_depth == "thorough"'
+}
+
+@test "infra-config-only forces minimal exploration even for larger diffs" {
+    session=$(create_session 1500 '[
+        {"path":"terraform/main.tf","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"terraform/variables.tf","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"terraform/outputs.tf","type":"config","is_infra_config":true,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.exploration_depth == "minimal"'
+    echo "$result" | jq -e '.agents == ["infra-config"]'
+}
+
+@test "infra-config not in skipped_agents when no infra files present" {
+    session=$(create_session 200 '[
+        {"path":"backend/api.py","type":"source","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    # infra-config should not appear in skipped when there are no infra files (follows frontend pattern)
+    echo "$result" | jq -e '.skipped_agents | contains(["infra-config"]) | not'
+}
+
+@test "no files with is_infra_config defaults to 0 count" {
+    session=$(create_session 200 '[
+        {"path":"backend/api.py","type":"source","is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    # Should not crash and should not select infra-config
+    echo "$result" | jq -e '.agents | contains(["infra-config"]) | not'
+}

--- a/tests/unit/test-classify-review-scope.bats
+++ b/tests/unit/test-classify-review-scope.bats
@@ -156,4 +156,6 @@ ENDJSON
     echo "$result" | jq -e '.agents == ["infra-config"] | not'
     # Should include correctness to catch the source deletion
     echo "$result" | jq -e '.agents | contains(["correctness"])'
+    # infra-config agent must still be included so the infra changes are reviewed
+    echo "$result" | jq -e '.agents | contains(["infra-config"])'
 }

--- a/tests/unit/test-classify-review-scope.bats
+++ b/tests/unit/test-classify-review-scope.bats
@@ -85,7 +85,7 @@ ENDJSON
     echo "$result" | jq -e '.exploration_depth == "thorough"'
 }
 
-@test "infra-config-only forces minimal exploration even for larger diffs" {
+@test "infra-config-only forces minimal exploration even for larger diffs (standard range)" {
     session=$(create_session 1500 '[
         {"path":"terraform/main.tf","type":"config","is_infra_config":true,"is_test":false},
         {"path":"terraform/variables.tf","type":"config","is_infra_config":true,"is_test":false},
@@ -95,6 +95,18 @@ ENDJSON
     result=$("$SCRIPT" "$session")
     echo "$result" | jq -e '.exploration_depth == "minimal"'
     echo "$result" | jq -e '.agents == ["infra-config"]'
+}
+
+@test "infra-config-only still selects infra-config agent for large diffs (>= 2000 tokens)" {
+    session=$(create_session 3000 '[
+        {"path":"argocd/contour-ingress/values/values.prod-us.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"argocd/contour-ingress/values/values.prod-eu.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"argocd/contour-ingress/values/values.dev.yaml","type":"config","is_infra_config":true,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents == ["infra-config"]'
+    echo "$result" | jq -e '.agents | contains(["security"]) | not'
 }
 
 @test "infra-config not in skipped_agents when no infra files present" {

--- a/tests/unit/test-pre-review-context.bats
+++ b/tests/unit/test-pre-review-context.bats
@@ -177,3 +177,154 @@ EOF
     echo "$result" | jq -e '.modified_files[0].likely_test_path != ""'
     echo "$result" | jq -r '.modified_files[0].likely_test_path' | grep -q "Component.test.tsx"
 }
+
+# Infra-config detection tests
+
+@test "detects YAML files in argocd/ as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/argocd/contour-ingress/values/values.prod-us.yaml b/argocd/contour-ingress/values/values.prod-us.yaml
++++ b/argocd/contour-ingress/values/values.prod-us.yaml
+@@ -1,0 +1,2 @@
++route:
++  path: /flags/definitions
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.modified_files[0].type == "config"'
+    echo "$result" | jq -e '.has_infra_config == true'
+}
+
+@test "detects YAML files in helm/ as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/helm/my-service/values.yaml b/helm/my-service/values.yaml
++++ b/helm/my-service/values.yaml
+@@ -1,0 +1,2 @@
++replicaCount: 3
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.has_infra_config == true'
+}
+
+@test "detects values.yaml by filename as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/some/path/values.yaml b/some/path/values.yaml
++++ b/some/path/values.yaml
+@@ -1,0 +1,1 @@
++key: value
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+}
+
+@test "detects Chart.yaml as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/charts/my-app/Chart.yaml b/charts/my-app/Chart.yaml
++++ b/charts/my-app/Chart.yaml
+@@ -1,0 +1,2 @@
++apiVersion: v2
++name: my-app
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+}
+
+@test "detects .tf files as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/terraform/main.tf b/terraform/main.tf
++++ b/terraform/main.tf
+@@ -1,0 +1,3 @@
++resource "aws_instance" "web" {
++  ami = "abc-123"
++}
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.modified_files[0].type == "config"'
+}
+
+@test "detects GitHub Actions workflow files as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -1,0 +1,3 @@
++name: CI
++on: push
++jobs: {}
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.has_infra_config == true'
+}
+
+@test "regular config files are NOT infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/package.json b/package.json
++++ b/package.json
+@@ -1,0 +1,1 @@
++{"name": "test"}
+diff --git a/tsconfig.json b/tsconfig.json
++++ b/tsconfig.json
+@@ -1,0 +1,1 @@
++{"strict": true}
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.has_config == true'
+    echo "$result" | jq -e '.has_infra_config == false'
+    echo "$result" | jq -e '[.modified_files[].is_infra_config] | all(. == false)'
+}
+
+@test "has_infra_config is false when no infra files" {
+    diff=$(cat <<'EOF'
+diff --git a/backend/api.py b/backend/api.py
++++ b/backend/api.py
+@@ -1,0 +1,1 @@
++print("hello")
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.has_infra_config == false'
+}
+
+@test "detects Dockerfile as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/deploy/Dockerfile b/deploy/Dockerfile
++++ b/deploy/Dockerfile
+@@ -1,0 +1,1 @@
++FROM python:3.11
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.modified_files[0].type == "config"'
+}
+
+@test "detects kustomization.yaml as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/k8s/kustomization.yaml b/k8s/kustomization.yaml
++++ b/k8s/kustomization.yaml
+@@ -1,0 +1,2 @@
++resources:
++  - deployment.yaml
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+}

--- a/tests/unit/test-pre-review-context.bats
+++ b/tests/unit/test-pre-review-context.bats
@@ -315,6 +315,22 @@ EOF
     echo "$result" | jq -e '.modified_files[0].type == "config"'
 }
 
+@test "detects .tfvars files as infra-config" {
+    diff=$(cat <<'EOF'
+diff --git a/terraform/variables.tfvars b/terraform/variables.tfvars
++++ b/terraform/variables.tfvars
+@@ -1,0 +1,2 @@
++region = "us-east-1"
++instance_type = "t3.medium"
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
+    echo "$result" | jq -e '.modified_files[0].type == "config"'
+    echo "$result" | jq -e '.has_infra_config == true'
+}
+
 @test "detects kustomization.yaml as infra-config" {
     diff=$(cat <<'EOF'
 diff --git a/k8s/kustomization.yaml b/k8s/kustomization.yaml

--- a/tests/unit/test-pre-review-context.bats
+++ b/tests/unit/test-pre-review-context.bats
@@ -344,3 +344,28 @@ EOF
     result=$(echo "$diff" | "$SCRIPT")
     echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
 }
+
+@test "deleted file increments deleted_file_count and is excluded from modified_files" {
+    diff=$(cat <<'EOF'
+diff --git a/backend/old_module.py b/backend/old_module.py
+deleted file mode 100644
+--- a/backend/old_module.py
++++ /dev/null
+@@ -1,3 +0,0 @@
+-def old_func():
+-    pass
+diff --git a/backend/api.py b/backend/api.py
++++ b/backend/api.py
+@@ -1,0 +1,1 @@
++print("hello")
+EOF
+)
+
+    result=$(echo "$diff" | "$SCRIPT")
+    # Deleted file counted
+    echo "$result" | jq -e '.deleted_file_count == 1'
+    # Modified files contains only the added/modified file, not the deleted one
+    echo "$result" | jq -e '.file_count == 1'
+    echo "$result" | jq -e '.modified_files | length == 1'
+    echo "$result" | jq -e '.modified_files[0].path == "backend/api.py"'
+}


### PR DESCRIPTION
## Summary

- Adds a new `code-reviewer-infra-config` agent purpose-built for reviewing Helm, Terraform, K8s, ArgoCD, and CI/CD changes — focuses on cross-environment consistency, route/service correctness, operational safety, and config structure instead of code-oriented analysis
- Extends `pre-review-context.sh` to detect infrastructure config files (`is_infra_config` flag) via directory patterns (argocd/, helm/, terraform/, etc.) and filename patterns (values.yaml, Chart.yaml, .tf, Dockerfile, etc.)
- Updates `classify-review-scope.sh` to route infra-config-only diffs to the new agent with minimal exploration depth, and adds infra-config alongside code agents for mixed changes
- Adds PostHog/charts repo context template with placeholders for environment structure, directory layout, and naming conventions

## Motivation

When reviewing PRs in infrastructure repos like PostHog/charts (e.g., a 7-line YAML change routing `/flags/definitions` to a new fleet), the pipeline wastes tokens by running code-oriented agents (correctness, compatibility) that search for function callers, API signatures, and integration boundaries — none of which applies to YAML values files.

## Test plan

- [x] `bin/test` passes (10 new infra-config detection tests in pre-review-context, 8 new scope classification tests)
- [ ] `bin/setup` installs the new agent
- [ ] `/review-code infra-config` area override works
- [ ] Test with a charts-like diff to verify infra-config agent is selected with minimal exploration
- [ ] Test mixed PR (infra + source) to verify both infra-config and code agents are selected