### PR TITLE
Add ci-monitor skill

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,16 @@
 
 ## File Locations
 
-This repo contains the source files for the `/review-code` skill:
+This repo contains the source files for the `/review-code` and `/ci-monitor` skills:
 
 - `skills/review-code/SKILL.md` - Skill definition (routing + small handlers)
 - `skills/review-code/handlers/` - Large handlers loaded on demand (find, review, learn)
 - `skills/review-code/scripts/` - Bash scripts that implement the skill
 - `skills/review-code/context/` - Base context files (languages, frameworks, orgs)
 - `skills/review-code/learnings/` - Learning system documentation
+- `skills/ci-monitor/SKILL.md` - CI monitoring skill definition
+- `skills/ci-monitor/handlers/` - Fix handler loaded on demand
+- `skills/ci-monitor/scripts/` - CI polling, log fetching, failure classification scripts
 - `agents/` - Agent definitions
 - `bin/` - Development utilities (fmt, lint, test, setup)
 
@@ -29,6 +32,11 @@ skills/review-code/
         frameworks/
         orgs/
     learnings/                        # Learning system docs
+skills/ci-monitor/
+    SKILL.md                          # CI monitoring skill definition
+    handlers/
+        fix.md                        # Fix cycle handler
+    scripts/                          # CI scripts (detect, poll, logs, classify)
 agents/                               # Review agent definitions
 ```
 

--- a/bin/fmt
+++ b/bin/fmt
@@ -48,6 +48,8 @@ if command_exists shfmt; then
         "evals/scripts/helpers/"*.sh
         "skills/review-code/scripts/"*.sh
         "skills/review-code/scripts/helpers/"*.sh
+        "skills/ci-monitor/scripts/"*.sh
+        "skills/ci-monitor/scripts/helpers/"*.sh
         "*.sh"
     )
 

--- a/bin/setup
+++ b/bin/setup
@@ -97,7 +97,7 @@ check_prerequisites() {
 }
 
 verify_repo_structure() {
-    local required_dirs=("skills/review-code" "skills/review-code/context" "skills/review-code/handlers" "agents")
+    local required_dirs=("skills/review-code" "skills/review-code/context" "skills/review-code/handlers" "skills/ci-monitor" "agents")
     local missing=()
 
     for dir in "${required_dirs[@]}"; do
@@ -191,6 +191,54 @@ install_skill() {
     fi
 
     info "Installed skill: review-code (${script_count} scripts)"
+}
+
+install_ci_monitor_skill() {
+    local src_dir="${SCRIPT_DIR}/skills/ci-monitor"
+    local dst_dir="${CLAUDE_DIR}/skills/ci-monitor"
+
+    # Create skill directory structure
+    mkdir -p "${dst_dir}/scripts/helpers"
+    mkdir -p "${dst_dir}/handlers"
+
+    # Copy SKILL.md
+    cp "${src_dir}/SKILL.md" "${dst_dir}/SKILL.md"
+
+    # Copy scripts
+    local script_count=0
+    for src in "${src_dir}/scripts/"*.sh; do
+        [[ -e "${src}" ]] || continue
+        local filename
+        filename=$(basename "${src}")
+        local dst="${dst_dir}/scripts/${filename}"
+
+        cp "${src}" "${dst}"
+        chmod +x "${dst}"
+        script_count=$((script_count + 1))
+    done
+
+    # Copy helper scripts
+    if [[ -d "${src_dir}/scripts/helpers" ]]; then
+        for src in "${src_dir}/scripts/helpers/"*.sh; do
+            [[ -e "${src}" ]] || continue
+            local filename
+            filename=$(basename "${src}")
+            local dst="${dst_dir}/scripts/helpers/${filename}"
+
+            cp "${src}" "${dst}"
+            chmod +x "${dst}"
+        done
+    fi
+
+    # Copy handlers
+    for src in "${src_dir}/handlers/"*.md; do
+        [[ -e "${src}" ]] || continue
+        local filename
+        filename=$(basename "${src}")
+        cp "${src}" "${dst_dir}/handlers/${filename}"
+    done
+
+    info "Installed skill: ci-monitor (${script_count} scripts)"
 }
 
 install_agents() {
@@ -561,6 +609,7 @@ main() {
     echo ""
     info "Installing review-code components…"
     install_skill
+    install_ci_monitor_skill
     install_agents
     install_context
 
@@ -576,10 +625,11 @@ main() {
     echo ""
     info "Installation complete!"
     echo ""
-    echo "Review-code is now ready to use:"
+    echo "Skills are now ready to use:"
     echo "  - Run: /review-code"
     echo "  - Review PR: /review-code <pr-number>"
     echo "  - Specific review: /review-code security"
+    echo "  - Monitor CI: /ci-monitor"
     echo ""
     echo "Installation locations:"
     echo "  - Skill: ${SKILL_DIR}/"

--- a/skills/ci-monitor/SKILL.md
+++ b/skills/ci-monitor/SKILL.md
@@ -1,0 +1,153 @@
+---
+description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
+argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
+allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*), Read(~/.claude/**)
+---
+
+Monitor GitHub CI checks for the current PR, wait for completion, classify failures as flaky or legit, and guide fixes for legit failures.
+
+**Arguments:**
+
+- `(no argument)` - Detect PR from current branch
+- `<pr-number>` - Monitor checks for a specific PR (e.g., `123`)
+- `<pr-url>` - Monitor checks for PR by URL (e.g., `https://github.com/org/repo/pull/123`)
+
+**Optional Flags:**
+
+- `--no-fix` - Monitor and report only; do not attempt fixes
+- `--timeout <minutes>` - Override default 30-minute timeout
+
+**Usage examples:**
+
+- `/ci-monitor` - Monitor CI for current branch's PR
+- `/ci-monitor 123` - Monitor CI for PR #123
+- `/ci-monitor --no-fix` - Monitor only, report failures without fixing
+- `/ci-monitor https://github.com/org/repo/pull/123 --timeout 45`
+
+---
+
+## Implementation
+
+**CRITICAL:** Follow these steps in order. If any step fails, inform the user and stop.
+
+### Step 1: Parse Arguments
+
+Extract the PR identifier and flags from `$ARGUMENTS`.
+
+**Flags to detect:**
+- `--no-fix` - Set `NO_FIX=true`
+- `--timeout <N>` - Set `TIMEOUT_MINUTES=N` (default: 30)
+
+Remove flags from the argument string, leaving just the PR identifier (number, URL, or empty).
+
+Run the detection script:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-detect-pr.sh $PR_IDENTIFIER 2>&1
+```
+
+Save the output as `PR_DATA`. If the `error` field is non-null, display the error and stop.
+
+Extract and save: `PR_NUMBER`, `ORG`, `REPO`, `HEAD_BRANCH`.
+
+Tell the user: "Monitoring CI checks for PR #$PR_NUMBER ($ORG/$REPO)…"
+
+Record the current time as `START_TIME` for timeout tracking.
+
+Initialize `RETRY_COUNT=0` and `MAX_RETRIES=3`.
+
+### Step 2: Check CI Status
+
+Run the status check:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-check-status.sh $PR_NUMBER "$ORG/$REPO" 2>&1
+```
+
+Save the output as `CHECK_DATA`.
+
+**Route based on status:**
+
+- If `status` is `"no_checks"`: Tell the user "No CI checks found for this PR." and stop.
+- If `all_passed` is `true`: Report "All CI checks passed!" with a summary of check counts and stop.
+- If `status` is `"in_progress"`: Go to **Step 3** (Polling Loop).
+- If `status` is `"completed"` and there are failures: Go to **Step 4** (Triage Failures).
+
+### Step 3: Polling Loop
+
+Checks are still running. Report progress:
+
+"CI checks in progress: $PASSED/$TOTAL passed, $PENDING pending. Checking again in 30 seconds…"
+
+Wait 30 seconds:
+
+```bash
+sleep 30
+```
+
+**Check timeout:** Calculate elapsed time. If elapsed exceeds `TIMEOUT_MINUTES * 60` seconds, tell the user "Timeout reached after $TIMEOUT_MINUTES minutes. $PENDING checks still pending." and show the current check status. Stop.
+
+Go back to **Step 2** to re-check status.
+
+### Step 4: Triage Failures
+
+For each failed check in the `failed_checks` array:
+
+**4a. Fetch failure logs:**
+
+If the check has a `run_id`:
+
+```bash
+~/.claude/skills/ci-monitor/scripts/ci-fetch-logs.sh $RUN_ID "$ORG/$REPO" 2>&1
+```
+
+Save as `LOG_DATA`.
+
+**4b. Classify failure:**
+
+Pass the log excerpt via stdin to the classifier:
+
+```bash
+echo "$LOG_EXCERPT" | ~/.claude/skills/ci-monitor/scripts/ci-classify-failure.sh $PR_NUMBER "$WORKFLOW_NAME" "$ORG/$REPO" 2>&1
+```
+
+Where `$LOG_EXCERPT` is the combined `log_excerpt` from all failed jobs in `LOG_DATA`, and `$WORKFLOW_NAME` is the check's `workflow` field.
+
+Save as `CLASSIFICATION`.
+
+**4c. Present findings to the user:**
+
+For each failure, report:
+- Check name and link
+- Classification: flaky / legit / uncertain
+- Confidence score
+- Reasoning (why classified this way)
+- Key log excerpt (first 20-30 relevant lines)
+
+**4d. Handle by classification:**
+
+**All flaky:** Report as flaky. Ask the user: "All failures appear to be flaky. Re-run failed workflows?" If yes, for each failed check with a `run_id`:
+
+```bash
+gh run rerun $RUN_ID --failed --repo "$ORG/$REPO"
+```
+
+Then go back to **Step 2** to monitor the re-run (this does NOT count against `RETRY_COUNT`).
+
+**All legit or mixed (with `--no-fix`):** Report the findings and stop. Do not attempt fixes.
+
+**All legit or mixed (without `--no-fix`):** Go to **Step 5**.
+
+**Uncertain classifications:** Present your own analysis of the log excerpt alongside the automated classification. Use your judgment to refine the classification before proceeding.
+
+### Step 5: Fix Cycle
+
+Check `RETRY_COUNT`: if `>= MAX_RETRIES`, tell the user "Max fix retries (${MAX_RETRIES}) reached. Please investigate manually." and stop.
+
+Load the fix handler:
+
+```
+Read ~/.claude/skills/ci-monitor/handlers/fix.md
+```
+
+Follow the instructions in the handler. After the handler completes (fix committed and pushed), increment `RETRY_COUNT` and go back to **Step 2** to monitor the new push.

--- a/skills/ci-monitor/SKILL.md
+++ b/skills/ci-monitor/SKILL.md
@@ -1,7 +1,7 @@
 ---
 description: Monitor CI checks after pushing, detect flaky vs legit failures, and auto-fix
 argument-hint: "[<pr-number>|<pr-url>|--no-fix|--timeout <min>]"
-allowed-tools: Bash(~/.claude/skills/ci-monitor/scripts/*:*), Read(~/.claude/**)
+allowed-tools: Bash(*), Read(~/.claude/**)
 ---
 
 Monitor GitHub CI checks for the current PR, wait for completion, classify failures as flaky or legit, and guide fixes for legit failures.

--- a/skills/ci-monitor/handlers/fix.md
+++ b/skills/ci-monitor/handlers/fix.md
@@ -1,0 +1,90 @@
+# Fix Handler
+
+Fix legit CI failures based on error logs, commit, and push.
+
+## Prerequisites
+
+Before this handler runs, the following variables should be available from SKILL.md:
+- `PR_NUMBER` - The PR number
+- `ORG/REPO` - The repository
+- `RETRY_COUNT` - Current fix attempt number
+- `failed_checks` - Array of legit/uncertain failures with their log data and classifications
+
+## Instructions
+
+### 1. Present Diagnosis
+
+For each legit or uncertain failure, show:
+- Check name and URL
+- Classification and confidence
+- The most relevant portion of the log excerpt (focus on the actual error, not setup/teardown output)
+- Your analysis of what went wrong
+
+### 2. Ask for Approval
+
+Use AskUserQuestion:
+- Question: "Found N legit CI failure(s). Attempt to fix?"
+- Options:
+  1. "Fix all" - Attempt to fix all legit failures
+  2. "Skip" - Report only, do not fix
+  3. "Re-run instead" - Re-run the failed workflows (treat as potentially flaky)
+
+If user selects "Skip", stop and return to SKILL.md (do not fix).
+
+If user selects "Re-run instead", re-run the workflows:
+```bash
+gh run rerun $RUN_ID --failed --repo "$ORG/$REPO"
+```
+Return to SKILL.md to re-monitor.
+
+### 3. Diagnose and Fix
+
+For each failure the user approved:
+
+**3a. Understand the error:**
+- Read the full log excerpt carefully
+- Identify the specific error message, failing test, or build error
+- Determine which file(s) are involved
+
+**3b. Read the relevant code:**
+- Read the files referenced in the error
+- Understand the context around the failing code
+
+**3c. Apply the fix:**
+- Make targeted, minimal changes to fix the specific error
+- Do not refactor or improve unrelated code
+- If the fix requires changes you are not confident about, tell the user what you think the issue is and ask for guidance instead of guessing
+
+**3d. Verify locally if possible:**
+- If you can identify the test command from the error log (e.g., `pytest`, `npm test`, `cargo test`), run the specific failing test locally
+- If local verification passes, proceed
+- If local verification fails, investigate further before committing
+- If you cannot determine how to run the test locally, skip local verification
+
+### 4. Commit and Push
+
+Stage only the files you changed:
+```bash
+git add <changed-files>
+```
+
+Commit with a descriptive message:
+```bash
+git commit -m "Fix CI: <brief description of fix>"
+```
+
+Push to the branch:
+```bash
+git push
+```
+
+### 5. Return
+
+After pushing, return control to SKILL.md. The main flow will increment `RETRY_COUNT` and go back to polling.
+
+## Safety Rules
+
+- **Never force-push.** If `git push` fails, inform the user.
+- **Never commit unrelated files.** Only stage files you explicitly changed.
+- **Never guess at fixes you are not confident about.** Ask the user instead.
+- **Never modify CI configuration files** (workflow YAML, Dockerfiles, etc.) without explicit user approval.

--- a/skills/ci-monitor/handlers/fix.md
+++ b/skills/ci-monitor/handlers/fix.md
@@ -6,7 +6,8 @@ Fix legit CI failures based on error logs, commit, and push.
 
 Before this handler runs, the following variables should be available from SKILL.md:
 - `PR_NUMBER` - The PR number
-- `ORG/REPO` - The repository
+- `ORG` - The repository owner or organization
+- `REPO` - The repository name
 - `RETRY_COUNT` - Current fix attempt number
 - `failed_checks` - Array of legit/uncertain failures with their log data and classifications
 

--- a/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/skills/ci-monitor/scripts/ci-check-status.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# ci-check-status.sh - Check CI status for a PR
+#
+# Usage:
+#   ci-check-status.sh <pr_number> [<org/repo>]
+#
+# Output: JSON with overall status, pass/fail counts, and per-check details
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+
+pr_number="${1:?Usage: ci-check-status.sh <pr_number> [<org/repo>]}"
+repo_arg="${2:-}"
+
+# Build repo flag if provided
+repo_flag=()
+if [[ -n "${repo_arg}" ]]; then
+    repo_flag=(--repo "${repo_arg}")
+fi
+
+# ── Fetch check status ──────────────────────────────────────────────────────
+
+# gh pr checks returns structured JSON with check details
+checks_json=$(gh pr checks "${pr_number}" \
+    "${repo_flag[@]}" \
+    --json name,state,bucket,link,workflow,event \
+    2> /dev/null) || {
+    ci_json_error "Could not fetch checks for PR #${pr_number}"
+    exit 0
+}
+
+# Count checks by state
+total=$(echo "${checks_json}" | jq 'length')
+
+if [[ "${total}" -eq 0 ]]; then
+    jq -n '{
+    status: "no_checks",
+    all_passed: false,
+    total: 0,
+    passed: 0,
+    failed: 0,
+    pending: 0,
+    checks: [],
+    failed_checks: []
+  }'
+    exit 0
+fi
+
+passed=$(echo "${checks_json}" | jq '[.[] | select(.bucket == "pass")] | length')
+failed=$(echo "${checks_json}" | jq '[.[] | select(.bucket == "fail")] | length')
+pending=$(echo "${checks_json}" | jq '[.[] | select(.bucket == "pending")] | length')
+
+# Determine overall status
+if [[ "${pending}" -gt 0 ]]; then
+    status="in_progress"
+elif [[ "${failed}" -gt 0 ]]; then
+    status="completed"
+else
+    status="completed"
+fi
+
+all_passed="false"
+if [[ "${failed}" -eq 0 ]] && [[ "${pending}" -eq 0 ]] && [[ "${passed}" -gt 0 ]]; then
+    all_passed="true"
+fi
+
+# ── Get run IDs for failed checks ───────────────────────────────────────────
+# We need run IDs to fetch failure logs. gh pr checks doesn't provide them,
+# so we cross-reference with gh run list.
+
+# Get the head branch for run listing
+head_branch=$(gh pr view "${pr_number}" "${repo_flag[@]}" --json headRefName -q '.headRefName' 2> /dev/null || echo "")
+
+runs_json="[]"
+if [[ -n "${head_branch}" ]] && [[ "${failed}" -gt 0 ]]; then
+    runs_json=$(gh run list \
+        --branch "${head_branch}" \
+        "${repo_flag[@]}" \
+        --limit 20 \
+        --json databaseId,status,conclusion,name,workflowName,headSha \
+        2> /dev/null) || runs_json="[]"
+fi
+
+# ── Build output ─────────────────────────────────────────────────────────────
+
+# Enrich failed checks with run IDs by matching workflow names
+enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" '
+  [.[] | . as $check |
+    {
+      name: .name,
+      state: .state,
+      bucket: .bucket,
+      workflow: .workflow.name,
+      link: .link,
+      run_id: (
+        if .bucket == "fail" then
+          ($runs | map(select(
+            (.conclusion == "failure") and
+            (.workflowName == $check.workflow.name)
+          )) | first | .databaseId // null)
+        else null end
+      )
+    }
+  ]
+')
+
+failed_checks=$(echo "${enriched_checks}" | jq '[.[] | select(.bucket == "fail")]')
+
+jq -n \
+    --arg status "${status}" \
+    --argjson all_passed "${all_passed}" \
+    --argjson total "${total}" \
+    --argjson passed "${passed}" \
+    --argjson failed "${failed}" \
+    --argjson pending "${pending}" \
+    --argjson checks "${enriched_checks}" \
+    --argjson failed_checks "${failed_checks}" \
+    '{
+    status: $status,
+    all_passed: $all_passed,
+    total: $total,
+    passed: $passed,
+    failed: $failed,
+    pending: $pending,
+    checks: $checks,
+    failed_checks: $failed_checks
+  }'

--- a/skills/ci-monitor/scripts/ci-check-status.sh
+++ b/skills/ci-monitor/scripts/ci-check-status.sh
@@ -71,8 +71,10 @@ fi
 # We need run IDs to fetch failure logs. gh pr checks doesn't provide them,
 # so we cross-reference with gh run list.
 
-# Get the head branch for run listing
-head_branch=$(gh pr view "${pr_number}" "${repo_flag[@]}" --json headRefName -q '.headRefName' 2> /dev/null || echo "")
+# Get the head branch and SHA for run listing
+pr_view_json=$(gh pr view "${pr_number}" "${repo_flag[@]}" --json headRefName,headRefOid 2> /dev/null || echo "{}")
+head_branch=$(echo "${pr_view_json}" | jq -r '.headRefName // ""')
+head_sha=$(echo "${pr_view_json}" | jq -r '.headRefOid // ""')
 
 runs_json="[]"
 if [[ -n "${head_branch}" ]] && [[ "${failed}" -gt 0 ]]; then
@@ -86,8 +88,9 @@ fi
 
 # ── Build output ─────────────────────────────────────────────────────────────
 
-# Enrich failed checks with run IDs by matching workflow names
-enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" '
+# Enrich failed checks with run IDs by matching workflow name and head SHA
+# to avoid picking up stale runs from earlier commits on the same branch
+enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" --arg head_sha "${head_sha}" '
   [.[] | . as $check |
     {
       name: .name,
@@ -99,7 +102,8 @@ enriched_checks=$(echo "${checks_json}" | jq --argjson runs "${runs_json}" '
         if .bucket == "fail" then
           ($runs | map(select(
             (.conclusion == "failure") and
-            (.workflowName == $check.workflow.name)
+            (.workflowName == $check.workflow.name) and
+            (.headSha == $head_sha)
           )) | first | .databaseId // null)
         else null end
       )

--- a/skills/ci-monitor/scripts/ci-classify-failure.sh
+++ b/skills/ci-monitor/scripts/ci-classify-failure.sh
@@ -57,7 +57,7 @@ references_changed_files="false"
 changed_file_matches=""
 
 # Get PR changed files
-changed_files=$(ci_get_pr_changed_files "${pr_number}")
+changed_files=$(ci_get_pr_changed_files "${pr_number}" "${repo_arg}")
 
 if [[ -n "${changed_files}" ]] && [[ -n "${log_excerpt}" ]]; then
     matched_files=()
@@ -70,8 +70,15 @@ if [[ -n "${changed_files}" ]] && [[ -n "${log_excerpt}" ]]; then
         # Also check just the filename (tests often reference basenames)
         basename_file=$(basename "${file}")
         if echo "${log_excerpt}" | grep -qF "${basename_file}"; then
-            # Avoid duplicates
-            if [[ ! " ${matched_files[*]:-} " =~ ${file} ]]; then
+            # Avoid duplicates using exact match (file paths contain regex metacharacters)
+            already_present="false"
+            for existing in "${matched_files[@]+"${matched_files[@]}"}"; do
+                if [[ "${existing}" == "${file}" ]]; then
+                    already_present="true"
+                    break
+                fi
+            done
+            if [[ "${already_present}" == "false" ]]; then
                 matched_files+=("${file}")
             fi
         fi

--- a/skills/ci-monitor/scripts/ci-classify-failure.sh
+++ b/skills/ci-monitor/scripts/ci-classify-failure.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# ci-classify-failure.sh - Classify a CI failure as flaky or legit
+#
+# Usage:
+#   ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]
+#
+# Reads log_excerpt from stdin.
+#
+# Output: JSON with classification (flaky/legit/uncertain), confidence, reasoning, signals
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+
+pr_number="${1:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]}"
+workflow_name="${2:?Usage: ci-classify-failure.sh <pr_number> <workflow_name> [<org/repo>]}"
+repo_arg="${3:-}"
+
+repo_flag=()
+if [[ -n "${repo_arg}" ]]; then
+    repo_flag=(--repo "${repo_arg}")
+fi
+
+# Read log excerpt from stdin
+log_excerpt=$(cat)
+
+# ── Signal 1: Does the same workflow fail on the default branch? ─────────────
+
+fails_on_main="false"
+main_reasoning=""
+
+# Get default branch
+default_branch=$(gh repo view "${repo_flag[@]}" --json defaultBranchRef -q '.defaultBranchRef.name' 2> /dev/null || echo "main")
+
+# Check recent runs on the default branch
+main_runs=$(gh run list \
+    --branch "${default_branch}" \
+    "${repo_flag[@]}" \
+    --workflow "${workflow_name}" \
+    --limit 5 \
+    --json conclusion \
+    2> /dev/null) || main_runs="[]"
+
+main_failure_count=$(echo "${main_runs}" | jq '[.[] | select(.conclusion == "failure")] | length')
+main_total=$(echo "${main_runs}" | jq 'length')
+
+if [[ "${main_failure_count}" -gt 0 ]]; then
+    fails_on_main="true"
+    main_reasoning="Workflow '${workflow_name}' has ${main_failure_count}/${main_total} recent failures on ${default_branch}"
+fi
+
+# ── Signal 2: Do error logs reference PR-changed files? ──────────────────────
+
+references_changed_files="false"
+changed_file_matches=""
+
+# Get PR changed files
+changed_files=$(ci_get_pr_changed_files "${pr_number}")
+
+if [[ -n "${changed_files}" ]] && [[ -n "${log_excerpt}" ]]; then
+    matched_files=()
+    while IFS= read -r file; do
+        [[ -z "${file}" ]] && continue
+        # Check if the file path appears in the log
+        if echo "${log_excerpt}" | grep -qF "${file}"; then
+            matched_files+=("${file}")
+        fi
+        # Also check just the filename (tests often reference basenames)
+        basename_file=$(basename "${file}")
+        if echo "${log_excerpt}" | grep -qF "${basename_file}"; then
+            # Avoid duplicates
+            if [[ ! " ${matched_files[*]:-} " =~ ${file} ]]; then
+                matched_files+=("${file}")
+            fi
+        fi
+    done <<< "${changed_files}"
+
+    if [[ ${#matched_files[@]} -gt 0 ]]; then
+        references_changed_files="true"
+        changed_file_matches=$(printf '%s, ' "${matched_files[@]}")
+        changed_file_matches="${changed_file_matches%, }"
+    fi
+fi
+
+# ── Signal 3: Known flaky patterns in logs ───────────────────────────────────
+
+known_flaky_pattern="false"
+flaky_pattern_match=""
+
+# Common flaky test indicators
+flaky_patterns=(
+    "timed out"
+    "deadline exceeded"
+    "ETIMEDOUT"
+    "ECONNRESET"
+    "ECONNREFUSED"
+    "connection refused"
+    "socket hang up"
+    "lock timeout"
+    "could not obtain lock"
+    "runner lost communication"
+    "The runner has received a shutdown signal"
+    "net/http: request canceled"
+    "context deadline exceeded"
+    "ResourceExhausted"
+    "Too many open files"
+    "no space left on device"
+)
+
+if [[ -n "${log_excerpt}" ]]; then
+    for pattern in "${flaky_patterns[@]}"; do
+        if echo "${log_excerpt}" | grep -qiF "${pattern}"; then
+            known_flaky_pattern="true"
+            flaky_pattern_match="${pattern}"
+            break
+        fi
+    done
+fi
+
+# ── Combine signals ──────────────────────────────────────────────────────────
+
+# Scoring: start at 0.5 (uncertain)
+# Flaky signals decrease score, legit signals increase
+score=50 # Using integers to avoid bash float issues
+
+if [[ "${fails_on_main}" == "true" ]]; then
+    score=$((score - 30))
+fi
+
+if [[ "${references_changed_files}" == "true" ]]; then
+    score=$((score + 30))
+fi
+
+if [[ "${known_flaky_pattern}" == "true" ]]; then
+    score=$((score - 15))
+fi
+
+# Classification thresholds
+if [[ ${score} -le 35 ]]; then
+    classification="flaky"
+elif [[ ${score} -ge 65 ]]; then
+    classification="legit"
+else
+    classification="uncertain"
+fi
+
+# Build reasoning
+reasoning=""
+if [[ "${fails_on_main}" == "true" ]]; then
+    reasoning="${main_reasoning}. "
+fi
+if [[ "${references_changed_files}" == "true" ]]; then
+    reasoning="${reasoning}Error logs reference PR-changed files: ${changed_file_matches}. "
+fi
+if [[ "${known_flaky_pattern}" == "true" ]]; then
+    reasoning="${reasoning}Log contains known flaky pattern: '${flaky_pattern_match}'. "
+fi
+if [[ -z "${reasoning}" ]]; then
+    reasoning="No strong signals detected."
+fi
+# Trim trailing space
+reasoning="${reasoning% }"
+
+# Confidence: distance from 50 (uncertain center)
+if [[ ${score} -ge 50 ]]; then
+    confidence_raw=$((score - 50))
+else
+    confidence_raw=$((50 - score))
+fi
+# Scale to 0.0-1.0 range (max distance is 50 -> 1.0)
+confidence=$(awk "BEGIN { printf \"%.2f\", 0.5 + (${confidence_raw} / 100.0) }")
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg classification "${classification}" \
+    --arg confidence "${confidence}" \
+    --arg reasoning "${reasoning}" \
+    --argjson fails_on_main "${fails_on_main}" \
+    --argjson references_changed_files "${references_changed_files}" \
+    --argjson known_flaky_pattern "${known_flaky_pattern}" \
+    --arg flaky_pattern_match "${flaky_pattern_match}" \
+    --arg changed_file_matches "${changed_file_matches}" \
+    '{
+    classification: $classification,
+    confidence: ($confidence | tonumber),
+    reasoning: $reasoning,
+    signals: {
+      fails_on_main: $fails_on_main,
+      references_changed_files: $references_changed_files,
+      known_flaky_pattern: $known_flaky_pattern,
+      flaky_pattern_match: $flaky_pattern_match,
+      changed_file_matches: $changed_file_matches
+    }
+  }'

--- a/skills/ci-monitor/scripts/ci-detect-pr.sh
+++ b/skills/ci-monitor/scripts/ci-detect-pr.sh
@@ -68,7 +68,10 @@ if [[ -n "${arg}" ]]; then
     fi
 else
     # No argument - detect from current branch
-    validate_git_repo
+    if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+        ci_json_error "Not in a git repository. Run from within a git checkout."
+        exit 0
+    fi
 
     org_repo=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
     org="${org_repo%|*}"

--- a/skills/ci-monitor/scripts/ci-detect-pr.sh
+++ b/skills/ci-monitor/scripts/ci-detect-pr.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ci-detect-pr.sh - Detect PR from current branch or argument
+#
+# Usage:
+#   ci-detect-pr.sh [<pr-number>|<pr-url>]
+#
+# When no argument is given, detects the PR from the current branch.
+#
+# Output: JSON object with pr_number, org, repo, head_branch, head_sha, error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+
+arg="${1:-}"
+
+# ── Parse argument ───────────────────────────────────────────────────────────
+
+if [[ -n "${arg}" ]]; then
+    if [[ "${arg}" =~ ^https?://[^/]+/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        # PR URL
+        org="${BASH_REMATCH[1]}"
+        repo="${BASH_REMATCH[2]}"
+        pr_number="${BASH_REMATCH[3]}"
+
+        # Normalize to lowercase
+        org=$(echo "${org}" | tr '[:upper:]' '[:lower:]')
+        repo=$(echo "${repo}" | tr '[:upper:]' '[:lower:]')
+
+        # Fetch PR metadata
+        pr_json=$(gh pr view "${pr_number}" \
+            --repo "${org}/${repo}" \
+            --json headRefName,headRefOid \
+            2> /dev/null) || {
+            ci_json_error "Could not fetch PR #${pr_number} from ${org}/${repo}"
+            exit 0
+        }
+
+        head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+        head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+
+    elif [[ "${arg}" =~ ^[0-9]+$ ]]; then
+        # PR number - infer org/repo from current directory
+        pr_number="${arg}"
+        org_repo=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
+        org="${org_repo%|*}"
+        repo="${org_repo#*|}"
+
+        if [[ "${org}" == "unknown" ]]; then
+            ci_json_error "Could not determine repository. Run from within a git checkout."
+            exit 0
+        fi
+
+        pr_json=$(gh pr view "${pr_number}" \
+            --json headRefName,headRefOid \
+            2> /dev/null) || {
+            ci_json_error "Could not fetch PR #${pr_number}"
+            exit 0
+        }
+
+        head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+        head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+    else
+        ci_json_error "Invalid argument: '${arg}'. Expected a PR number or PR URL."
+        exit 0
+    fi
+else
+    # No argument - detect from current branch
+    validate_git_repo
+
+    org_repo=$(get_git_org_repo 2> /dev/null || echo "unknown|unknown")
+    org="${org_repo%|*}"
+    repo="${org_repo#*|}"
+
+    if [[ "${org}" == "unknown" ]]; then
+        ci_json_error "Could not determine repository. Run from within a git checkout."
+        exit 0
+    fi
+
+    head_branch=$(get_current_branch)
+
+    # Try to find an associated PR
+    pr_json=$(gh pr view "${head_branch}" \
+        --json number,headRefName,headRefOid \
+        2> /dev/null) || {
+        ci_json_error "No PR found for branch '${head_branch}'. Push your branch and create a PR first, or pass a PR number."
+        exit 0
+    }
+
+    pr_number=$(echo "${pr_json}" | jq -r '.number')
+    head_branch=$(echo "${pr_json}" | jq -r '.headRefName')
+    head_sha=$(echo "${pr_json}" | jq -r '.headRefOid')
+fi
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg pr_number "${pr_number}" \
+    --arg org "${org}" \
+    --arg repo "${repo}" \
+    --arg head_branch "${head_branch}" \
+    --arg head_sha "${head_sha}" \
+    '{
+    pr_number: ($pr_number | tonumber),
+    org: $org,
+    repo: $repo,
+    head_branch: $head_branch,
+    head_sha: $head_sha,
+    error: null
+  }'

--- a/skills/ci-monitor/scripts/ci-fetch-logs.sh
+++ b/skills/ci-monitor/scripts/ci-fetch-logs.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ci-fetch-logs.sh - Fetch failure logs for a workflow run
+#
+# Usage:
+#   ci-fetch-logs.sh <run_id> [<org/repo>]
+#
+# Output: JSON with structured failure log excerpts, truncated to last N lines per job
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/ci-helpers.sh
+source "${SCRIPT_DIR}/helpers/ci-helpers.sh"
+
+run_id="${1:?Usage: ci-fetch-logs.sh <run_id> [<org/repo>]}"
+repo_arg="${2:-}"
+
+repo_flag=()
+if [[ -n "${repo_arg}" ]]; then
+    repo_flag=(--repo "${repo_arg}")
+fi
+
+# ── Fetch run metadata ──────────────────────────────────────────────────────
+
+run_json=$(gh run view "${run_id}" \
+    "${repo_flag[@]}" \
+    --json name,workflowName,conclusion,jobs \
+    2> /dev/null) || {
+    ci_json_error "Could not fetch run ${run_id}"
+    exit 0
+}
+
+workflow_name=$(echo "${run_json}" | jq -r '.workflowName // .name // "unknown"')
+
+# ── Fetch failed job logs ────────────────────────────────────────────────────
+
+# gh run view --log-failed outputs logs prefixed with job/step names
+raw_logs=$(gh run view "${run_id}" \
+    "${repo_flag[@]}" \
+    --log-failed \
+    2> /dev/null) || raw_logs=""
+
+if [[ -z "${raw_logs}" ]]; then
+    # No failed logs available - might be a non-test failure (e.g., cancelled)
+    jq -n \
+        --arg run_id "${run_id}" \
+        --arg workflow "${workflow_name}" \
+        '{
+      run_id: ($run_id | tonumber),
+      workflow: $workflow,
+      failed_jobs: [],
+      error: "No failure logs available. The run may have been cancelled or the logs expired."
+    }'
+    exit 0
+fi
+
+# Parse logs by job name (first tab-separated field)
+# Group lines by job, keep last CI_LOG_TAIL_LINES per job
+failed_jobs_json=$(echo "${raw_logs}" | awk -F'\t' -v tail_lines="${CI_LOG_TAIL_LINES}" '
+BEGIN {
+  job_count = 0
+}
+{
+  # Extract job name from first field
+  job = $1
+  # Rest is the log line (rejoin remaining fields)
+  log_line = ""
+  for (i = 2; i <= NF; i++) {
+    if (i > 2) log_line = log_line "\t"
+    log_line = log_line $i
+  }
+
+  if (!(job in seen)) {
+    seen[job] = 1
+    jobs[job_count] = job
+    job_count++
+    line_count[job] = 0
+  }
+
+  # Store lines in a circular buffer
+  idx = line_count[job] % tail_lines
+  lines[job, idx] = log_line
+  line_count[job]++
+}
+END {
+  printf "["
+  for (j = 0; j < job_count; j++) {
+    job = jobs[j]
+    count = line_count[job]
+    start = 0
+    total = count
+    if (count > tail_lines) {
+      start = count % tail_lines
+      total = tail_lines
+    }
+
+    if (j > 0) printf ","
+    printf "{\"name\":%s,\"log_excerpt\":\"", json_escape_key(job)
+
+    for (k = 0; k < total; k++) {
+      idx = (start + k) % tail_lines
+      line = lines[job, idx]
+      # Escape JSON special characters
+      gsub(/\\/, "\\\\", line)
+      gsub(/"/, "\\\"", line)
+      gsub(/\t/, "\\t", line)
+      gsub(/\r/, "", line)
+      if (k > 0) printf "\\n"
+      printf "%s", line
+    }
+    printf "\"}"
+  }
+  printf "]"
+}
+
+function json_escape_key(s) {
+  gsub(/\\/, "\\\\", s)
+  gsub(/"/, "\\\"", s)
+  return "\"" s "\""
+}
+')
+
+# ── Output ───────────────────────────────────────────────────────────────────
+
+jq -n \
+    --arg run_id "${run_id}" \
+    --arg workflow "${workflow_name}" \
+    --argjson failed_jobs "${failed_jobs_json}" \
+    '{
+    run_id: ($run_id | tonumber),
+    workflow: $workflow,
+    failed_jobs: $failed_jobs,
+    error: null
+  }'

--- a/skills/ci-monitor/scripts/helpers/ci-helpers.sh
+++ b/skills/ci-monitor/scripts/helpers/ci-helpers.sh
@@ -19,27 +19,32 @@ _REVIEW_HELPERS="${HOME}/.claude/skills/review-code/scripts/helpers"
 if [[ -f "${_REVIEW_HELPERS}/git-helpers.sh" ]]; then
     # shellcheck source=/dev/null
     source "${_REVIEW_HELPERS}/git-helpers.sh"
-elif [[ -f "${_CI_HELPER_DIR}/../../../../review-code/scripts/helpers/git-helpers.sh" ]]; then
+elif [[ -f "${_CI_HELPER_DIR}/../../../review-code/scripts/helpers/git-helpers.sh" ]]; then
     # Fallback for development (running from repo)
     # shellcheck source=/dev/null
-    source "${_CI_HELPER_DIR}/../../review-code/scripts/helpers/git-helpers.sh"
+    source "${_CI_HELPER_DIR}/../../../review-code/scripts/helpers/git-helpers.sh"
 fi
 
 if [[ -f "${_REVIEW_HELPERS}/gh-wrapper.sh" ]]; then
     # shellcheck source=/dev/null
     source "${_REVIEW_HELPERS}/gh-wrapper.sh"
-elif [[ -f "${_CI_HELPER_DIR}/../../../../review-code/scripts/helpers/gh-wrapper.sh" ]]; then
+elif [[ -f "${_CI_HELPER_DIR}/../../../review-code/scripts/helpers/gh-wrapper.sh" ]]; then
     # shellcheck source=/dev/null
-    source "${_CI_HELPER_DIR}/../../review-code/scripts/helpers/gh-wrapper.sh"
+    source "${_CI_HELPER_DIR}/../../../review-code/scripts/helpers/gh-wrapper.sh"
 fi
 
 # ── Utility Functions ────────────────────────────────────────────────────────
 
 # Get the list of files changed in a PR
-# Usage: ci_get_pr_changed_files <pr_number>
+# Usage: ci_get_pr_changed_files <pr_number> [<org/repo>]
 ci_get_pr_changed_files() {
     local pr_number="$1"
-    gh pr diff "${pr_number}" --name-only 2> /dev/null || echo ""
+    local repo="${2:-}"
+    local repo_flag=()
+    if [[ -n "${repo}" ]]; then
+        repo_flag=(--repo "${repo}")
+    fi
+    gh pr diff "${pr_number}" "${repo_flag[@]}" --name-only 2> /dev/null || echo ""
 }
 
 # JSON output helper

--- a/skills/ci-monitor/scripts/helpers/ci-helpers.sh
+++ b/skills/ci-monitor/scripts/helpers/ci-helpers.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# ci-helpers.sh - Shared constants and utilities for ci-monitor skill
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")/helpers/ci-helpers.sh"
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+CI_POLL_INTERVAL=30   # seconds between polls
+CI_TIMEOUT_MINUTES=30 # default overall timeout
+CI_MAX_FIX_RETRIES=3  # max fix-push-monitor cycles
+CI_LOG_TAIL_LINES=200 # lines of log to keep per failed job
+
+# ── Source shared helpers from review-code ───────────────────────────────────
+
+_CI_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_REVIEW_HELPERS="${HOME}/.claude/skills/review-code/scripts/helpers"
+
+if [[ -f "${_REVIEW_HELPERS}/git-helpers.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${_REVIEW_HELPERS}/git-helpers.sh"
+elif [[ -f "${_CI_HELPER_DIR}/../../../../review-code/scripts/helpers/git-helpers.sh" ]]; then
+    # Fallback for development (running from repo)
+    # shellcheck source=/dev/null
+    source "${_CI_HELPER_DIR}/../../review-code/scripts/helpers/git-helpers.sh"
+fi
+
+if [[ -f "${_REVIEW_HELPERS}/gh-wrapper.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${_REVIEW_HELPERS}/gh-wrapper.sh"
+elif [[ -f "${_CI_HELPER_DIR}/../../../../review-code/scripts/helpers/gh-wrapper.sh" ]]; then
+    # shellcheck source=/dev/null
+    source "${_CI_HELPER_DIR}/../../review-code/scripts/helpers/gh-wrapper.sh"
+fi
+
+# ── Utility Functions ────────────────────────────────────────────────────────
+
+# Get the list of files changed in a PR
+# Usage: ci_get_pr_changed_files <pr_number>
+ci_get_pr_changed_files() {
+    local pr_number="$1"
+    gh pr diff "${pr_number}" --name-only 2> /dev/null || echo ""
+}
+
+# JSON output helper
+ci_json_error() {
+    local message="$1"
+    jq -n --arg msg "${message}" '{"error": $msg}'
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -70,6 +70,13 @@ remove_skill() {
     fi
 }
 
+remove_ci_monitor_skill() {
+    if [[ -d "${CLAUDE_DIR}/skills/ci-monitor" ]]; then
+        rm -rf "${CLAUDE_DIR}/skills/ci-monitor"
+        info "Removed ci-monitor skill"
+    fi
+}
+
 remove_agents() {
     local agents=(
         "code-review-context-explorer"
@@ -166,8 +173,9 @@ main() {
     preserve_reviews
 
     # Remove components
-    info "Removing review-code components…"
+    info "Removing components…"
     remove_skill
+    remove_ci_monitor_skill
     remove_agents
 
     # Clean up any old config files


### PR DESCRIPTION
## Summary

- Adds a new `/ci-monitor` skill that monitors CI checks after pushing to GitHub, classifies failures as flaky or branch-caused, and attempts automated fixes
- Includes scripts for PR detection, CI status polling, log fetching, and failure classification
- Updates `bin/setup`, `bin/fmt`, and `uninstall.sh` to handle the new skill

## Test plan

- Run `bin/setup` and verify `~/.claude/skills/ci-monitor/` is populated with SKILL.md, handlers, and scripts
- Run `bin/fmt` and confirm ci-monitor scripts are formatted
- Run `bin/test` and verify all tests pass
- Invoke `/ci-monitor` from a repo with an open PR and verify it detects and polls CI status
- Run `uninstall.sh` and confirm the ci-monitor skill directory is removed