### PR TITLE
Fix Copilot timeout and diff whitespace parsing

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -461,7 +461,7 @@ Where `$diff` is the diff from the session data. Use `jq` to safely encode the d
 
 Save the JSON output as `$copilot_review`.
 
-**Chunked reviews:** When `is_chunked` is true, dispatch one Copilot review **per chunk** in parallel (alongside the Claude agent dispatches), up to a maximum of 5 concurrent Copilot invocations. If there are more than 5 chunks, batch the remaining chunks and dispatch them as earlier batches complete. For each chunk in the `chunks` array:
+**Chunked reviews:** When `is_chunked` is true, dispatch one Copilot review **per chunk** in parallel (alongside the Claude agent dispatches), up to a maximum of 5 concurrent Copilot invocations. If there are more than 5 chunks, use a sliding window: dispatch the next chunk as each earlier one completes, keeping up to 5 in flight at all times. For each chunk in the `chunks` array:
 
 ```bash
 jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 180 '$ARGS.named' \
@@ -472,9 +472,15 @@ Where `$chunk_diff` is the chunk's `diff` field. Save each result as `$copilot_c
 
 In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chunk.id-response.json` (raw JSON from `copilot-review.sh`) and `chunk-$chunk.id-result.md` (rendered result), so per-chunk failures and timeouts remain diagnosable.
 
-Before dispatching any chunked Copilot reviews, record a `$start_time_ms` (e.g., using `date +%s%3N`). After all chunks (including all batches) have completed, record an `$end_time_ms`. Then merge the successful results **in deterministic order**: iterate over the `chunks` in ascending `chunk.id` order (or the original `chunks` array order), and concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to `$end_time_ms - $start_time_ms` so it reflects total wall-clock time for the chunked Copilot review. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
+**Merge chunked results** after all chunks complete:
 
-Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
+1. Before dispatching, record `$start_time_ms` (e.g., `date +%s%3N`).
+2. After all chunks complete, record `$end_time_ms`.
+3. Iterate over chunks in ascending `chunk.id` order. For each chunk with a non-empty `raw_output`, prepend `## Chunk $chunk.id: $chunk.label\n` and concatenate into a single string.
+4. Build a merged `$copilot_review` object: `{ available: true, timed_out: false, raw_output: <merged>, duration_ms: $end_time_ms - $start_time_ms }`.
+5. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
+
+Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`. Also record an aggregate `copilot_review` entry with the merged `duration_ms`.
 
 **Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore that Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error. Individual chunk failures do not affect other chunks.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -446,7 +446,11 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 
 ### Copilot Cross-Model Review (Parallel)
 
-If `copilot_available` is true in the session data, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. The diff is passed directly in the prompt (not via `--add-dir`) to stay within Copilot's context window. Add this as an additional Bash tool call alongside the agent dispatches:
+If `copilot_available` is true in the session data, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. The diff is passed directly in the prompt (not via `--add-dir`) to stay within Copilot's context window.
+
+**Skip conditions:** If `copilot_available` is false or absent, skip this step entirely.
+
+**Non-chunked reviews:** Add this as an additional Bash tool call alongside the agent dispatches:
 
 ```bash
 jq -n --arg diff "$diff" --argjson timeout_seconds 180 '$ARGS.named' \
@@ -455,13 +459,24 @@ jq -n --arg diff "$diff" --argjson timeout_seconds 180 '$ARGS.named' \
 
 Where `$diff` is the diff from the session data. Use `jq` to safely encode the diff as JSON (handles newlines, quotes, and special characters).
 
-Save the JSON output as `$copilot_review`. This runs concurrently with all Claude agents and should not block or delay them.
+Save the JSON output as `$copilot_review`.
 
-**Skip conditions:** If `copilot_available` is false or absent, skip this step entirely.
+**Chunked reviews:** When `is_chunked` is true, dispatch one Copilot review **per chunk** in parallel (alongside the Claude agent dispatches), up to a maximum of 5 concurrent Copilot invocations. If there are more than 5 chunks, batch the remaining chunks and dispatch them as earlier batches complete. For each chunk in the `chunks` array:
 
-**Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore the Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error.
+```bash
+jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 180 '$ARGS.named' \
+  | ~/.claude/skills/review-code/scripts/copilot-review.sh
+```
 
-If `$copilot_review` succeeds, record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
+Where `$chunk_diff` is the chunk's `diff` field. Save each result as `$copilot_chunk_reviews[$chunk.id]`.
+
+After all complete, merge the successful results: concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to the maximum across all chunks. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
+
+Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
+
+**Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore that Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error. Individual chunk failures do not affect other chunks.
+
+If `$copilot_review` succeeds (non-chunked), record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
 
 ### Collect and Synthesize Results
 
@@ -548,7 +563,7 @@ This filter reduces noise before the expensive extended-thinking synthesis step.
 
 If `$copilot_review` exists and has `available: true`, `timed_out: false`, no `error` field, and a non-empty `raw_output`:
 
-1. **Parse Copilot's review.** Use extended thinking to extract findings from Copilot's free-form `raw_output` text. For each finding, identify: file path, line number (if present), type (blocking/suggestion/nit/question based on the severity language used), description, and a confidence estimate (your best judgment of how confident Copilot seemed).
+1. **Parse Copilot's review.** Use extended thinking to extract findings from Copilot's free-form `raw_output` text. For chunked reviews, the output contains `## Chunk N: label` headers separating each chunk's review; ignore these headers during finding extraction. For each finding, identify: file path, line number (if present), type (blocking/suggestion/nit/question based on the severity language used), description, and a confidence estimate (your best judgment of how confident Copilot seemed).
 
 2. **Apply the same scope filter** to Copilot findings: drop any that reference files not in `IN_SCOPE_PATHS`.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -470,7 +470,9 @@ jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 180 '$ARGS.named' \
 
 Where `$chunk_diff` is the chunk's `diff` field. Save each result as `$copilot_chunk_reviews[$chunk.id]`.
 
-After all complete, merge the successful results: concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to the maximum across all chunks. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
+In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chunk_id-response.json` (raw JSON from `copilot-review.sh`) and `chunk-$chunk_id-result.md` (rendered result), so per-chunk failures and timeouts remain diagnosable.
+
+After all complete, merge the successful results **in deterministic order**: iterate over the `chunks` in ascending `chunk.id` order (or the original `chunks` array order), and concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to the maximum across all chunks. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
 
 Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -470,9 +470,9 @@ jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 180 '$ARGS.named' \
 
 Where `$chunk_diff` is the chunk's `diff` field. Save each result as `$copilot_chunk_reviews[$chunk.id]`.
 
-In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chunk_id-response.json` (raw JSON from `copilot-review.sh`) and `chunk-$chunk_id-result.md` (rendered result), so per-chunk failures and timeouts remain diagnosable.
+In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chunk.id-response.json` (raw JSON from `copilot-review.sh`) and `chunk-$chunk.id-result.md` (rendered result), so per-chunk failures and timeouts remain diagnosable.
 
-After all complete, merge the successful results **in deterministic order**: iterate over the `chunks` in ascending `chunk.id` order (or the original `chunks` array order), and concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to the maximum across all chunks. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
+Before dispatching any chunked Copilot reviews, record a `$start_time_ms` (e.g., using `date +%s%3N`). After all chunks (including all batches) have completed, record an `$end_time_ms`. Then merge the successful results **in deterministic order**: iterate over the `chunks` in ascending `chunk.id` order (or the original `chunks` array order), and concatenate all non-empty `raw_output` values (prefixed with `## Chunk $chunk.id: $chunk.label\n`) into a single `$copilot_review` object with `available: true`, `timed_out: false`, the merged `raw_output`, and `duration_ms` set to `$end_time_ms - $start_time_ms` so it reflects total wall-clock time for the chunked Copilot review. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
 
 Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
 

--- a/skills/review-code/scripts/code-language-detect.sh
+++ b/skills/review-code/scripts/code-language-detect.sh
@@ -32,7 +32,7 @@ debug_save "03-language-detection" "diff-input.txt" "${diff_content}"
 # Extract file paths from diff
 # Format: +++ b/path/to/file.ext or --- a/path/to/file.ext
 # grep returns 1 if no matches (which is fine), but we want to catch real errors
-file_paths=$(echo "${diff_content}" | { grep -E "^(\+\+\+|---) [ab]/" || test $? = 1; } | sed 's/^... [ab]\///')
+file_paths=$(echo "${diff_content}" | { grep -E "^(\+\+\+|---) [ab]/" || test $? = 1; } | sed 's/^... [ab]\///; s/[[:space:]]*$//')
 
 # Detect languages from file extensions using associative arrays for O(1) lookups
 declare -A seen_languages

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -6,9 +6,9 @@
 COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-180}"
 COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-90}"
 
-# Max diff size (bytes) to send to Copilot. Diffs larger than this exceed
-# both Copilot's context window and OS argument length limits (ARG_MAX).
-COPILOT_MAX_DIFF_BYTES="${COPILOT_MAX_DIFF_BYTES:-262144}"
+# Max diff size (bytes) to send to Copilot. Larger diffs cause timeouts
+# (176KB timed out at 180s). 100KB gives headroom for prompt wrapping.
+COPILOT_MAX_DIFF_BYTES="${COPILOT_MAX_DIFF_BYTES:-102400}"
 
 # Check if Copilot CLI is installed
 # Returns: 0 if available, 1 if not

--- a/skills/review-code/scripts/pre-review-context.sh
+++ b/skills/review-code/scripts/pre-review-context.sh
@@ -34,7 +34,7 @@ diff_content=$(cat)
 
 # Extract file paths from diff
 # Format: +++ b/path/to/file.ext
-file_paths=$(echo "${diff_content}" | { grep -E "^\+\+\+ b/" || test $? = 1; } | sed 's/^+++ b\///')
+file_paths=$(echo "${diff_content}" | { grep -E "^\+\+\+ b/" || test $? = 1; } | sed 's/^+++ b\///; s/[[:space:]]*$//')
 
 # Count deleted files (diff entries where the target is /dev/null)
 deleted_file_count=$(echo "${diff_content}" | { grep -cE "^\+\+\+ /dev/null" || test $? = 1; })

--- a/tests/unit/test-code-language-detect.bats
+++ b/tests/unit/test-code-language-detect.bats
@@ -378,11 +378,13 @@ EOF
 
 @test "strips trailing whitespace from file paths in diff headers" {
     # Diff headers can have trailing tabs/spaces (e.g. from git on some platforms)
-    diff=$(printf 'diff --git a/test.py b/test.py\n+++ b/test.py\t\n--- a/test.py\t\n@@ -1,0 +1,1 @@\n+x = 1\n')
+    diff=$(printf 'diff --git a/test.py b/test.py\n--- a/test.py\t\n+++ b/test.py\t\n@@ -1,0 +1,1 @@\n+x = 1\n')
 
     result=$(echo "$diff" | "$SCRIPT")
     echo "$result" | jq -e '.languages | contains(["python"])'
     echo "$result" | jq -e '.file_extensions | contains([".py"])'
+    # Verify extensions have no trailing whitespace (the actual regression guard)
+    echo "$result" | jq -e '.file_extensions[] | test("\\s$") | not'
 }
 
 @test "performance: single-pass framework detection" {

--- a/tests/unit/test-code-language-detect.bats
+++ b/tests/unit/test-code-language-detect.bats
@@ -376,6 +376,15 @@ EOF
     echo "$result" | jq -e '.frameworks | contains(["react"]) | not'
 }
 
+@test "strips trailing whitespace from file paths in diff headers" {
+    # Diff headers can have trailing tabs/spaces (e.g. from git on some platforms)
+    diff=$(printf 'diff --git a/test.py b/test.py\n+++ b/test.py\t\n--- a/test.py\t\n@@ -1,0 +1,1 @@\n+x = 1\n')
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.languages | contains(["python"])'
+    echo "$result" | jq -e '.file_extensions | contains([".py"])'
+}
+
 @test "performance: single-pass framework detection" {
     # Verify we're using single-pass awk, not multiple greps
     # This is a meta-test that checks the implementation

--- a/tests/unit/test-pre-review-context.bats
+++ b/tests/unit/test-pre-review-context.bats
@@ -345,6 +345,15 @@ EOF
     echo "$result" | jq -e '.modified_files[0].is_infra_config == true'
 }
 
+@test "strips trailing whitespace from file paths in diff headers" {
+    # Diff headers can have trailing tabs/spaces (e.g. from git on some platforms)
+    diff=$(printf 'diff --git a/backend/api.py b/backend/api.py\n+++ b/backend/api.py\t\n@@ -1,0 +1,1 @@\n+print("hello")\n')
+
+    result=$(echo "$diff" | "$SCRIPT")
+    echo "$result" | jq -e '.file_count == 1'
+    echo "$result" | jq -e '.modified_files[0].path == "backend/api.py"'
+}
+
 @test "deleted file increments deleted_file_count and is excluded from modified_files" {
     diff=$(cat <<'EOF'
 diff --git a/backend/old_module.py b/backend/old_module.py


### PR DESCRIPTION
## Summary

- **Fix Copilot timeout on large diffs:** Lower `COPILOT_MAX_DIFF_BYTES` from 256KB to 100KB. A 176KB diff caused a full 180s timeout with empty output, so the previous limit was too generous for Copilot CLI's processing capacity.
- **Per-chunk Copilot dispatch:** In chunked reviews, send each chunk's diff to Copilot separately (in parallel, max 5 concurrent) instead of the full diff. This gives Copilot a chance to review large PRs where the full diff would exceed the byte limit.
- **Fix trailing whitespace in diff path extraction:** Add `s/[[:space:]]*$//` to sed in `pre-review-context.sh` and `code-language-detect.sh`. Git diff appends a tab to `+++ b/` lines for filenames with spaces, causing malformed JSON that breaks jq parsing.

## Test plan

- [x] All 1131 unit tests pass
- [x] All 12 integration tests pass
- [ ] Run `/review-code` on a PR with a large diff (>100KB) and verify Copilot either reviews chunks successfully or gracefully skips oversized ones
- [ ] Run `/review-code` on a PR that modifies files with spaces in their names and verify no jq parse errors