### PR TITLE
Add Copilot stderr logging and increase timeouts

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -138,9 +138,9 @@ jq -n --arg dir "$debug_session_dir" --arg content "$variable_with_content" \
 - **08-context-explorer**: Record timing (start/end). Save the explorer prompt as `prompt.md` and the result (`$architectural_context`) as `result.md`.
 - **09-per-chunk-analysis** (chunked reviews only): Record timing (start/end). For each chunk, save the prompt as `chunk-{id}-prompt.md` and result as `chunk-{id}-result.md`.
 - **10-agent-dispatch**: Record timing (start/end). For each agent (or chunk x agent combination), save the prompt as `{agent}-prompt.md` (or `chunk-{id}-{agent}-prompt.md`) and result as `{agent}-result.md` (or `chunk-{id}-{agent}-result.md`). Save stats with agent count.
-- **10b-copilot-review** (when Copilot available): Record timing (start/end). Save the raw Copilot output as `result.md` and the parsed JSON response as `response.json`.
+- **10b-copilot-review** (when Copilot available): Record timing (start/end). Save the raw Copilot output as `result.md` and the parsed JSON response as `response.json`. On timeout or error, also save `stderr.log` (from `copilot_stderr` field) and `log-path.txt` (from `copilot_log` field).
 - **11-synthesis**: Record timing (start/end). Save the merged findings as `merged-findings.md` and corroboration results as `corroboration.md`.
-- **11b-copilot-validate** (when Copilot available): For each blocking finding validated by Copilot, save the result as `validate-{N}-result.json`.
+- **11b-copilot-validate** (when Copilot available): For each blocking finding validated by Copilot, save the result as `validate-{N}-result.json`. On timeout or error, the `reasoning` field in the result includes the log path and stderr tail.
 - **12-token-usage**: After the review is complete, save stats with per-agent token usage and aggregate totals (see "Track Token Usage" below).
 
 ### Track Token Usage
@@ -453,7 +453,7 @@ If `copilot_available` is true in the session data, dispatch a Copilot review **
 **Non-chunked reviews:** Add this as an additional Bash tool call alongside the agent dispatches:
 
 ```bash
-jq -n --arg diff "$diff" --argjson timeout_seconds 180 '$ARGS.named' \
+jq -n --arg diff "$diff" --argjson timeout_seconds 300 '$ARGS.named' \
   | ~/.claude/skills/review-code/scripts/copilot-review.sh
 ```
 
@@ -464,7 +464,7 @@ Save the JSON output as `$copilot_review`.
 **Chunked reviews:** When `is_chunked` is true, dispatch one Copilot review **per chunk** in parallel (alongside the Claude agent dispatches), up to a maximum of 5 concurrent Copilot invocations. If there are more than 5 chunks, use a sliding window: dispatch the next chunk as each earlier one completes, keeping up to 5 in flight at all times. For each chunk in the `chunks` array:
 
 ```bash
-jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 180 '$ARGS.named' \
+jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 300 '$ARGS.named' \
   | ~/.claude/skills/review-code/scripts/copilot-review.sh
 ```
 
@@ -483,6 +483,8 @@ In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chu
 Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`. Also record an aggregate `copilot_review` entry with the merged `duration_ms`.
 
 **Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore that Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error. Individual chunk failures do not affect other chunks.
+
+**Copilot error logging:** When `$copilot_review` contains `timed_out: true` or an `error` field, the JSON output includes `copilot_log` (path to the full stderr log file) and `copilot_stderr` (last 20 lines of stderr). In **debug mode**, save these as debug artifacts under stage `10b-copilot-review`: save `copilot_stderr` as `stderr.log` and save the `copilot_log` path as `log-path.txt`. These logs persist in `~/.cache/review-code/copilot-logs/` regardless of debug mode, so they can be examined after the fact.
 
 If `$copilot_review` succeeds (non-chunked), record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
 
@@ -673,7 +675,7 @@ jq -n \
   --argjson line <line> \
   --arg proposed_fix "<proposed fix>" \
   --arg diff_context "<relevant diff snippet for this file>" \
-  --argjson timeout_seconds 90 \
+  --argjson timeout_seconds 150 \
   '$ARGS.named' | ~/.claude/skills/review-code/scripts/copilot-validate.sh
 ```
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -484,7 +484,7 @@ Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` wi
 
 **Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore that Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error. Individual chunk failures do not affect other chunks.
 
-**Copilot error logging:** When `$copilot_review` contains `timed_out: true` or an `error` field, the JSON output includes `copilot_log` (path to the full stderr log file) and `copilot_stderr` (last 20 lines of stderr). In **debug mode**, save these as debug artifacts under stage `10b-copilot-review`: save `copilot_stderr` as `stderr.log` and save the `copilot_log` path as `log-path.txt`. These logs persist in `~/.cache/review-code/copilot-logs/` regardless of debug mode, so they can be examined after the fact.
+**Copilot error logging:** The JSON output always includes `copilot_log` (path to the full stderr log file). When `$copilot_review` contains `timed_out: true` or an `error` field, the output also includes `copilot_stderr` (last 20 lines of stderr). In **debug mode**, save these as debug artifacts under stage `10b-copilot-review`: save `copilot_stderr` as `stderr.log` and save the `copilot_log` path as `log-path.txt`. These logs persist in `~/.cache/review-code/copilot-logs/` regardless of debug mode, so they can be examined after the fact.
 
 If `$copilot_review` succeeds (non-chunked), record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
 

--- a/skills/review-code/scripts/copilot-review.sh
+++ b/skills/review-code/scripts/copilot-review.sh
@@ -72,12 +72,16 @@ main() {
     prompt=$(build_review_prompt "${diff}")
 
     # Run copilot with timeout, passing diff in the prompt (no --add-dir)
-    local raw_output="" duration_ms=0
+    local raw_output="" duration_ms=0 log_file=""
     local run_result=0
-    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
+    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms log_file \
         -p "${prompt}" \
         --output-format json \
         --silent || run_result=$?
+
+    # Read stderr on failure for inclusion in JSON output
+    local stderr_tail=""
+    [[ "${run_result}" -ne 0 ]] && stderr_tail=$(copilot_read_stderr "${log_file}")
 
     case "${run_result}" in
         0)
@@ -86,12 +90,15 @@ main() {
             parsed_output=$(copilot_parse_final_message <<< "${raw_output}")
             copilot_json_output true false \
                 raw_output "${parsed_output}" \
+                copilot_log "${log_file}" \
                 duration_ms "${duration_ms}"
             ;;
         1)
             # Timeout
             copilot_json_output true true \
                 raw_output "" \
+                copilot_log "${log_file}" \
+                copilot_stderr "${stderr_tail}" \
                 duration_ms "${duration_ms}"
             ;;
         *)
@@ -99,6 +106,8 @@ main() {
             copilot_json_output true false \
                 raw_output "" \
                 error "copilot exited with error" \
+                copilot_log "${log_file}" \
+                copilot_stderr "${stderr_tail}" \
                 duration_ms "${duration_ms}"
             ;;
     esac

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -119,12 +119,16 @@ main() {
     prompt=$(build_validation_prompt "${finding_description}" "${file}" "${line}" "${proposed_fix}" "${diff_context}")
 
     # Run copilot with timeout, passing diff context in the prompt (no --add-dir)
-    local raw_output="" duration_ms=0
+    local raw_output="" duration_ms=0 log_file=""
     local run_result=0
-    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms \
+    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms log_file \
         -p "${prompt}" \
         --output-format json \
         --silent || run_result=$?
+
+    # Read stderr on failure for inclusion in output
+    local stderr_tail=""
+    [[ "${run_result}" -ne 0 ]] && stderr_tail=$(copilot_read_stderr "${log_file}")
 
     case "${run_result}" in
         0)
@@ -140,11 +144,11 @@ main() {
             ;;
         1)
             # Timeout
-            validate_json_output true "INCONCLUSIVE" "copilot timed out after ${timeout_secs}s" "${duration_ms}"
+            validate_json_output true "INCONCLUSIVE" "copilot timed out after ${timeout_secs}s (log: ${log_file})${stderr_tail:+ stderr: ${stderr_tail}}" "${duration_ms}"
             ;;
         *)
             # Other error
-            validate_json_output true "INCONCLUSIVE" "copilot exited with error" "${duration_ms}"
+            validate_json_output true "INCONCLUSIVE" "copilot exited with error (log: ${log_file})${stderr_tail:+ stderr: ${stderr_tail}}" "${duration_ms}"
             ;;
     esac
 }

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -33,7 +33,7 @@ current_time_ms() {
 # Clean up Copilot log files older than 7 days
 copilot_cleanup_old_logs() {
     [[ -d "${COPILOT_LOG_DIR}" ]] || return 0
-    find "${COPILOT_LOG_DIR}" -name '*.log' -mtime +7 -delete 2> /dev/null || true
+    find "${COPILOT_LOG_DIR}" -type f -name '*.log' -mtime +7 -delete 2> /dev/null || true
 }
 
 # Run copilot with a timeout, capturing output, timing, and stderr
@@ -58,7 +58,7 @@ copilot_run_with_timeout() {
         echo "=== Copilot invocation ==="
         echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
         echo "Timeout: ${timeout_secs}s"
-        echo "Args: $*"
+        echo "Args: [${#} arguments, prompt omitted]"
         echo "=== stderr ==="
     } > "${_log_file_ref}"
 

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -35,7 +35,7 @@ copilot_cleanup_old_logs() {
     [[ -d "${COPILOT_LOG_DIR}" ]] || return 0
     # Safety: skip cleanup for root or shallow directories (require 3+ path segments)
     [[ "${COPILOT_LOG_DIR%/}" == */*/* ]] || return 0
-    find "${COPILOT_LOG_DIR}" -maxdepth 1 -type f -name '*.log' -mtime +7 -delete 2> /dev/null || true
+    find "${COPILOT_LOG_DIR}" -maxdepth 1 -type f -name 'copilot-*.log' -mtime +7 -delete 2> /dev/null || true
 }
 
 # Run copilot with a timeout, capturing output, timing, and stderr
@@ -52,7 +52,7 @@ copilot_run_with_timeout() {
     mkdir -p "${COPILOT_LOG_DIR}"
     copilot_cleanup_old_logs
     local log_timestamp
-    log_timestamp=$(date +%Y%m%d-%H%M%S)
+    log_timestamp=$(date -u +%Y%m%d-%H%M%SZ)
     _log_file_ref="${COPILOT_LOG_DIR}/copilot-${log_timestamp}-$$.log"
 
     # Write log header

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -33,7 +33,9 @@ current_time_ms() {
 # Clean up Copilot log files older than 7 days
 copilot_cleanup_old_logs() {
     [[ -d "${COPILOT_LOG_DIR}" ]] || return 0
-    find "${COPILOT_LOG_DIR}" -type f -name '*.log' -mtime +7 -delete 2> /dev/null || true
+    # Safety: skip cleanup for root or shallow directories (require 3+ path segments)
+    [[ "${COPILOT_LOG_DIR%/}" == */*/* ]] || return 0
+    find "${COPILOT_LOG_DIR}" -maxdepth 1 -type f -name '*.log' -mtime +7 -delete 2> /dev/null || true
 }
 
 # Run copilot with a timeout, capturing output, timing, and stderr

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -3,12 +3,15 @@
 # Provides availability detection, timeout execution, and JSONL parsing
 
 # Timeouts (seconds)
-COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-180}"
-COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-90}"
+COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-300}"
+COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-150}"
 
 # Max diff size (bytes) to send to Copilot. Larger diffs cause timeouts
 # (176KB timed out at 180s). 100KB gives headroom for prompt wrapping.
 COPILOT_MAX_DIFF_BYTES="${COPILOT_MAX_DIFF_BYTES:-102400}"
+
+# Directory for Copilot stderr logs (persisted for post-mortem debugging)
+COPILOT_LOG_DIR="${COPILOT_LOG_DIR:-${HOME}/.cache/review-code/copilot-logs}"
 
 # Check if Copilot CLI is installed
 # Returns: 0 if available, 1 if not
@@ -27,14 +30,37 @@ current_time_ms() {
     fi
 }
 
-# Run copilot with a timeout, capturing output and timing
-# Usage: copilot_run_with_timeout <timeout_seconds> <output_var> <duration_var> <copilot_args...>
+# Clean up Copilot log files older than 7 days
+copilot_cleanup_old_logs() {
+    [[ -d "${COPILOT_LOG_DIR}" ]] || return 0
+    find "${COPILOT_LOG_DIR}" -name '*.log' -mtime +7 -delete 2> /dev/null || true
+}
+
+# Run copilot with a timeout, capturing output, timing, and stderr
+# Usage: copilot_run_with_timeout <timeout_seconds> <output_var> <duration_var> <log_file_var> <copilot_args...>
 # Sets the named variables via nameref. Returns 0 on success, 1 on timeout, 2 on error.
 copilot_run_with_timeout() {
     local timeout_secs="$1"
     local -n _output_ref="$2"
     local -n _duration_ref="$3"
-    shift 3
+    local -n _log_file_ref="$4"
+    shift 4
+
+    # Set up log directory and file
+    mkdir -p "${COPILOT_LOG_DIR}"
+    copilot_cleanup_old_logs
+    local log_timestamp
+    log_timestamp=$(date +%Y%m%d-%H%M%S)
+    _log_file_ref="${COPILOT_LOG_DIR}/copilot-${log_timestamp}-$$.log"
+
+    # Write log header
+    {
+        echo "=== Copilot invocation ==="
+        echo "Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        echo "Timeout: ${timeout_secs}s"
+        echo "Args: $*"
+        echo "=== stderr ==="
+    } > "${_log_file_ref}"
 
     local start_ms
     start_ms=$(current_time_ms)
@@ -44,17 +70,24 @@ copilot_run_with_timeout() {
 
     local exit_code=0
     if command -v gtimeout > /dev/null 2>&1; then
-        gtimeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+        gtimeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2>> "${_log_file_ref}" || exit_code=$?
     elif command -v timeout > /dev/null 2>&1; then
-        timeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+        timeout "${timeout_secs}" copilot "$@" > "${tmpfile}" 2>> "${_log_file_ref}" || exit_code=$?
     else
         # No timeout command available, run directly
-        copilot "$@" > "${tmpfile}" 2> /dev/null || exit_code=$?
+        copilot "$@" > "${tmpfile}" 2>> "${_log_file_ref}" || exit_code=$?
     fi
 
     local end_ms
     end_ms=$(current_time_ms)
     _duration_ref=$((end_ms - start_ms))
+
+    # Append exit code and duration to log
+    {
+        echo "=== result ==="
+        echo "Exit code: ${exit_code}"
+        echo "Duration: ${_duration_ref}ms"
+    } >> "${_log_file_ref}"
 
     _output_ref=$(cat "${tmpfile}")
     rm -f "${tmpfile}"
@@ -66,6 +99,16 @@ copilot_run_with_timeout() {
         return 2
     fi
     return 0
+}
+
+# Read the last N lines of stderr from a copilot log file (skipping the header)
+# Usage: copilot_read_stderr <log_file> [max_lines]
+copilot_read_stderr() {
+    local log_file="$1"
+    local max_lines="${2:-20}"
+    [[ -f "${log_file}" ]] || return 0
+    # Extract lines between "=== stderr ===" and "=== result ===" headers
+    sed -n '/^=== stderr ===/,/^=== result ===/p' "${log_file}" | sed '1d;$d' | tail -n "${max_lines}"
 }
 
 # Extract the final assistant message text from Copilot JSONL output


### PR DESCRIPTION
## Summary

- Capture Copilot stderr to timestamped log files in `~/.cache/review-code/copilot-logs/` instead of discarding to `/dev/null`, so timeouts and errors can be diagnosed after the fact
- Include `copilot_log` (file path) and `copilot_stderr` (last 20 lines) in JSON output on timeout/error
- Increase default timeouts: review 180s to 300s, validation 90s to 150s
- Auto-clean log files older than 7 days
- Surface logs as debug artifacts when debug mode is enabled

## Test plan

- [ ] Run `bin/test` (all 1155 tests pass)
- [ ] Run a review with Copilot available and verify log file is created in `~/.cache/review-code/copilot-logs/`
- [ ] Force a timeout with `COPILOT_REVIEW_TIMEOUT=5` and verify stderr is captured in JSON output
- [ ] Run with `REVIEW_CODE_DEBUG=1` and verify copilot logs appear in debug artifacts on error