### PR TITLE
Fix review-code diff scope computing wrong commit range

### DIFF
--- a/skills/review-code/scripts/get-review-diff.sh
+++ b/skills/review-code/scripts/get-review-diff.sh
@@ -78,7 +78,7 @@ if [[ "${BASH_SOURCE[0]:-}" = "${0}" ]]; then
         "branch")
             branch="$1"
             base_branch="$2"
-            run_git_diff diff "${base_branch}..${branch}" "branch (${base_branch}..${branch})" "${pattern_arg}"
+            run_git_diff diff "${base_branch}...${branch}" "branch (${base_branch}...${branch})" "${pattern_arg}"
             ;;
 
         "range")
@@ -120,7 +120,7 @@ if [[ "${BASH_SOURCE[0]:-}" = "${0}" ]]; then
             base_branch="$2"
 
             # Get branch diff using helper
-            run_git_diff diff "${base_branch}..${branch}" "branch + uncommitted (${base_branch}..${branch} + local)" "${pattern_arg}"
+            run_git_diff diff "${base_branch}...${branch}" "branch + uncommitted (${base_branch}...${branch} + local)" "${pattern_arg}"
             branch_diff="${diff_content}"
 
             # Get uncommitted diff (reuse local mode logic)

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -85,7 +85,9 @@ ref_exists() {
 # Helper: Get base branch with smart fallback
 # Prefers origin/ refs (updated by fetch) over potentially-stale local branches.
 # When origin/HEAD is unavailable, picks the closest candidate by commit distance.
+# Args: $1 (optional) = target ref for distance calculation (default: HEAD)
 get_base_branch() {
+    local target_ref="${1:-HEAD}"
     # Get the default branch name from remote origin/HEAD
     local default_branch_name
     default_branch_name=$(git symbolic-ref refs/remotes/origin/HEAD 2> /dev/null | sed 's@^refs/remotes/origin/@@')
@@ -113,7 +115,7 @@ get_base_branch() {
     for candidate in "${candidates[@]}"; do
         if ref_exists "${candidate}"; then
             local count
-            count=$(git rev-list --count "${candidate}..HEAD" 2> /dev/null) || continue
+            count=$(git rev-list --count "${candidate}..${target_ref}" 2> /dev/null) || continue
             if [[ -z "${best_count}" ]] || [[ "${count}" -lt "${best_count}" ]]; then
                 best_count="${count}"
                 best_base="${candidate}"
@@ -359,7 +361,7 @@ detect_git_ref() {
     fi
 
     local base_branch
-    base_branch=$(get_base_branch)
+    base_branch=$(get_base_branch "${arg}")
 
     # Handle non-ambiguous cases first
     if [[ "${is_branch}" == "true" ]] && [[ "${is_current}" == "false" ]]; then
@@ -404,9 +406,11 @@ detect_no_arg() {
         has_uncommitted=true
     fi
 
-    # Check if on a non-base branch
+    # Check if on a non-base branch (strip origin/ prefix for comparison since
+    # get_base_branch may return origin/master while current_branch is master)
     local is_feature_branch=false
-    if [[ "${current_branch}" != "${base_branch}" ]]; then
+    local base_branch_name="${base_branch#origin/}"
+    if [[ "${current_branch}" != "${base_branch_name}" ]]; then
         is_feature_branch=true
     fi
 

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -83,7 +83,8 @@ ref_exists() {
 }
 
 # Helper: Get base branch with smart fallback
-# Tries to use local branch first, falls back to remote tracking branch if needed
+# Prefers origin/ refs (updated by fetch) over potentially-stale local branches.
+# When origin/HEAD is unavailable, picks the closest candidate by commit distance.
 get_base_branch() {
     # Get the default branch name from remote origin/HEAD
     local default_branch_name
@@ -91,41 +92,37 @@ get_base_branch() {
 
     # If we got a default branch name, try to use it
     if [[ -n "${default_branch_name}" ]]; then
-        # First try: local branch
-        if ref_exists "${default_branch_name}"; then
-            echo "${default_branch_name}"
-            return 0
-        fi
-
-        # Second try: remote tracking branch
+        # Prefer remote tracking branch (most up-to-date via fetch)
         if ref_exists "origin/${default_branch_name}"; then
             echo "origin/${default_branch_name}"
             return 0
         fi
+
+        # Fall back to local branch
+        if ref_exists "${default_branch_name}"; then
+            echo "${default_branch_name}"
+            return 0
+        fi
     fi
 
-    # Fallback chain: try common branch names
-    # Try local "main"
-    if ref_exists "main"; then
-        echo "main"
-        return 0
-    fi
+    # origin/HEAD unavailable — pick the candidate with fewest commits to HEAD
+    # (the real base branch will have the shortest distance)
+    local candidates=("origin/main" "origin/master" "main" "master")
+    local best_base="" best_count=""
 
-    # Try remote "origin/main"
-    if ref_exists "origin/main"; then
-        echo "origin/main"
-        return 0
-    fi
+    for candidate in "${candidates[@]}"; do
+        if ref_exists "${candidate}"; then
+            local count
+            count=$(git rev-list --count "${candidate}..HEAD" 2> /dev/null) || continue
+            if [[ -z "${best_count}" ]] || [[ "${count}" -lt "${best_count}" ]]; then
+                best_count="${count}"
+                best_base="${candidate}"
+            fi
+        fi
+    done
 
-    # Try local "master"
-    if ref_exists "master"; then
-        echo "master"
-        return 0
-    fi
-
-    # Try remote "origin/master"
-    if ref_exists "origin/master"; then
-        echo "origin/master"
+    if [[ -n "${best_base}" ]]; then
+        echo "${best_base}"
         return 0
     fi
 

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -107,8 +107,8 @@ get_base_branch() {
         fi
     fi
 
-    # origin/HEAD unavailable — pick the candidate with fewest commits to HEAD
-    # (the real base branch will have the shortest distance)
+    # origin/HEAD unavailable — pick the candidate with fewest commits to target_ref
+    # (which defaults to HEAD; the real base branch will have the shortest distance)
     local candidates=("origin/main" "origin/master" "main" "master")
     local best_base="" best_count=""
 

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -823,7 +823,7 @@ build_summary() {
                     base_branch: $base_branch,
                     commit: $commit,
                     working_directory: $working_dir,
-                    comparison: "\($base_branch)..\($branch)",
+                    comparison: "\($base_branch)...\($branch)",
                     stats: {
                         commits: $commits,
                         files_changed: $files,

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -320,7 +320,14 @@ build_review_data() {
                 cm_branch=$(echo "${mode_args_json}" | jq -r '.mode_branch // ""')
                 cm_base=$(echo "${mode_args_json}" | jq -r '.mode_base_branch // ""')
                 if [[ -n "${cm_branch}" && -n "${cm_base}" ]]; then
-                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_base}..${cm_branch}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
+                    local cm_merge_base
+                    cm_merge_base=$(git merge-base "${cm_base}" "${cm_branch}" 2> /dev/null || echo "")
+                    local cm_range="${cm_merge_base:-${cm_base}}..${cm_branch}"
+                    commit_messages=$(git --no-pager log --no-color --format="%h %s%n%w(0,4,4)%b" "${cm_range}" 2> /dev/null | head -c 8192 | iconv -f UTF-8 -t UTF-8 -c || true)
+                    # Store merge-base so build_summary can reuse it
+                    if [[ -n "${cm_merge_base}" ]]; then
+                        mode_args_json=$(echo "${mode_args_json}" | jq --arg mb "${cm_merge_base}" '. + {mode_merge_base: $mb}')
+                    fi
                 fi
                 ;;
             "pr")
@@ -766,9 +773,15 @@ build_summary() {
             target_branch=$(echo "${parsed_args}" | jq -r '.mode_branch // "unknown"')
             base_branch=$(echo "${parsed_args}" | jq -r '.mode_base_branch // "unknown"')
 
-            # Count commits in branch
+            # Count commits in branch (use pre-computed merge-base for accuracy)
             local commit_count
-            commit_count=$(git rev-list --count "${base_branch}..${target_branch}" 2> /dev/null || echo "unknown")
+            local merge_base
+            merge_base=$(echo "${parsed_args}" | jq -r '.mode_merge_base // ""')
+            if [[ -n "${merge_base}" ]]; then
+                commit_count=$(git rev-list --count "${merge_base}..${target_branch}" 2> /dev/null || echo "unknown")
+            else
+                commit_count=$(git rev-list --count "${base_branch}..${target_branch}" 2> /dev/null || echo "unknown")
+            fi
 
             # Extract PR fields if context available
             local pr_number="" pr_title="" pr_url="" pr_author="" pr_state=""

--- a/tests/unit/test-get-review-diff.bats
+++ b/tests/unit/test-get-review-diff.bats
@@ -227,7 +227,7 @@ teardown_test_repo() {
     run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" branch feature main
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"DIFF_TYPE: branch (main..feature)"* ]]
+    [[ "$output" == *"DIFF_TYPE: branch (main...feature)"* ]]
     [[ "$output" == *"feature.txt"* ]]
     [[ "$output" == *"feature content"* ]]
 
@@ -354,7 +354,7 @@ teardown_test_repo() {
     run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" branch-plus-uncommitted feature main
 
     [ "$status" -eq 0 ]
-    [[ "$output" == *"DIFF_TYPE: branch + uncommitted (main..feature + local)"* ]]
+    [[ "$output" == *"DIFF_TYPE: branch + uncommitted (main...feature + local)"* ]]
     [[ "$output" == *"file2.txt"* ]]  # Branch changes
     [[ "$output" == *"file3.txt"* ]]  # Uncommitted changes
     [[ "$output" == *"Uncommitted Changes"* ]]

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -751,3 +751,85 @@ reset_globals() {
     [ "$APPEND_MODE" = "true" ]
     [ "$arg" = "123" ]
 }
+
+# =============================================================================
+# get_base_branch tests
+# =============================================================================
+
+@test "get_base_branch: prefers origin/ ref when origin/HEAD is set" {
+    setup_test_git_repo
+
+    # Set origin/HEAD to point to main
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    # Create origin/main ref (fake remote tracking branch)
+    git update-ref refs/remotes/origin/main HEAD
+
+    run get_base_branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/main" ]
+}
+
+@test "get_base_branch: uses closest-candidate fallback when origin/HEAD branch missing" {
+    setup_test_git_repo
+
+    # origin/HEAD points to a branch that doesn't exist as a remote ref
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/nonexistent 2>/dev/null || true
+    git update-ref -d refs/remotes/origin/main 2>/dev/null || true
+
+    # Falls through to closest-candidate logic; "main" is the only local candidate
+    run get_base_branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "get_base_branch: picks closest candidate when origin/HEAD not set" {
+    setup_test_git_repo
+
+    # Remove origin/HEAD
+    git symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+
+    # Create a feature branch with one commit ahead of main
+    git checkout -q -b feature
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "Feature commit"
+
+    # Create a "master" branch that's far behind
+    git branch master HEAD~1 2>/dev/null || true
+
+    # Both main and master are 1 commit away; "main" wins by iteration order
+    run get_base_branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "get_base_branch: prefers closer base over farther one" {
+    setup_test_git_repo
+
+    # Remove origin/HEAD so fallback logic kicks in
+    git symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+
+    # Make several commits on main
+    for i in 1 2 3 4 5; do
+        echo "commit $i" > "file$i.txt"
+        git add "file$i.txt"
+        git commit -q -m "Main commit $i"
+    done
+
+    # Create master pointing at current HEAD (latest)
+    git branch master HEAD
+
+    # Create feature branch with one more commit
+    git checkout -q -b feature
+    echo "feature" > feature.txt
+    git add feature.txt
+    git commit -q -m "Feature commit"
+
+    # Reset main to root commit so it's far (6 commits away); master stays at HEAD~1 (1 away)
+    local initial_commit
+    initial_commit=$(git rev-list --max-parents=0 HEAD)
+    git branch -f main "$initial_commit"
+    run get_base_branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "master" ]
+}

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -794,7 +794,7 @@ reset_globals() {
     git add feature.txt
     git commit -q -m "Feature commit"
 
-    # Create a "master" branch that's far behind
+    # Create a "master" branch that's one commit behind
     git branch master HEAD~1 2>/dev/null || true
 
     # Both main and master are 1 commit away; "main" wins by iteration order


### PR DESCRIPTION
## Summary

- Fix `get_base_branch()` to prefer `origin/` refs (updated by fetch) over potentially-stale local branches, and use commit distance to pick the closest candidate when `origin/HEAD` is unavailable
- Switch branch diff from two-dot (`base..branch`) to three-dot (`base...branch`) syntax so only branch changes are shown, even when the base has diverged
- Use `git merge-base` for commit counting and log ranges; compute once and pass via `mode_args_json` to eliminate duplicate calls

## Context

When running `/review-code --force` on a branch with only 1 commit vs master, the orchestrator reported 9 commits and 57 files. Root causes: wrong base branch selection when `origin/HEAD` is not set (fallback picked `main` before `master`), two-dot diff comparing tree snapshots directly (including reverse changes from base), and commit count not anchored to the merge-base.

## Test plan

- [x] All 1159 unit tests pass
- [x] All 12 integration tests pass
- [x] `bin/fmt` produces no changes
- [ ] Run `/review-code --force` on a branch with a single commit and verify the summary shows 1 commit and only that commit's files