### PR TITLE
Replace Copilot full review with lightweight meta-review

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -526,7 +526,7 @@ This filter reduces noise before the expensive extended-thinking synthesis step.
 
 Synthesize the remaining findings using extended thinking into a coherent, deduplicated review document. Apply confidence-based filtering and cross-agent corroboration before producing the final output.
 
-**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function.
+**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Cross-model corroboration (a Copilot meta-review `CONFIRMED` verdict) also counts as corroboration even if only one Claude agent flagged the issue.
 
 **Filtering rules:**
 - **Corroborated (2+ agents or chunks):** Keep even if individual confidence is below 40%. Note as corroborated in the review.

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -138,9 +138,8 @@ jq -n --arg dir "$debug_session_dir" --arg content "$variable_with_content" \
 - **08-context-explorer**: Record timing (start/end). Save the explorer prompt as `prompt.md` and the result (`$architectural_context`) as `result.md`.
 - **09-per-chunk-analysis** (chunked reviews only): Record timing (start/end). For each chunk, save the prompt as `chunk-{id}-prompt.md` and result as `chunk-{id}-result.md`.
 - **10-agent-dispatch**: Record timing (start/end). For each agent (or chunk x agent combination), save the prompt as `{agent}-prompt.md` (or `chunk-{id}-{agent}-prompt.md`) and result as `{agent}-result.md` (or `chunk-{id}-{agent}-result.md`). Save stats with agent count.
-- **10b-copilot-review** (when Copilot available): Record timing (start/end). Save the raw Copilot output as `result.md` and the parsed JSON response as `response.json`. On timeout or error, also save `stderr.log` (from `copilot_stderr` field) and `log-path.txt` (from `copilot_log` field).
 - **11-synthesis**: Record timing (start/end). Save the merged findings as `merged-findings.md` and corroboration results as `corroboration.md`.
-- **11b-copilot-validate** (when Copilot available): For each blocking finding validated by Copilot, save the result as `validate-{N}-result.json`. On timeout or error, the `reasoning` field in the result includes the log path and stderr tail.
+- **11b-copilot-meta-review** (when Copilot available): Record timing (start/end). Save the input payload as `input.json`, the raw Copilot output as `raw-output.md`, and the parsed JSON response as `response.json`. On timeout or error, also save `stderr.log` (from `copilot_stderr` field) and `log-path.txt` (from `copilot_log` field).
 - **12-token-usage**: After the review is complete, save stats with per-agent token usage and aggregate totals (see "Track Token Usage" below).
 
 ### Track Token Usage
@@ -444,50 +443,6 @@ IMPORTANT: Build upon the previous review. Do not duplicate findings. You may:
 - Update status if code changed
 - Mark findings as resolved if fixed
 
-### Copilot Cross-Model Review (Parallel)
-
-If `copilot_available` is true in the session data, dispatch a Copilot review **in parallel** with the Claude agent Task tool calls above. The diff is passed directly in the prompt (not via `--add-dir`) to stay within Copilot's context window.
-
-**Skip conditions:** If `copilot_available` is false or absent, skip this step entirely.
-
-**Non-chunked reviews:** Add this as an additional Bash tool call alongside the agent dispatches:
-
-```bash
-jq -n --arg diff "$diff" --argjson timeout_seconds 300 '$ARGS.named' \
-  | ~/.claude/skills/review-code/scripts/copilot-review.sh
-```
-
-Where `$diff` is the diff from the session data. Use `jq` to safely encode the diff as JSON (handles newlines, quotes, and special characters).
-
-Save the JSON output as `$copilot_review`.
-
-**Chunked reviews:** When `is_chunked` is true, dispatch one Copilot review **per chunk** in parallel (alongside the Claude agent dispatches), up to a maximum of 5 concurrent Copilot invocations. If there are more than 5 chunks, use a sliding window: dispatch the next chunk as each earlier one completes, keeping up to 5 in flight at all times. For each chunk in the `chunks` array:
-
-```bash
-jq -n --arg diff "$chunk_diff" --argjson timeout_seconds 300 '$ARGS.named' \
-  | ~/.claude/skills/review-code/scripts/copilot-review.sh
-```
-
-Where `$chunk_diff` is the chunk's `diff` field. Save each result as `$copilot_chunk_reviews[$chunk.id]`.
-
-In **debug mode**, also persist each chunk's raw response to disk as `chunk-$chunk.id-response.json` (raw JSON from `copilot-review.sh`) and `chunk-$chunk.id-result.md` (rendered result), so per-chunk failures and timeouts remain diagnosable.
-
-**Merge chunked results** after all chunks complete:
-
-1. Before dispatching, record `$start_time_ms` (e.g., `date +%s%3N`).
-2. After all chunks complete, record `$end_time_ms`.
-3. Iterate over chunks in ascending `chunk.id` order. For each chunk with a non-empty `raw_output`, prepend `## Chunk $chunk.id: $chunk.label\n` and concatenate into a single string.
-4. Build a merged `$copilot_review` object: `{ available: true, timed_out: false, raw_output: <merged>, duration_ms: $end_time_ms - $start_time_ms }`.
-5. If **all** chunks failed (timed out, errored, or were skipped), treat it as if Copilot returned no results.
-
-Record token usage per chunk as `copilot-review-chunk-{id}` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`. Also record an aggregate `copilot_review` entry with the merged `duration_ms`.
-
-**Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore that Copilot result and continue with Claude-only review. Never fail or stop the review because of a Copilot error. Individual chunk failures do not affect other chunks.
-
-**Copilot error logging:** The JSON output always includes `copilot_log` (path to the full stderr log file). When `$copilot_review` contains `timed_out: true` or an `error` field, the output also includes `copilot_stderr` (last 20 lines of stderr). In **debug mode**, save these as debug artifacts under stage `10b-copilot-review`: save `copilot_stderr` as `stderr.log` and save the `copilot_log` path as `log-path.txt`. These logs persist in `~/.cache/review-code/copilot-logs/` regardless of debug mode, so they can be examined after the fact.
-
-If `$copilot_review` succeeds (non-chunked), record `copilot_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
-
 ### Collect and Synthesize Results
 
 After all review agents complete, extract usage metadata from each agent's response and record in `$token_usage` keyed by agent type (e.g., `$token_usage["code-reviewer-security"]`). For chunked reviews, key by `chunk-{id}-{agent-type}`.
@@ -569,28 +524,9 @@ After all agent results are collected (including all chunks in chunked mode), ap
 
 This filter reduces noise before the expensive extended-thinking synthesis step. Line-level precision is handled later by the "Validate Findings Against the Diff" step.
 
-**Merge Copilot Findings**
-
-If `$copilot_review` exists and has `available: true`, `timed_out: false`, no `error` field, and a non-empty `raw_output`:
-
-1. **Parse Copilot's review.** Use extended thinking to extract findings from Copilot's free-form `raw_output` text. For chunked reviews, the output contains `## Chunk N: label` headers separating each chunk's review; ignore these headers during finding extraction. For each finding, identify: file path, line number (if present), type (blocking/suggestion/nit/question based on the severity language used), description, and a confidence estimate (your best judgment of how confident Copilot seemed).
-
-2. **Apply the same scope filter** to Copilot findings: drop any that reference files not in `IN_SCOPE_PATHS`.
-
-3. **Match against Claude findings.** For each surviving Copilot finding, check if a Claude finding references the same file within 10 lines and addresses the same logical concern. If matched:
-   - Mark the Claude finding as **cross-model corroborated**.
-   - Boost its confidence by 15 percentage points (capped at 95%).
-   - Append note: "*(corroborated by Copilot)*"
-
-4. **Add unmatched Copilot findings.** For Copilot findings that don't match any Claude finding, add them to the finding pool with `agent: "copilot"` and a note: "*(flagged by external model)*". These are subject to the same filtering thresholds as Claude findings.
-
-5. **Corroboration rule update:** Cross-model corroboration (any Claude agent + Copilot) counts as corroboration even if only one Claude agent flagged the issue. Different-model agreement is at least as strong as same-model multi-agent agreement.
-
-If `$copilot_review` is absent, unavailable, timed out, or errored, skip this section and proceed with Claude-only findings.
-
 Synthesize the remaining findings using extended thinking into a coherent, deduplicated review document. Apply confidence-based filtering and cross-agent corroboration before producing the final output.
 
-**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Cross-model corroboration (Claude + Copilot) also counts as corroboration.
+**Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function.
 
 **Filtering rules:**
 - **Corroborated (2+ agents or chunks):** Keep even if individual confidence is below 40%. Note as corroborated in the review.
@@ -664,36 +600,50 @@ Where `targets` contains `{"path": "<file>", "line": <number>}` objects, and `di
 
 - **Otherwise** (non-blocking findings): Use the Read tool to verify the claim is accurate before including it.
 
-### Copilot Cross-Model Validation (Parallel)
+### Copilot Meta-Review
 
-If `copilot_available` is true in the session data, also validate each blocking finding with Copilot **in parallel with** the Claude finding-validator dispatches above. For each blocking finding, extract the relevant diff snippet for the finding's file (the hunk(s) containing the finding's line) and dispatch a Bash tool call:
+If `copilot_available` is true in the session data, run a Copilot meta-review after Claude findings have been synthesized and validated. This gives Copilot a focused task: validate Claude's findings and scan the diff for anything glaringly obvious that was missed.
+
+**Skip conditions:** If `copilot_available` is false or absent, skip this step entirely.
+
+**Build the findings payload.** Collect all findings that survived synthesis and validation into a JSON array. For each finding, include: a sequential `id` (starting at 1), `agent` (source agent name), `type` (blocking/suggestion/nit/question), `file`, `line`, `description`, `proposed_fix` (if any), and `confidence`.
+
+**Dispatch the meta-review:**
 
 ```bash
 jq -n \
-  --arg finding_description "<finding description>" \
-  --arg file "<file>" \
-  --argjson line <line> \
-  --arg proposed_fix "<proposed fix>" \
-  --arg diff_context "<relevant diff snippet for this file>" \
-  --argjson timeout_seconds 150 \
-  '$ARGS.named' | ~/.claude/skills/review-code/scripts/copilot-validate.sh
+  --argjson findings '<findings JSON array>' \
+  --arg diff "$diff" \
+  --argjson timeout_seconds 120 \
+  '$ARGS.named' | ~/.claude/skills/review-code/scripts/copilot-meta-review.sh
 ```
 
-Where `diff_context` is the portion of the diff relevant to this finding's file and surrounding hunks. This keeps the prompt small and focused for Copilot's context window.
+Where `$diff` is the full diff from session data and `<findings JSON array>` is the JSON array of surviving findings. Use `jq` to safely encode both as JSON.
 
-Save each result as `$copilot_validate_N`. Record in `$token_usage` as `copilot-validate-{N}` with `{ total_tokens: 0, tool_uses: 0, duration_ms }`.
+Save the JSON output as `$copilot_meta_review`.
 
-**Combine Claude validator and Copilot validator verdicts:**
+In **debug mode**, save debug artifacts under stage `11b-copilot-meta-review`: save the input payload as `input.json`, the raw Copilot output as `raw-output.md`, and the parsed response as `response.json`. On timeout or error, also save `stderr.log` and `log-path.txt`.
 
-| Claude Validator | Copilot Validator | Action |
-|---|---|---|
-| CONFIRMED | CONFIRMED | Keep as `blocking:`. Append: "*(confirmed by adversarial review and cross-model validation)*" |
-| CONFIRMED | DISMISSED | Keep as `blocking:`. Append Copilot's counter-argument as context: "*(Note: alternative model disagreed: [copilot reasoning])*" |
-| DISMISSED | CONFIRMED | Keep as `suggestion:` (downgraded from blocking). Append: "*(Downgraded from blocking, but alternative model flagged as real: [copilot reasoning])*" |
-| DISMISSED | DISMISSED | Downgrade to `suggestion:` with strong confidence that this is not blocking. |
-| Any | INCONCLUSIVE | Ignore Copilot result. Use Claude validator verdict only. |
+**Integrate meta-review results:**
 
-**Skip conditions:** If `copilot_available` is false or absent, skip Copilot validation entirely and use Claude validator results only.
+If `$copilot_meta_review` has `available: true`, `timed_out: false`, and no `error` field:
+
+1. **Process validations.** For each entry in `validations`:
+   - **CONFIRMED**: Mark the matching finding as cross-model corroborated. Boost confidence by 15 percentage points (capped at 95%). Append note: "*(corroborated by Copilot)*"
+   - **DISMISSED**: If the finding is `blocking:`, downgrade to `suggestion:`. Append Copilot's reasoning: "*(Copilot disagreed: [reasoning])*". Do NOT remove the finding entirely; Claude's analysis takes precedence, but the dissent is noted.
+   - **ADJUSTED**: Keep the finding but incorporate Copilot's reasoning as additional context. Append: "*(Copilot note: [reasoning])*"
+   - If a `finding_id` does not match any surviving finding, ignore it silently.
+
+2. **Process missed issues.** For each entry in `missed_issues`:
+   - Apply the same scope filter: drop any that reference files not in `IN_SCOPE_PATHS`.
+   - For surviving missed issues, add them to the finding pool with `agent: "copilot"`, the type from the meta-review output, and a note: "*(flagged by Copilot during meta-review)*".
+   - These are subject to the same filtering thresholds as Claude findings. Since they come from a single source (Copilot), they are solo findings and need confidence >= 40% to be included (unless they are questions/nits). Assign a default confidence of 50% to Copilot missed issues.
+
+3. **Corroboration rule.** Cross-model corroboration (Claude + Copilot CONFIRMED) counts as corroboration even if only one Claude agent flagged the issue.
+
+**Error handling:** If the script returns `available: false`, `timed_out: true`, or contains an `error` field, ignore the meta-review result and continue with Claude-only findings. Never fail or stop the review because of a Copilot error.
+
+Record `copilot_meta_review` in `$token_usage` with `{ total_tokens: 0, tool_uses: 0, duration_ms }` using the `duration_ms` value from the output.
 
 ### Compose the Review Document
 

--- a/skills/review-code/scripts/copilot-meta-review.sh
+++ b/skills/review-code/scripts/copilot-meta-review.sh
@@ -83,9 +83,9 @@ parse_structured_response() {
     local json_text
 
     # Try raw JSON, then markdown-fenced JSON, then the full text
-    json_text=$(printf '%s' "${text}" | sed -n '/^[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p' | head -100)
+    json_text=$(printf '%s' "${text}" | sed -n '/^[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p')
     if [[ -z "${json_text}" ]]; then
-        json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d' | head -100)
+        json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d')
     fi
     if [[ -z "${json_text}" ]]; then
         json_text="${text}"
@@ -108,11 +108,11 @@ parse_freeform_fallback() {
     for fid in ${finding_ids}; do
         local verdict_line
         # Match patterns: "#1: CONFIRMED", "Finding 1: DISMISSED", "1. CONFIRMED"
-        verdict_line=$(printf '%s' "${text}" | grep -iE "(#${fid}|finding ${fid}|^${fid}[.):]).*\b(CONFIRMED|DISMISSED|ADJUSTED)\b" | head -1)
+        verdict_line=$(printf '%s' "${text}" | grep -iE "(#${fid}|finding ${fid}|^${fid}[.):])" | grep -iwE "CONFIRMED|DISMISSED|ADJUSTED" | head -1)
 
         if [[ -n "${verdict_line}" ]]; then
             local verdict
-            verdict=$(printf '%s' "${verdict_line}" | grep -ioE '\b(CONFIRMED|DISMISSED|ADJUSTED)\b' | head -1 | tr '[:lower:]' '[:upper:]')
+            verdict=$(printf '%s' "${verdict_line}" | grep -iowE 'CONFIRMED|DISMISSED|ADJUSTED' | head -1 | tr '[:lower:]' '[:upper:]')
             local reasoning
             reasoning=$(printf '%s' "${verdict_line}" | sed "s/.*${verdict}[[:space:]]*//" | sed 's/^[[:space:]-]*//')
 
@@ -181,9 +181,13 @@ main() {
         return 0
     fi
 
-    # Clear diff if it exceeds Copilot's practical limits
-    if [[ -n "${diff}" ]] && [[ "${#diff}" -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
-        diff=""
+    # Clear diff if it exceeds Copilot's practical limits (byte count, not char count)
+    if [[ -n "${diff}" ]]; then
+        local diff_bytes
+        diff_bytes=$(printf '%s' "${diff}" | LC_ALL=C wc -c | tr -d '[:space:]')
+        if [[ "${diff_bytes}" -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
+            diff=""
+        fi
     fi
 
     local findings_text
@@ -219,6 +223,7 @@ main() {
             meta_review_json_output true false \
                 validations "${validations}" \
                 missed_issues "${missed_issues}" \
+                raw_output "${parsed_text}" \
                 copilot_log "${log_file}" \
                 duration_ms "${duration_ms}"
             ;;

--- a/skills/review-code/scripts/copilot-meta-review.sh
+++ b/skills/review-code/scripts/copilot-meta-review.sh
@@ -82,19 +82,20 @@ parse_structured_response() {
     local text="$1"
     local json_text
 
-    # Try raw JSON, then markdown-fenced JSON, then the full text
-    json_text=$(printf '%s' "${text}" | sed -n '/^[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p')
-    if [[ -z "${json_text}" ]]; then
-        json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d')
-    fi
-    if [[ -z "${json_text}" ]]; then
-        json_text="${text}"
+    # Try full text first so nested pretty-printed JSON is preserved
+    if printf '%s' "${text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
+        printf '%s' "${text}"
+        return 0
     fi
 
-    if printf '%s' "${json_text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
+    # If wrapped in markdown fences, strip them and try again
+    local json_text
+    json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d')
+    if [[ -n "${json_text}" ]] && printf '%s' "${json_text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
         printf '%s' "${json_text}"
         return 0
     fi
+
     return 1
 }
 

--- a/skills/review-code/scripts/copilot-meta-review.sh
+++ b/skills/review-code/scripts/copilot-meta-review.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# copilot-meta-review.sh - Use Copilot CLI to validate review findings and do a cursory code scan
+#
+# Usage:
+#   echo '{"findings": [...], "diff": "<diff text>", "timeout_seconds": 120}' | copilot-meta-review.sh
+#
+# Input (stdin): JSON with findings array (required), diff (optional), and optional timeout_seconds
+# Output (stdout): JSON with available, timed_out, validations, missed_issues, duration_ms
+#
+# Replaces the previous parallel copilot-review.sh approach (which always timed out)
+# with a lighter meta-review: validate Claude's findings + cursory scan for obvious misses.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/copilot-helpers.sh
+source "${SCRIPT_DIR}/helpers/copilot-helpers.sh"
+
+build_meta_review_prompt() {
+    local findings_text="$1"
+    local diff="$2"
+
+    cat << PROMPT
+You are a skeptical senior engineer performing a meta-review. You have two tasks:
+
+## Task 1: Validate Existing Findings
+
+For each finding below, try to DISPROVE it. Your default posture is that the finding is wrong until proven otherwise. Consider:
+- Is it based on a misreading of the code?
+- Does the code handle this case correctly through a path the reviewer missed?
+- Is there a guard, check, middleware, or framework feature that prevents the issue?
+- Is the scenario purely theoretical with no realistic trigger?
+- Does the proposed fix introduce its own problems?
+
+**Findings:**
+${findings_text}
+PROMPT
+
+    if [[ -n "${diff}" ]]; then
+        cat << PROMPT
+
+## Task 2: Cursory Scan for Missed Issues
+
+Scan the diff for anything glaringly obvious that was NOT covered by the findings above. Focus only on:
+- Security vulnerabilities (injection, auth bypass, secrets)
+- Crash-causing bugs (null deref, out-of-bounds, unhandled errors)
+- Data loss or corruption risks
+
+Do NOT flag style issues, naming, or minor suggestions. Only flag things a senior engineer would consider obviously wrong.
+
+\`\`\`diff
+${diff}
+\`\`\`
+PROMPT
+    fi
+
+    cat << 'PROMPT'
+
+## Response Format
+
+Respond with valid JSON only. No markdown fencing, no preamble, no explanation outside the JSON:
+
+{
+  "validations": [
+    {"finding_id": <number>, "verdict": "CONFIRMED|DISMISSED|ADJUSTED", "reasoning": "<concrete explanation citing code>"}
+  ],
+  "missed_issues": [
+    {"file": "<path>", "line": <number>, "type": "blocking|suggestion", "description": "<what is wrong and why>"}
+  ]
+}
+
+If all findings are valid and nothing was missed, return empty arrays.
+PROMPT
+}
+
+format_findings_for_prompt() {
+    local findings_json="$1"
+    jq -r '.[] | "#\(.id) [\(.type)] \(.file):\(.line) (confidence: \(.confidence)%)\n  Agent: \(.agent)\n  Description: \(.description)\n  Proposed fix: \(.proposed_fix // "none")\n"' <<< "${findings_json}"
+}
+
+parse_structured_response() {
+    local text="$1"
+    local json_text
+
+    # Try raw JSON, then markdown-fenced JSON, then the full text
+    json_text=$(printf '%s' "${text}" | sed -n '/^[[:space:]]*{/,/^[[:space:]]*}[[:space:]]*$/p' | head -100)
+    if [[ -z "${json_text}" ]]; then
+        json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d' | head -100)
+    fi
+    if [[ -z "${json_text}" ]]; then
+        json_text="${text}"
+    fi
+
+    if printf '%s' "${json_text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
+        printf '%s' "${json_text}"
+        return 0
+    fi
+    return 1
+}
+
+parse_freeform_fallback() {
+    local text="$1"
+    local findings_json="$2"
+    local validations="[]"
+    local finding_ids
+    finding_ids=$(jq -r '.[].id' <<< "${findings_json}")
+
+    for fid in ${finding_ids}; do
+        local verdict_line
+        # Match patterns: "#1: CONFIRMED", "Finding 1: DISMISSED", "1. CONFIRMED"
+        verdict_line=$(printf '%s' "${text}" | grep -iE "(#${fid}|finding ${fid}|^${fid}[.):]).*\b(CONFIRMED|DISMISSED|ADJUSTED)\b" | head -1)
+
+        if [[ -n "${verdict_line}" ]]; then
+            local verdict
+            verdict=$(printf '%s' "${verdict_line}" | grep -ioE '\b(CONFIRMED|DISMISSED|ADJUSTED)\b' | head -1 | tr '[:lower:]' '[:upper:]')
+            local reasoning
+            reasoning=$(printf '%s' "${verdict_line}" | sed "s/.*${verdict}[[:space:]]*//" | sed 's/^[[:space:]-]*//')
+
+            validations=$(jq --argjson fid "${fid}" --arg verdict "${verdict}" --arg reasoning "${reasoning}" \
+                '. + [{"finding_id": $fid, "verdict": $verdict, "reasoning": $reasoning}]' <<< "${validations}")
+        fi
+    done
+
+    jq -n --argjson validations "${validations}" \
+        '{"validations": $validations, "missed_issues": []}'
+}
+
+meta_review_json_output() {
+    local available="$1"
+    local timed_out="$2"
+    shift 2
+
+    local jq_args=(
+        --argjson available "${available}"
+        --argjson timed_out "${timed_out}"
+    )
+    local has_validations=false has_missed=false
+
+    while [[ $# -ge 2 ]]; do
+        local key="$1" value="$2"
+        shift 2
+        case "${key}" in
+            validations)
+                jq_args+=(--argjson validations "${value}")
+                has_validations=true
+                ;;
+            missed_issues)
+                jq_args+=(--argjson missed_issues "${value}")
+                has_missed=true
+                ;;
+            duration_ms) jq_args+=(--argjson duration_ms "${value}") ;;
+            *) jq_args+=(--arg "${key}" "${value}") ;;
+        esac
+    done
+
+    [[ "${has_validations}" == "false" ]] && jq_args+=(--argjson validations '[]')
+    [[ "${has_missed}" == "false" ]] && jq_args+=(--argjson missed_issues '[]')
+
+    jq -n "${jq_args[@]}" '$ARGS.named'
+}
+
+main() {
+    if ! copilot_available; then
+        meta_review_json_output false false duration_ms 0
+        return 0
+    fi
+
+    # Single jq call to extract all input fields
+    local input parsed_fields findings_json diff timeout_secs
+    input=$(cat)
+    parsed_fields=$(jq -r --arg default_timeout "${COPILOT_META_REVIEW_TIMEOUT}" \
+        '[(.findings // []), (.diff // ""), (.timeout_seconds // ($default_timeout | tonumber))] | @json' <<< "${input}")
+    findings_json=$(jq -r '.[0]' <<< "${parsed_fields}")
+    diff=$(jq -r '.[1]' <<< "${parsed_fields}")
+    timeout_secs=$(jq -r '.[2]' <<< "${parsed_fields}")
+
+    local findings_count
+    findings_count=$(jq 'length' <<< "${findings_json}")
+    if [[ "${findings_count}" -eq 0 ]]; then
+        meta_review_json_output true false duration_ms 0
+        return 0
+    fi
+
+    # Clear diff if it exceeds Copilot's practical limits
+    if [[ -n "${diff}" ]] && [[ "${#diff}" -gt ${COPILOT_MAX_DIFF_BYTES} ]]; then
+        diff=""
+    fi
+
+    local findings_text
+    findings_text=$(format_findings_for_prompt "${findings_json}")
+    local prompt
+    prompt=$(build_meta_review_prompt "${findings_text}" "${diff}")
+
+    local raw_output="" duration_ms=0 log_file=""
+    local run_result=0
+    copilot_run_with_timeout "${timeout_secs}" raw_output duration_ms log_file \
+        -p "${prompt}" \
+        --output-format json \
+        --silent || run_result=$?
+
+    local stderr_tail=""
+    [[ "${run_result}" -ne 0 ]] && stderr_tail=$(copilot_read_stderr "${log_file}")
+
+    case "${run_result}" in
+        0)
+            local parsed_text
+            parsed_text=$(copilot_parse_final_message <<< "${raw_output}")
+
+            # Try structured JSON, fall back to freeform verdict extraction
+            local result
+            if ! result=$(parse_structured_response "${parsed_text}"); then
+                result=$(parse_freeform_fallback "${parsed_text}" "${findings_json}")
+            fi
+
+            local validations missed_issues
+            validations=$(jq '.validations // []' <<< "${result}")
+            missed_issues=$(jq '.missed_issues // []' <<< "${result}")
+
+            meta_review_json_output true false \
+                validations "${validations}" \
+                missed_issues "${missed_issues}" \
+                copilot_log "${log_file}" \
+                duration_ms "${duration_ms}"
+            ;;
+        1)
+            meta_review_json_output true true \
+                copilot_log "${log_file}" \
+                copilot_stderr "${stderr_tail}" \
+                duration_ms "${duration_ms}"
+            ;;
+        *)
+            meta_review_json_output true false \
+                error "copilot exited with error" \
+                copilot_log "${log_file}" \
+                copilot_stderr "${stderr_tail}" \
+                duration_ms "${duration_ms}"
+            ;;
+    esac
+}
+
+main "$@"

--- a/skills/review-code/scripts/copilot-meta-review.sh
+++ b/skills/review-code/scripts/copilot-meta-review.sh
@@ -89,7 +89,6 @@ parse_structured_response() {
     fi
 
     # If wrapped in markdown fences, strip them and try again
-    local json_text
     json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d')
     if [[ -n "${json_text}" ]] && printf '%s' "${json_text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
         printf '%s' "${json_text}"
@@ -108,8 +107,8 @@ parse_freeform_fallback() {
 
     for fid in ${finding_ids}; do
         local verdict_line
-        # Match patterns: "#1: CONFIRMED", "Finding 1: DISMISSED", "1. CONFIRMED"
-        verdict_line=$(printf '%s' "${text}" | grep -iE "(#${fid}|finding ${fid}|^${fid}[.):])" | grep -iwE "CONFIRMED|DISMISSED|ADJUSTED" | head -1)
+        # Require non-digit boundary after ID so #1 does not match #10
+        verdict_line=$(printf '%s' "${text}" | grep -iE "(#${fid}([^0-9]|$)|finding[[:space:]]+${fid}([^0-9]|$)|^${fid}[.):])" | grep -iwE "CONFIRMED|DISMISSED|ADJUSTED" | head -1)
 
         if [[ -n "${verdict_line}" ]]; then
             local verdict
@@ -230,6 +229,7 @@ main() {
             ;;
         1)
             meta_review_json_output true true \
+                raw_output "" \
                 copilot_log "${log_file}" \
                 copilot_stderr "${stderr_tail}" \
                 duration_ms "${duration_ms}"
@@ -237,6 +237,7 @@ main() {
         *)
             meta_review_json_output true false \
                 error "copilot exited with error" \
+                raw_output "" \
                 copilot_log "${log_file}" \
                 copilot_stderr "${stderr_tail}" \
                 duration_ms "${duration_ms}"

--- a/skills/review-code/scripts/copilot-review.sh
+++ b/skills/review-code/scripts/copilot-review.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # copilot-review.sh - Run Copilot CLI code review on a diff and return results as JSON
 #
+# NOTE: No longer called from the review flow. Replaced by copilot-meta-review.sh
+# which validates Claude's findings instead of running a full independent review.
+# Kept for potential standalone use.
+#
 # Usage:
 #   echo '{"diff": "<diff text>", "timeout_seconds": 180}' | copilot-review.sh
 #

--- a/skills/review-code/scripts/copilot-validate.sh
+++ b/skills/review-code/scripts/copilot-validate.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 # copilot-validate.sh - Use Copilot CLI to adversarially validate a blocking finding
 #
+# NOTE: No longer called from the review flow. Per-finding validation is now handled
+# by copilot-meta-review.sh which validates all findings in a single call.
+# Kept for potential standalone use.
+#
 # Usage:
 #   echo '{"finding_description": "...", "file": "src/auth.ts", "line": 42,
 #          "proposed_fix": "...", "diff_context": "<relevant diff snippet>",

--- a/skills/review-code/scripts/helpers/copilot-helpers.sh
+++ b/skills/review-code/scripts/helpers/copilot-helpers.sh
@@ -5,6 +5,7 @@
 # Timeouts (seconds)
 COPILOT_REVIEW_TIMEOUT="${COPILOT_REVIEW_TIMEOUT:-300}"
 COPILOT_VALIDATE_TIMEOUT="${COPILOT_VALIDATE_TIMEOUT:-150}"
+COPILOT_META_REVIEW_TIMEOUT="${COPILOT_META_REVIEW_TIMEOUT:-120}"
 
 # Max diff size (bytes) to send to Copilot. Larger diffs cause timeouts
 # (176KB timed out at 180s). 100KB gives headroom for prompt wrapping.

--- a/tests/unit/test-copilot-meta-review.bats
+++ b/tests/unit/test-copilot-meta-review.bats
@@ -1,0 +1,285 @@
+#!/usr/bin/env bats
+# Tests for copilot-meta-review.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/copilot-meta-review.sh"
+
+    # Create temp directory for mock scripts and test data
+    MOCK_DIR=$(mktemp -d)
+    TMP_DIR=$(mktemp -d)
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR" "$TMP_DIR"
+}
+
+# Helper to create a mock copilot that returns structured JSON
+create_mock_copilot() {
+    local response="$1"
+    cat > "$MOCK_DIR/copilot" << MOCKEOF
+#!/bin/bash
+echo '{"type":"result","content":$response}'
+MOCKEOF
+    chmod +x "$MOCK_DIR/copilot"
+}
+
+# Helper to create a mock copilot that times out (exit 124)
+create_timeout_mock_copilot() {
+    cat > "$MOCK_DIR/copilot" << 'EOF'
+#!/bin/bash
+exit 124
+EOF
+    chmod +x "$MOCK_DIR/copilot"
+}
+
+# Helper to create a mock copilot that errors (exit 2)
+create_error_mock_copilot() {
+    cat > "$MOCK_DIR/copilot" << 'EOF'
+#!/bin/bash
+echo "something went wrong" >&2
+exit 2
+EOF
+    chmod +x "$MOCK_DIR/copilot"
+}
+
+# Helper to write input JSON to a tmpfile and run the script
+run_script_with_input() {
+    local input="$1"
+    echo "$input" > "$TMP_DIR/input.json"
+    run bash -c "'$SCRIPT' < '$TMP_DIR/input.json'"
+}
+
+# Helper to build sample input and run the script (deduplicates the common 3-line pattern)
+run_with_sample_input() {
+    local timeout="${1:-5}"
+    local input
+    input=$(jq -n --argjson findings "$(sample_findings)" --arg diff "$(sample_diff)" --argjson timeout_seconds "$timeout" '$ARGS.named')
+    run_script_with_input "$input"
+}
+
+# Helper to build a sample findings JSON
+sample_findings() {
+    cat << 'JSON'
+[{"id":1,"agent":"security","type":"blocking","file":"src/auth.ts","line":42,"description":"SQL injection","proposed_fix":"Use parameterized queries","confidence":75},{"id":2,"agent":"correctness","type":"suggestion","file":"src/utils.ts","line":10,"description":"Unchecked null","proposed_fix":"Add null check","confidence":60}]
+JSON
+}
+
+sample_diff() {
+    printf '%s\n' \
+        'diff --git a/src/auth.ts b/src/auth.ts' \
+        '--- a/src/auth.ts' \
+        '+++ b/src/auth.ts' \
+        '@@ -40,3 +40,5 @@' \
+        ' function login(user) {' \
+        '+  db.query("SELECT * FROM users WHERE name = " + user);' \
+        '+  return true;' \
+        ' }'
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "copilot-meta-review: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: uses set -euo pipefail" {
+    run bash -c "head -20 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: sources copilot-helpers.sh" {
+    run bash -c "grep -q 'copilot-helpers.sh' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: has main function" {
+    run bash -c "grep -q '^main()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: has build_meta_review_prompt function" {
+    run bash -c "grep -q '^build_meta_review_prompt()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: has parse_structured_response function" {
+    run bash -c "grep -q '^parse_structured_response()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+@test "copilot-meta-review: has parse_freeform_fallback function" {
+    run bash -c "grep -q '^parse_freeform_fallback()' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Copilot unavailable tests
+# =============================================================================
+
+@test "copilot-meta-review: returns available false when copilot not installed" {
+    # Override PATH to only include essentials, excluding the real copilot
+    local input
+    input=$(jq -n --argjson findings "$(sample_findings)" --arg diff "$(sample_diff)" '$ARGS.named')
+    echo "$input" > "$TMP_DIR/input.json"
+    run bash -c "PATH='/usr/bin:/bin:$MOCK_DIR' '$SCRIPT' < '$TMP_DIR/input.json'"
+    [ "$status" -eq 0 ]
+    local available
+    available=$(echo "$output" | jq -r '.available')
+    [ "$available" = "false" ]
+}
+
+# =============================================================================
+# Empty findings tests
+# =============================================================================
+
+@test "copilot-meta-review: returns empty results for empty findings array" {
+    create_mock_copilot '"unused"'
+    local input
+    input=$(jq -n --argjson findings '[]' --arg diff "$(sample_diff)" '$ARGS.named')
+    run_script_with_input "$input"
+    [ "$status" -eq 0 ]
+    local available validations missed
+    available=$(echo "$output" | jq -r '.available')
+    validations=$(echo "$output" | jq '.validations | length')
+    missed=$(echo "$output" | jq '.missed_issues | length')
+    [ "$available" = "true" ]
+    [ "$validations" -eq 0 ]
+    [ "$missed" -eq 0 ]
+}
+
+# =============================================================================
+# Successful structured output tests
+# =============================================================================
+
+@test "copilot-meta-review: parses structured JSON response" {
+    local copilot_response='"{\"validations\":[{\"finding_id\":1,\"verdict\":\"CONFIRMED\",\"reasoning\":\"Real issue\"}],\"missed_issues\":[]}"'
+    create_mock_copilot "$copilot_response"
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local available timed_out verdict
+    available=$(echo "$output" | jq -r '.available')
+    timed_out=$(echo "$output" | jq -r '.timed_out')
+    verdict=$(echo "$output" | jq -r '.validations[0].verdict')
+    [ "$available" = "true" ]
+    [ "$timed_out" = "false" ]
+    [ "$verdict" = "CONFIRMED" ]
+}
+
+@test "copilot-meta-review: parses missed issues from response" {
+    local copilot_response='"{\"validations\":[],\"missed_issues\":[{\"file\":\"src/new.ts\",\"line\":5,\"type\":\"blocking\",\"description\":\"Buffer overflow\"}]}"'
+    create_mock_copilot "$copilot_response"
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local missed_count missed_file
+    missed_count=$(echo "$output" | jq '.missed_issues | length')
+    missed_file=$(echo "$output" | jq -r '.missed_issues[0].file')
+    [ "$missed_count" -eq 1 ]
+    [ "$missed_file" = "src/new.ts" ]
+}
+
+# =============================================================================
+# Timeout tests
+# =============================================================================
+
+@test "copilot-meta-review: handles timeout correctly" {
+    create_timeout_mock_copilot
+    run_with_sample_input 1
+    [ "$status" -eq 0 ]
+
+    local available timed_out
+    available=$(echo "$output" | jq -r '.available')
+    timed_out=$(echo "$output" | jq -r '.timed_out')
+    [ "$available" = "true" ]
+    [ "$timed_out" = "true" ]
+}
+
+# =============================================================================
+# Error handling tests
+# =============================================================================
+
+@test "copilot-meta-review: handles copilot error gracefully" {
+    create_error_mock_copilot
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local available error
+    available=$(echo "$output" | jq -r '.available')
+    error=$(echo "$output" | jq -r '.error')
+    [ "$available" = "true" ]
+    [ "$error" = "copilot exited with error" ]
+}
+
+# =============================================================================
+# Diff size limit tests
+# =============================================================================
+
+@test "copilot-meta-review: still validates findings when diff exceeds size limit" {
+    local copilot_response='"{\"validations\":[{\"finding_id\":1,\"verdict\":\"CONFIRMED\",\"reasoning\":\"Confirmed without diff\"}],\"missed_issues\":[]}"'
+    create_mock_copilot "$copilot_response"
+
+    # Generate a diff larger than COPILOT_MAX_DIFF_BYTES (102400)
+    local large_diff
+    large_diff=$(python3 -c "print('x' * 110000)")
+
+    local input
+    input=$(jq -n --argjson findings "$(sample_findings)" --arg diff "$large_diff" --argjson timeout_seconds 5 '$ARGS.named')
+    run_script_with_input "$input"
+    [ "$status" -eq 0 ]
+
+    local available verdict
+    available=$(echo "$output" | jq -r '.available')
+    verdict=$(echo "$output" | jq -r '.validations[0].verdict')
+    [ "$available" = "true" ]
+    [ "$verdict" = "CONFIRMED" ]
+}
+
+# =============================================================================
+# Freeform fallback tests
+# =============================================================================
+
+@test "copilot-meta-review: falls back to freeform parsing when JSON invalid" {
+    local freeform_text='"#1: CONFIRMED - The SQL injection is real and dangerous\n#2: DISMISSED - The null check exists upstream"'
+    create_mock_copilot "$freeform_text"
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local available validations_count
+    available=$(echo "$output" | jq -r '.available')
+    validations_count=$(echo "$output" | jq '.validations | length')
+    [ "$available" = "true" ]
+    [ "$validations_count" -ge 1 ]
+}
+
+# =============================================================================
+# Output structure tests
+# =============================================================================
+
+@test "copilot-meta-review: output always has required fields" {
+    create_mock_copilot '"{\"validations\":[],\"missed_issues\":[]}"'
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    echo "$output" | jq -e 'has("available")' > /dev/null
+    echo "$output" | jq -e 'has("timed_out")' > /dev/null
+    echo "$output" | jq -e 'has("validations")' > /dev/null
+    echo "$output" | jq -e 'has("missed_issues")' > /dev/null
+    echo "$output" | jq -e 'has("duration_ms")' > /dev/null
+}
+
+@test "copilot-meta-review: duration_ms is a number" {
+    create_mock_copilot '"{\"validations\":[],\"missed_issues\":[]}"'
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local duration_type
+    duration_type=$(echo "$output" | jq -r '.duration_ms | type')
+    [ "$duration_type" = "number" ]
+}

--- a/tests/unit/test-copilot-meta-review.bats
+++ b/tests/unit/test-copilot-meta-review.bats
@@ -185,6 +185,34 @@ sample_diff() {
     [ "$missed_file" = "src/new.ts" ]
 }
 
+@test "copilot-meta-review: parses pretty-printed multi-line JSON response" {
+    # Build a mock that returns pretty-printed JSON (nested braces on their own lines)
+    cat > "$MOCK_DIR/copilot" << 'MOCKEOF'
+#!/bin/bash
+jq -n --arg content '{
+  "validations": [
+    {
+      "finding_id": 1,
+      "verdict": "CONFIRMED",
+      "reasoning": "Real SQL injection"
+    }
+  ],
+  "missed_issues": []
+}' '{type: "result", content: $content}'
+MOCKEOF
+    chmod +x "$MOCK_DIR/copilot"
+    run_with_sample_input
+    [ "$status" -eq 0 ]
+
+    local available timed_out verdict
+    available=$(echo "$output" | jq -r '.available')
+    timed_out=$(echo "$output" | jq -r '.timed_out')
+    verdict=$(echo "$output" | jq -r '.validations[0].verdict')
+    [ "$available" = "true" ]
+    [ "$timed_out" = "false" ]
+    [ "$verdict" = "CONFIRMED" ]
+}
+
 # =============================================================================
 # Timeout tests
 # =============================================================================


### PR DESCRIPTION
## Summary
- Replace Copilot's parallel full-review (which always timed out at 300s) with a sequential meta-review that validates Claude's findings and does a cursory scan for obvious misses
- New `copilot-meta-review.sh` script takes synthesized findings + diff, asks Copilot to validate/critique each finding (CONFIRMED/DISMISSED/ADJUSTED) and flag anything glaringly missed
- Subsumes the separate per-finding `copilot-validate.sh` step into a single call, simplifying the review flow

## Test plan
- [x] All 1172 unit tests pass (including 17 new tests for `copilot-meta-review.sh`)
- [x] All 12 integration tests pass
- [ ] Manual test: run `/review-code` on a PR and verify Copilot meta-review completes without timeout
- [ ] Verify findings are annotated with Copilot corroboration/dissent notes