### PR TITLE
Remove post-draft submit prompt

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -1007,50 +1007,6 @@ If failed, show the error and suggest using the review file manually.
   3. Suggest: "You can copy comments from the review file and post them manually on GitHub."
   4. **STOP HERE.** Do NOT attempt to post comments using `gh pr review` or any other method as a fallback. This will submit the review instead of keeping it pending.
 
-### Offer to Submit Review
-
-After creating the draft review successfully, offer to submit it from within Claude Code.
-
-Only proceed if the draft review was created successfully (the `create-draft-review.sh` output has `success: true` and a valid `review_id`).
-
-Use `AskUserQuestion` with these options:
-
-1. "Submit as Comment": neutral feedback, no approval or rejection
-2. "Submit as Approve": approve the PR
-3. "Submit as Request Changes": request changes before merge
-4. "Keep as draft": don't submit now; visit GitHub to review and submit manually
-
-**If the user selects a submit option:**
-
-Map the selection to an event value:
-- "Submit as Comment" → `COMMENT`
-- "Submit as Approve" → `APPROVE`
-- "Submit as Request Changes" → `REQUEST_CHANGES`
-
-Call `submit-review.sh` with the review ID from the draft creation output:
-
-```bash
-~/.claude/skills/review-code/scripts/submit-review.sh <<'EOF'
-{"owner": "<owner>", "repo": "<repo>", "pr_number": <number>, "review_id": <review_id>, "event": "<EVENT>"}
-EOF
-```
-
-If successful:
-```
-Review submitted!
-
-Review: <review_url>
-Event: <event> (State: <state>)
-```
-
-If failed, show the error and tell the user they can submit manually on GitHub.
-
-**If the user selects "Keep as draft":**
-
-```
-Review kept as draft. Visit GitHub to review and submit:
-<review_url>
-```
 ### Cleanup Session
 
 After the review is complete, clean up the session (replace `<SESSION_ID>` with the actual session ID):


### PR DESCRIPTION
## Summary

- After `/review-code <pr> --draft` creates a pending GitHub review, stop instead of asking the user to pick Submit as Comment / Approve / Request Changes / Keep as draft.
- Lets the user discuss the review findings before deciding what to do with the draft.
- `submit-review.sh` is unchanged, so the user can still ask to submit the draft conversationally.

## Test plan

- [ ] Run `bin/setup` and then `/review-code <PR-url> --draft` against a test PR; confirm the skill ends after "Draft review created on GitHub!" with no submit-or-keep question.
- [ ] Follow up with "submit this as a comment" in chat; confirm `submit-review.sh` still works.
- [ ] Confirm non-draft `/review-code` flow is unaffected.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*