### PR TITLE
Speed up cross-repo PR reviews with worktree-based local clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,20 @@ Review any GitHub pull request by URL - works from anywhere (inside or outside a
 
 This means you can review PRs for any repository without needing to clone it locally.
 
+#### Speeding up cross-repo PR reviews with `repos.conf`
+
+When reviewing a PR from outside its repository, the skill can provision a short-lived worktree off a local clone you already have, giving agents native `Read`/`Grep`/`Glob` access to the PR source instead of falling back to a diff-only review. Opt in by creating `~/.claude/skills/review-code/repos.conf`:
+
+```
+# Format: <org>/<repo>  <absolute-or-tilde-path>
+posthog/posthog     ~/dev/posthog/posthog
+someorg/somerepo    ~/dev/someorg/somerepo
+```
+
+`$REVIEW_CODE_CONFIG_DIR/repos.conf` overrides the default location (used by tests and advanced setups).
+
+Without a mapping for the PR's repo, the review falls back to diff-only (with a warning).
+
 ### Review Git History
 
 ```bash

--- a/bin/setup
+++ b/bin/setup
@@ -487,6 +487,50 @@ cleanup_old_config() {
     done
 }
 
+# Report PR review worktrees present under the skill's worktree root.
+# Includes both active (in-flight reviews) and orphan (crashed reviews) entries
+# — distinguishing them reliably would require cross-referencing live sessions.
+# Doesn't auto-delete; the user decides whether to run `git worktree prune`
+# in the owning clone.
+check_orphan_worktrees() {
+    # Source the layout helper for the one-place-only definition of the
+    # worktree root and directory depth.
+    # shellcheck source=../skills/review-code/scripts/helpers/worktree-layout.sh
+    source "${SCRIPT_DIR}/skills/review-code/scripts/helpers/worktree-layout.sh"
+
+    local worktree_root_dir
+    worktree_root_dir="$(worktree_root)"
+    [[ -d "${worktree_root_dir}" ]] || return 0
+
+    local depth
+    depth="$(worktree_layout_depth)"
+
+    local -a worktrees=()
+    while IFS= read -r wt; do
+        worktrees+=("${wt}")
+    done < <(find "${worktree_root_dir}" -mindepth "${depth}" -maxdepth "${depth}" -type d -name 'pr-*' 2> /dev/null || true)
+
+    local count="${#worktrees[@]}"
+    if [[ "${count}" -gt 0 ]]; then
+        echo ""
+        warn "Found ${count} review worktree(s) under ${worktree_root_dir}."
+        echo "  These are reused on subsequent reviews of the same PR; crashed reviews may leave behind entries."
+        local wt gitdir_line clone
+        for wt in "${worktrees[@]}"; do
+            clone="unknown"
+            if [[ -f "${wt}/.git" ]]; then
+                # The .git file contains: gitdir: <clone>/.git/worktrees/<name>
+                gitdir_line=$(cat "${wt}/.git" 2> /dev/null || echo "")
+                gitdir_line="${gitdir_line#gitdir: }"
+                clone="${gitdir_line%/.git/worktrees/*}"
+            fi
+            echo "    ${wt}  (clone: ${clone})"
+        done
+        echo "  To inspect:  git -C <clone> worktree list"
+        echo "  To clean up: git -C <clone> worktree prune"
+    fi
+}
+
 check_old_installation() {
     local old_dir="${HOME}/.review-code"
 
@@ -558,12 +602,22 @@ main() {
     # Clean up deprecated config files
     cleanup_old_config
 
+    # Clean up legacy bare-cache directory from the pre-worktree approach.
+    local legacy_cache="${SKILL_DIR}/cache"
+    if [[ -d "${legacy_cache}" ]]; then
+        info "Removing legacy bare-clone cache at ${legacy_cache}…"
+        rm -rf "${legacy_cache}"
+    fi
+
     # Install components
     echo ""
     info "Installing review-code components…"
     install_skill
     install_agents
     install_context
+
+    # Check for orphaned review worktrees (from crashed reviews).
+    check_orphan_worktrees
 
     # Cleanup old installation if requested
     if [[ "${remove_old}" -eq 0 ]]; then

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -70,7 +70,7 @@ From the session file JSON, extract these fields for building agent context:
 - `git`: git repository context
 - `languages`: detected languages
 - `file_info.file_path`: where to save the review
-- `file_ref`: (optional) git ref for reading PR files when on a different branch
+- `file_ref`: (optional) git ref for reading PR files when on a different branch or via a provisioned worktree
 - `commit_messages`: (optional) commit messages for the reviewed changes (subject + body, truncated to 8KB)
 - `chunks`: (optional) array of chunk objects when the diff was split
 - `chunk_metadata`: (optional) object with `chunked`, `reason`, `chunk_count`
@@ -161,30 +161,38 @@ If `chunk_metadata` exists and `chunk_metadata.chunked` is `true`, set `is_chunk
 "This is a large PR ({chunk_metadata.reason}). Splitting into {chunk_count} chunks for focused review."
 
 Mode-specific fields:
-- **PR mode:** `pr`: PR details (number, title, author, body, comments, etc.); `file_ref`: git ref for file access (present when reviewing from a different branch)
+- **PR mode:** `pr`: PR details (number, title, author, body, comments, etc.); `file_ref`: git ref for file access (present when reviewing from a different branch or via a provisioned worktree). When the review runs outside the PR's repo and a local clone is mapped in `repos.conf`, `git.working_dir` points at a detached worktree checked out to the PR. Otherwise — no mapping, provisioning failed, or the PR ref could not be fetched into an in-repo clone — `working_dir` is null and only the diff is available.
 - **Branch/commit/range modes:** `branch`, `base_branch`, `commit`, `range`
 - **Area-specific reviews:** `area`
 
 ### Prepare File Access Instructions
 
-Build `$file_access_instructions` based on the session data. This block is included in both the context explorer and agent prompts.
+Build `$file_access_instructions` based on the session data. This block is included in both the context explorer and agent prompts. Substitute the actual `git.working_dir` path into the instructions when `working_dir` is set — do not emit `$git.working_dir` or similar placeholders verbatim.
 
-**If `file_ref` is set:**
+`git.local_clone` is set only for cross-repo reviews where a detached worktree was provisioned from a configured clone; when it is set and `working_dir` is set, `working_dir` is that worktree and Read/Grep/Glob read the PR's files directly. In the same-repo cross-branch case, `local_clone` is null and `working_dir` is the user's current checkout — which may be on a different branch — so Read on `working_dir` would read the wrong content for PR files.
+
+**If `working_dir` is set and `file_ref` is set and `local_clone` is set:**
 ```
 **File Access:**
-You are reviewing from a different branch in the same repo. To read files as they appear in the PR, use `git show "$file_ref:<path>"` via the Bash tool (always quote the argument to handle paths with spaces or special characters). Do NOT use `git checkout` or `git switch`: this would modify the user's working tree. The Read, Grep, and Glob tools operate on the current working tree (which may differ from the PR branch), so use them for finding patterns and conventions but not for reading the PR's file contents. `git show` works for any file that exists at the ref, including files newly added in the PR. If `git show` fails (e.g., the file was deleted or renamed, the path is wrong, or the ref was not fetched), fall back to the diff content.
+A detached worktree checked out to this PR is available at the path given by `git.working_dir` in the session data. Use Read, Grep, and Glob normally; they operate on that directory. Do not run `git checkout` or `git switch` anywhere, and do not run other write operations in the worktree — the orchestrator owns its lifetime.
 ```
 
-**If `file_ref` is NOT set and `working_dir` is not null:**
+**If `working_dir` is set and `file_ref` is set and `local_clone` is null:**
 ```
 **File Access:**
-You are on the PR's branch. Use the Read tool to read files normally.
+You are reviewing from a different branch in the same repo. The user's working tree at `git.working_dir` is on a different branch than the PR, so Read/Grep/Glob there see the wrong file contents for the PR. To read files as they appear in the PR, use `git show "$file_ref:<path>"` via the Bash tool (substitute the actual ref from the session data and always quote the argument to handle paths with spaces or special characters). Do NOT use `git checkout` or `git switch`: this would modify the user's working tree. Read, Grep, and Glob are still useful for finding patterns and conventions in the user's working tree — just not for reading the PR's file contents. `git show` works for any file that exists at the ref, including files newly added in the PR. If `git show` fails (e.g., the file was deleted or renamed, the path is wrong, or the ref was not fetched), fall back to the diff content.
+```
+
+**If `working_dir` is set and `file_ref` is NOT set:**
+```
+**File Access:**
+You are on the PR's branch in the user's working directory. Use the Read tool to read files normally. Do not run `git checkout` or `git switch`: it would disturb the user's working tree.
 ```
 
 **If `working_dir` is null:**
 ```
 **File Access:**
-No local checkout available. Work from the diff content only.
+No safe local checkout is available for reading PR files. This can happen because no local clone is configured for the repo in `repos.conf`, because worktree provisioning failed, or because the PR ref could not be fetched into the user's clone. Work from the diff content only.
 ```
 
 ### Gather Architectural Context

--- a/skills/review-code/scripts/helpers/repo-detection.sh
+++ b/skills/review-code/scripts/helpers/repo-detection.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# repo-detection.sh - Zero-dependency git-repo detection helper.
+#
+# Usage (sourced):
+#   source "$(dirname "${BASH_SOURCE[0]}")/repo-detection.sh"
+#   is_git_repo "${path}" && echo "yes"
+
+# Check if a directory looks like a valid git metadata dir: HEAD plus either
+# objects/ (normal/bare repo) or commondir (linked worktree).
+# Args: $1 = git metadata directory path
+# Returns: exit 0 if valid, 1 otherwise.
+_is_valid_git_dir() {
+    local git_dir="$1"
+    [[ -d "${git_dir}" && -f "${git_dir}/HEAD" ]] || return 1
+    [[ -d "${git_dir}/objects" || -f "${git_dir}/commondir" ]]
+}
+
+# Check if a directory looks like a git repository (bare or non-bare).
+# Accepts `.git` as either a directory (normal clone) or a file (worktree
+# or submodule, where `.git` contains `gitdir: <path>`). For the file form,
+# the referenced gitdir must itself resolve to a valid metadata dir so a
+# stale `gitdir:` pointer isn't mistaken for a real clone.
+# Args: $1 = path
+# Returns: exit 0 if it is, 1 otherwise. No output.
+is_git_repo() {
+    local path="$1"
+    if [[ -d "${path}/.git" ]]; then
+        _is_valid_git_dir "${path}/.git"
+        return
+    fi
+    if [[ -f "${path}/.git" ]]; then
+        local first_line="" gitdir_path=""
+        read -r first_line < "${path}/.git" 2> /dev/null || return 1
+        [[ "${first_line}" == gitdir:* ]] || return 1
+        gitdir_path="${first_line#gitdir:}"
+        # Trim leading/trailing whitespace.
+        gitdir_path="${gitdir_path#"${gitdir_path%%[![:space:]]*}"}"
+        gitdir_path="${gitdir_path%"${gitdir_path##*[![:space:]]}"}"
+        [[ -n "${gitdir_path}" ]] || return 1
+        # Relative gitdir paths are resolved against the directory containing
+        # the `.git` file (git's own convention for submodule pointers).
+        [[ "${gitdir_path}" != /* ]] && gitdir_path="${path}/${gitdir_path}"
+        _is_valid_git_dir "${gitdir_path}"
+        return
+    fi
+    _is_valid_git_dir "${path}"
+}

--- a/skills/review-code/scripts/helpers/repos-config.sh
+++ b/skills/review-code/scripts/helpers/repos-config.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# repos-config.sh - Resolve local clone paths from repos.conf
+#
+# Config file format (flat, whitespace-separated):
+#   # comments begin with hash
+#   <org>/<repo>   <absolute-or-tilde-path>
+#   posthog/posthog  ~/dev/posthog/posthog
+#
+# Location:
+#   ~/.claude/skills/review-code/repos.conf
+#   (overridable via $REVIEW_CODE_CONFIG_DIR for tests/advanced users)
+#
+# Usage (sourced):
+#   source helpers/repos-config.sh
+#   path=$(resolve_local_clone "posthog" "posthog")
+#   # Empty string if not found or not a git repo.
+
+_REPOS_CONFIG_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=repo-detection.sh
+source "${_REPOS_CONFIG_HELPER_DIR}/repo-detection.sh"
+
+# Find repos.conf. Echoes the file path on stdout and exits 0 when found,
+# or exits 1 when not. The echoed path tracks the caller-supplied
+# REVIEW_CODE_CONFIG_DIR verbatim, so a relative value yields a relative
+# path; only the default fallback under ${HOME} is guaranteed absolute.
+find_repos_config() {
+    if [[ -n "${REVIEW_CODE_CONFIG_DIR:-}" ]]; then
+        local candidate="${REVIEW_CODE_CONFIG_DIR%/}/repos.conf"
+        if [[ -f "${candidate}" ]]; then
+            echo "${candidate}"
+            return 0
+        fi
+        # Treat a set override as an explicit commitment: if the file isn't
+        # there, don't fall through to the default. Otherwise a typo'd
+        # override (or a test scoping to a temp dir that doesn't have the
+        # file) silently reads the host's real repos.conf.
+        return 1
+    fi
+
+    local default="${HOME}/.claude/skills/review-code/repos.conf"
+    if [[ -f "${default}" ]]; then
+        echo "${default}"
+        return 0
+    fi
+
+    return 1
+}
+
+# Look up org/repo in repos.conf. Echoes the resolved path if the entry
+# exists and points at a git repo; empty otherwise.
+resolve_local_clone() {
+    local org="${1:-}"
+    local repo="${2:-}"
+    if [[ -z "${org}" || -z "${repo}" ]]; then
+        return 0
+    fi
+
+    local config
+    config=$(find_repos_config) || return 0
+    [[ -n "${config}" && -f "${config}" ]] || return 0
+
+    local key="${org}/${repo}"
+    local raw_path
+    raw_path=$(awk -v k="${key}" '
+        /^[[:space:]]*#/ { next }
+        /^[[:space:]]*$/ { next }
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+            n = match(line, /[[:space:]]+/)
+            if (n == 0) next
+            if (tolower(substr(line, 1, n - 1)) == tolower(k)) {
+                print substr(line, n + RLENGTH)
+                exit
+            }
+        }
+    ' "${config}")
+
+    [[ -n "${raw_path}" ]] || return 0
+
+    local expanded="${raw_path/#\~/${HOME}}"
+
+    # Spec is <absolute-or-tilde-path>. A relative path would resolve against
+    # the caller's cwd, which is surprising for a user-level machine map.
+    if [[ "${expanded}" != /* ]]; then
+        return 0
+    fi
+
+    if is_git_repo "${expanded}"; then
+        echo "${expanded}"
+    fi
+}

--- a/skills/review-code/scripts/helpers/repos-config.sh
+++ b/skills/review-code/scripts/helpers/repos-config.sh
@@ -57,10 +57,14 @@ resolve_local_clone() {
 
     local config
     config=$(find_repos_config) || return 0
-    [[ -n "${config}" && -f "${config}" ]] || return 0
+    # Require readability too: an unreadable config (permissions, transient FS)
+    # would fail the awk below, and since we're sourced into a `set -e` parent,
+    # that non-zero exit would abort the review instead of falling back to
+    # diff-only. Treat unreadable the same as missing.
+    [[ -n "${config}" && -f "${config}" && -r "${config}" ]] || return 0
 
     local key="${org}/${repo}"
-    local raw_path
+    local raw_path=""
     raw_path=$(awk -v k="${key}" '
         /^[[:space:]]*#/ { next }
         /^[[:space:]]*$/ { next }
@@ -75,7 +79,7 @@ resolve_local_clone() {
                 exit
             }
         }
-    ' "${config}")
+    ' "${config}" 2> /dev/null) || raw_path=""
 
     [[ -n "${raw_path}" ]] || return 0
 

--- a/skills/review-code/scripts/helpers/worktree-layout.sh
+++ b/skills/review-code/scripts/helpers/worktree-layout.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# worktree-layout.sh - Single source of truth for the PR worktree filesystem layout.
+#
+# The layout is: ${REVIEW_CODE_WORKTREE_DIR}/<org>/<repo>/pr-<N>. Every consumer
+# (pr-worktree.sh, session-hooks, bin/setup) should go through these helpers so
+# changes to the shape live in one place.
+
+# Root directory that holds all review worktrees.
+worktree_root() {
+    echo "${REVIEW_CODE_WORKTREE_DIR:-${HOME}/.claude/skills/review-code/worktrees}"
+}
+
+# Path leaf relative to worktree_root, e.g. "acme/widget/pr-7". Lowercases org
+# and repo so the on-disk layout is stable regardless of caller casing.
+worktree_leaf_for() {
+    local org="$1"
+    local repo="$2"
+    local pr_number="$3"
+    echo "${org,,}/${repo,,}/pr-${pr_number}"
+}
+
+# Absolute worktree path for a given org/repo/PR.
+worktree_path_for() {
+    local org="$1"
+    local repo="$2"
+    local pr_number="$3"
+    echo "$(worktree_root)/$(worktree_leaf_for "${org}" "${repo}" "${pr_number}")"
+}
+
+# Depth beneath worktree_root where a worktree lives (for find -mindepth/-maxdepth).
+worktree_layout_depth() {
+    echo 3
+}

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -153,7 +153,9 @@ provision() {
             fi
         fi
     elif [[ -e "${path}" ]]; then
-        error "Path exists but is not a registered worktree: ${path}. Remove it manually or run \`git -C ${local_clone} worktree prune\` and retry."
+        local quoted_clone
+        printf -v quoted_clone '%q' "${local_clone}"
+        error "Path exists but is not a registered worktree: ${path}. Remove it manually or run \`git -C ${quoted_clone} worktree prune\` and retry."
         return 1
     else
         log "Creating worktree at ${path}…"

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# pr-worktree.sh - Provision short-lived worktrees off a local clone for PR reviews.
+#
+# Usage:
+#   pr-worktree.sh provision <org> <repo> <pr_number> <local_clone>
+#     Fetches refs/pull/<N>/head into refs/review-code/pr/<N> inside the user's
+#     clone, then creates (or reuses) a detached worktree at
+#     ${REVIEW_CODE_WORKTREE_DIR:-$HOME/.claude/skills/review-code/worktrees}/<org>/<repo>/pr-<N>.
+#
+#     stdout: JSON {"worktree_path": "<abs>", "ref": "refs/review-code/pr/<N>"}
+#     stderr: progress / diagnostics
+#     exit 1 on fetch or worktree failure (caller falls back to diff-only)
+#
+#   pr-worktree.sh teardown <org> <repo> <pr_number> <local_clone>
+#     Removes the worktree via `git worktree remove --force`. Keeps the ref
+#     (trivially small; speeds up re-reviews of the same PR).
+#     No error if the worktree is already gone.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+# shellcheck source=helpers/repo-detection.sh
+source "${SCRIPT_DIR}/helpers/repo-detection.sh"
+# shellcheck source=helpers/worktree-layout.sh
+source "${SCRIPT_DIR}/helpers/worktree-layout.sh"
+
+export GIT_TERMINAL_PROMPT=0
+
+# All progress output goes to stderr; stdout is reserved for the provision JSON.
+log() {
+    echo "$*" >&2
+}
+
+# Resolve symlinks in <path>. Needed because `git worktree list` returns
+# canonical paths and direct string comparison breaks on macOS where
+# /var -> /private/var. Falls back to the raw path when no ancestor resolves
+# (e.g. during teardown of an already-gone worktree).
+#
+# stdout is intentionally the canonical path (consumed by
+# `path=$(canonicalize ...)`); do not echo anything else inside this
+# function — the file-level contract reserves stdout for the provision JSON.
+canonicalize() {
+    local p="$1"
+    if [[ -d "${p}" ]]; then
+        (cd "${p}" && pwd -P)
+        return
+    fi
+    local parent="${p%/*}"
+    local leaf="${p##*/}"
+    [[ -z "${parent}" ]] && parent="/"
+    if [[ -d "${parent}" ]]; then
+        echo "$(cd "${parent}" && pwd -P)/${leaf}"
+    else
+        echo "${p}"
+    fi
+}
+
+ref_for() {
+    echo "refs/review-code/pr/$1"
+}
+
+validate_args() {
+    local cmd="$1"
+    local org="${2:-}"
+    local repo="${3:-}"
+    local pr_number="${4:-}"
+    local local_clone="${5:-}"
+
+    if [[ -z "${org}" || -z "${repo}" || -z "${pr_number}" || -z "${local_clone}" ]]; then
+        error "Usage: pr-worktree.sh ${cmd} <org> <repo> <pr_number> <local_clone>"
+        return 1
+    fi
+    if [[ ! "${pr_number}" =~ ^[0-9]+$ ]]; then
+        error "Invalid PR number: ${pr_number}"
+        return 1
+    fi
+    # org/repo become filesystem segments under WORKTREE_ROOT. Defense-in-depth
+    # for any future caller that bypasses the orchestrator's upstream sanitization.
+    if [[ ! "${org}" =~ ^[a-zA-Z0-9._-]+$ ]] || [[ "${org}" == "." || "${org}" == ".." ]]; then
+        error "Invalid org: ${org}"
+        return 1
+    fi
+    if [[ ! "${repo}" =~ ^[a-zA-Z0-9._-]+$ ]] || [[ "${repo}" == "." || "${repo}" == ".." ]]; then
+        error "Invalid repo: ${repo}"
+        return 1
+    fi
+    if ! is_git_repo "${local_clone}"; then
+        error "Not a git repo: ${local_clone}"
+        return 1
+    fi
+}
+
+worktree_is_registered() {
+    local clone="$1"
+    local path="$2"
+    git -C "${clone}" worktree list --porcelain 2> /dev/null \
+        | grep -Fqx "worktree ${path}"
+}
+
+# Create a detached worktree at $path pointing at $ref. Caller must ensure the
+# parent directory exists. Returns 1 on failure. git's stderr passes through
+# so the "fatal: …" line surfaces to the caller; stdout is dropped so the
+# "Preparing worktree" progress message doesn't leak into the provision JSON.
+create_worktree() {
+    local local_clone="$1"
+    local path="$2"
+    local ref="$3"
+    git -C "${local_clone}" worktree add --detach "${path}" "${ref}" > /dev/null
+}
+
+provision() {
+    validate_args provision "$@" || return 1
+    local org="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local local_clone="$4"
+
+    local ref
+    ref=$(ref_for "${pr_number}")
+    local path
+    path=$(worktree_path_for "${org}" "${repo}" "${pr_number}")
+
+    log "Fetching pull/${pr_number}/head into ${local_clone}…"
+    # Try a partial-clone fetch first (fast on large repos), then fall back
+    # to a regular fetch for older git or remotes that reject --filter.
+    if ! git -C "${local_clone}" fetch --filter=blob:none origin \
+        "+refs/pull/${pr_number}/head:${ref}" >&2; then
+        log "Partial-clone fetch failed; retrying without --filter=blob:none…"
+        if ! git -C "${local_clone}" fetch origin \
+            "+refs/pull/${pr_number}/head:${ref}" >&2; then
+            error "Fetch failed for ${org}/${repo}#${pr_number}"
+            return 1
+        fi
+    fi
+
+    mkdir -p "$(dirname "${path}")"
+    path=$(canonicalize "${path}")
+
+    if worktree_is_registered "${local_clone}" "${path}"; then
+        log "Reusing worktree at ${path} (checking out ${ref})…"
+        if ! git -C "${path}" checkout --detach "${ref}" > /dev/null 2>&1; then
+            # Reused worktree has dirty state (a prior review crashed mid-edit,
+            # or an agent wrote inside it). The detached checkout refuses to
+            # overwrite. Discarding silently would lose work the user cared
+            # about, so recreate the orchestrator-owned worktree instead.
+            log "Checkout rejected (dirty worktree?); recreating…"
+            git -C "${local_clone}" worktree remove --force "${path}" > /dev/null 2>&1 || true
+            if ! create_worktree "${local_clone}" "${path}" "${ref}"; then
+                error "Failed to recreate worktree at ${path}"
+                return 1
+            fi
+        fi
+    elif [[ -e "${path}" ]]; then
+        error "Path exists but is not a registered worktree: ${path}. Remove it manually or run \`git -C ${local_clone} worktree prune\` and retry."
+        return 1
+    else
+        log "Creating worktree at ${path}…"
+        if ! create_worktree "${local_clone}" "${path}" "${ref}"; then
+            error "Worktree creation failed for ${org}/${repo}#${pr_number}"
+            return 1
+        fi
+    fi
+
+    jq -n --arg path "${path}" --arg ref "${ref}" \
+        '{worktree_path: $path, ref: $ref}'
+}
+
+teardown() {
+    validate_args teardown "$@" || return 1
+    local org="$1"
+    local repo="$2"
+    local pr_number="$3"
+    # local_clone is load-bearing for the crashed-session case: if the
+    # worktree directory was deleted or rendered unusable between provision
+    # and teardown, we can't derive the clone from the worktree's .git
+    # pointer (which may be gone), but the clone still has a stale
+    # registration that needs `git worktree remove --force` to drop.
+    local local_clone="$4"
+
+    local path
+    path=$(worktree_path_for "${org}" "${repo}" "${pr_number}")
+    path=$(canonicalize "${path}")
+
+    if ! worktree_is_registered "${local_clone}" "${path}"; then
+        return 0
+    fi
+
+    log "Removing worktree ${path}…"
+    git -C "${local_clone}" worktree remove --force "${path}" > /dev/null 2>&1 || true
+    # Best-effort cleanup of empty ancestor directories.
+    local repo_dir="${path%/*}"
+    local org_dir="${repo_dir%/*}"
+    rmdir "${repo_dir}" 2> /dev/null || true
+    rmdir "${org_dir}" 2> /dev/null || true
+}
+
+main() {
+    local cmd="${1:-}"
+    shift || true
+
+    case "${cmd}" in
+        provision)
+            provision "$@"
+            ;;
+        teardown)
+            teardown "$@"
+            ;;
+        *)
+            error "Usage: pr-worktree.sh {provision|teardown} <org> <repo> <pr_number> <local_clone>"
+            exit 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -1136,20 +1136,59 @@ handle_pr_review() {
         fi
     fi
 
-    # If not in the same repo, construct a synthetic git_context with PR's org/repo.
-    # working_dir is null since there's no meaningful local directory.
+    # Not in the same repo. If repos.conf maps this repo to a local clone,
+    # provision a detached worktree off that clone so agents can use Read/Grep/
+    # Glob natively. Otherwise fall back to diff-only.
+    local local_clone="" worktree_path=""
     if [[ -z "${git_context}" ]]; then
+        # shellcheck source=helpers/repos-config.sh
+        source "${SCRIPT_DIR}/helpers/repos-config.sh"
+
+        local_clone=$(resolve_local_clone "${org}" "${repo}")
+
+        if [[ -n "${local_clone}" ]]; then
+            local wt_stderr wt_stdout
+            wt_stdout=$(mktemp)
+            # Redirect ordering matters: `2>&1 > file` first aliases stderr to
+            # the current stdout (the $(…) capture), then retargets stdout to
+            # file. Net: stderr is captured in $wt_stderr, JSON in $wt_stdout.
+            if wt_stderr=$("${SCRIPT_DIR}/pr-worktree.sh" provision \
+                "${org}" "${repo}" "${pr_number}" "${local_clone}" \
+                2>&1 > "${wt_stdout}"); then
+                # Read both fields in one jq pass via here-string so a
+                # malformed/empty stdout can't abort under `set -e`; the
+                # follow-up empty-check converts it to a diff-only fallback.
+                local wt_fields=""
+                wt_fields=$(jq -r '[.worktree_path // "", .ref // ""] | @tsv' \
+                    < "${wt_stdout}" 2> /dev/null) || wt_fields=""
+                IFS=$'\t' read -r worktree_path file_ref <<< "${wt_fields}"
+                if [[ -z "${worktree_path}" || -z "${file_ref}" ]]; then
+                    warning "Worktree provisioning returned invalid or incomplete metadata for ${org}/${repo}#${pr_number}; falling back to diff-only"
+                    worktree_path=""
+                    file_ref=""
+                fi
+            else
+                warning "Worktree provisioning failed for ${org}/${repo}#${pr_number}: ${wt_stderr}; falling back to diff-only"
+            fi
+            rm -f "${wt_stdout}"
+        else
+            warning "No local clone configured in repos.conf for ${org}/${repo}; diff-only review"
+        fi
+
         git_context=$(jq -n \
             --arg org "${org}" \
             --arg repo "${repo}" \
             --arg branch "${head_ref}" \
+            --arg working_dir "${worktree_path}" \
+            --arg clone "${local_clone}" \
             '{
                 org: $org,
                 repo: $repo,
                 branch: $branch,
                 commit: null,
-                working_dir: null,
-                has_changes: false
+                working_dir: (if $working_dir == "" then null else $working_dir end),
+                has_changes: false,
+                local_clone: (if $working_dir == "" or $clone == "" then null else $clone end)
             }')
     fi
 

--- a/skills/review-code/scripts/session-hooks/review-code-cleanup.sh
+++ b/skills/review-code/scripts/session-hooks/review-code-cleanup.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# review-code-cleanup.sh - Per-session cleanup hook for /review-code sessions.
+#
+# Invoked by session-manager.sh when a review-code session is being torn down.
+# Reads the session JSON, validates the stored worktree path, and asks
+# pr-worktree.sh to remove the worktree if one was provisioned.
+#
+# Usage: review-code-cleanup.sh <session-file>
+#
+# Exits 0 in all cases; cleanup hooks must never fail the session teardown.
+
+# Deliberately omit `-e`: a cleanup hook must never fail the session teardown.
+# Each guard below exits 0 on its own so errors can't cascade.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../helpers/worktree-layout.sh
+source "${SCRIPT_DIR}/../helpers/worktree-layout.sh"
+
+session_file="${1:-}"
+[[ -f "${session_file}" ]] || exit 0
+
+# Read the five worktree-related fields in one jq pass. Capturing via command
+# substitution + here-string (rather than `read < <(jq …)`) guarantees the read
+# cannot fail: a jq error on malformed JSON leaves jq_out empty and read
+# populates empty fields, instead of tripping `set -e` on an EOF return from
+# read.
+jq_out=""
+jq_out=$(jq -r '[.git.org // "", .git.repo // "", .pr.number // "",
+                .git.local_clone // "", .git.working_dir // ""] | @tsv' \
+    "${session_file}" 2> /dev/null) || jq_out=""
+
+IFS=$'\t' read -r wt_org wt_repo wt_pr wt_clone wt_path <<< "${jq_out}"
+
+# Nothing to do if any field is missing (diff-only review, or this review
+# didn't provision a worktree).
+[[ -n "${wt_org}" && -n "${wt_repo}" && -n "${wt_pr}" \
+    && -n "${wt_clone}" && -n "${wt_path}" ]] || exit 0
+
+# Validate wt_path before trusting it: the stored path must be absolute and end
+# with the expected <org>/<repo>/pr-<N> segments pr-worktree.sh wrote at
+# provision. This stops a corrupted session file from redirecting teardown
+# (which trusts REVIEW_CODE_WORKTREE_DIR) to an unrelated root.
+expected_leaf=$(worktree_leaf_for "${wt_org}" "${wt_repo}" "${wt_pr}")
+[[ "${wt_path}" == /* && "${wt_path}" == *"/${expected_leaf}" ]] || exit 0
+
+wt_root="${wt_path%/${expected_leaf}}"
+[[ -n "${wt_root}" ]] || exit 0
+
+wt_script="${SCRIPT_DIR}/../pr-worktree.sh"
+[[ -x "${wt_script}" ]] || exit 0
+
+REVIEW_CODE_WORKTREE_DIR="${wt_root}" \
+    "${wt_script}" teardown "${wt_org}" "${wt_repo}" "${wt_pr}" "${wt_clone}" \
+    > /dev/null 2>&1 || true
+
+exit 0

--- a/skills/review-code/scripts/session-manager.sh
+++ b/skills/review-code/scripts/session-manager.sh
@@ -204,32 +204,46 @@ session_cleanup() {
     command_name=$(sanitize_identifier "${command_name}") || return 1
 
     local command_dir="${SESSION_DIR}/${command_name}"
+    local session_file="${command_dir}/${session_id}.json"
+
+    # Give the command a chance to run per-session teardown (e.g. remove a
+    # provisioned worktree). Hooks are optional and keyed by command name; a
+    # missing or non-executable hook is silently skipped. The hook must not
+    # fail the cleanup, so all errors are swallowed.
+    local hook="$(dirname "${BASH_SOURCE[0]}")/session-hooks/${command_name}-cleanup.sh"
+    if [[ -f "${session_file}" && -x "${hook}" ]]; then
+        "${hook}" "${session_file}" > /dev/null 2>&1 || true
+    fi
 
     # Remove session file and metadata
-    rm -f "${command_dir}/${session_id}.json"
+    rm -f "${session_file}"
     rm -f "${command_dir}/${session_id}.meta.json"
 }
 
 # Cleanup old sessions (older than 1 hour)
 # Args: $1 = command name (optional, if not provided cleans all commands)
+# Routes each stale session through session_cleanup so per-session teardown
+# (e.g. worktree removal) runs. Meta files have no per-session teardown so
+# they're swept separately with find -delete.
 session_cleanup_old() {
     local command_name="${1:-}"
 
+    local search_dir
     if [[ -z "${command_name}" ]]; then
-        # Cleanup all commands
-        find "${SESSION_DIR}" -name "*.json" -type f -mmin +60 -delete 2> /dev/null || true
-        find "${SESSION_DIR}" -name "*.meta.json" -type f -mmin +60 -delete 2> /dev/null || true
+        search_dir="${SESSION_DIR}"
     else
-        # Sanitize command name
         command_name=$(sanitize_identifier "${command_name}") || return 1
-
-        # Cleanup specific command
-        local command_dir="${SESSION_DIR}/${command_name}"
-        if [[ -d "${command_dir}" ]]; then
-            find "${command_dir}" -name "*.json" -type f -mmin +60 -delete 2> /dev/null || true
-            find "${command_dir}" -name "*.meta.json" -type f -mmin +60 -delete 2> /dev/null || true
-        fi
+        search_dir="${SESSION_DIR}/${command_name}"
+        [[ -d "${search_dir}" ]] || return 0
     fi
+
+    local stale_file session_id
+    while IFS= read -r -d '' stale_file; do
+        session_id=$(basename "${stale_file}" .json)
+        session_cleanup "${session_id}" 2> /dev/null || true
+    done < <(find "${search_dir}" -name "*.json" -not -name "*.meta.json" -type f -mmin +60 -print0 2> /dev/null)
+
+    find "${search_dir}" -name "*.meta.json" -type f -mmin +60 -delete 2> /dev/null || true
 }
 
 # List active sessions for a command

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -1,0 +1,254 @@
+#!/usr/bin/env bats
+# Tests for scripts/pr-worktree.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/pr-worktree.sh"
+    export PROJECT_ROOT SCRIPT
+
+    TEST_DIR=$(mktemp -d)
+    BARE_ORIGIN="$TEST_DIR/origin.git"
+    CLONE_DIR="$TEST_DIR/clone"
+    WORKTREE_ROOT="$TEST_DIR/worktrees"
+
+    git init --bare --quiet "$BARE_ORIGIN"
+
+    # Seed the bare origin with a commit on main and a PR ref.
+    local seed="$TEST_DIR/seed"
+    git init --quiet "$seed"
+    git -C "$seed" config commit.gpgsign false
+    git -C "$seed" config user.email "test@example.com"
+    git -C "$seed" config user.name "Test User"
+    echo "hello" > "$seed/file.txt"
+    git -C "$seed" add file.txt
+    git -C "$seed" commit --quiet -m "initial"
+    git -C "$seed" branch -M main
+    git -C "$seed" remote add origin "$BARE_ORIGIN"
+    git -C "$seed" push --quiet origin main
+
+    # Simulate a PR: a second commit pushed to refs/pull/42/head
+    echo "world" >> "$seed/file.txt"
+    git -C "$seed" commit --quiet -am "pr commit"
+    git -C "$seed" push --quiet origin "HEAD:refs/pull/42/head"
+    rm -rf "$seed"
+
+    # The user's local clone of the origin.
+    git clone --quiet "$BARE_ORIGIN" "$CLONE_DIR"
+    git -C "$CLONE_DIR" config commit.gpgsign false
+    git -C "$CLONE_DIR" config user.email "test@example.com"
+    git -C "$CLONE_DIR" config user.name "Test User"
+
+    export REVIEW_CODE_WORKTREE_DIR="$WORKTREE_ROOT"
+    export TEST_DIR BARE_ORIGIN CLONE_DIR WORKTREE_ROOT
+}
+
+teardown() {
+    # Best-effort cleanup: remove any registered worktrees first, then the tmp.
+    if [[ -d "$CLONE_DIR" ]]; then
+        git -C "$CLONE_DIR" worktree list --porcelain 2> /dev/null \
+            | awk '/^worktree / { print substr($0, 10) }' \
+            | while read -r wt; do
+                [[ "$wt" = "$CLONE_DIR" ]] && continue
+                git -C "$CLONE_DIR" worktree remove --force "$wt" > /dev/null 2>&1 || true
+            done
+    fi
+    rm -rf "$TEST_DIR"
+}
+
+# =============================================================================
+# provision
+# =============================================================================
+
+@test "pr-worktree provision: creates worktree and outputs JSON" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+
+    # Output is valid JSON with both fields.
+    echo "$output" | jq -e '.worktree_path and .ref' > /dev/null
+
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+    local ref
+    ref=$(echo "$output" | jq -r '.ref')
+
+    [ "$ref" = "refs/review-code/pr/42" ]
+    [ -d "$wt_path" ]
+    [ -f "$wt_path/file.txt" ]
+
+    # Ref is registered in the clone.
+    run git -C "$CLONE_DIR" rev-parse --verify "$ref"
+    [ "$status" -eq 0 ]
+
+    # Worktree is registered.
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" == *"$wt_path"* ]]
+}
+
+@test "pr-worktree provision: is idempotent on second invocation" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local first_path
+    first_path=$(echo "$output" | jq -r '.worktree_path')
+
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local second_path
+    second_path=$(echo "$output" | jq -r '.worktree_path')
+
+    [ "$first_path" = "$second_path" ]
+    [ -d "$second_path" ]
+}
+
+@test "pr-worktree provision: rejects non-numeric PR number" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>&1" _ myorg myrepo notanumber "$CLONE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid PR number"* ]]
+}
+
+@test "pr-worktree provision: rejects non-git-repo local clone" {
+    local bogus="$TEST_DIR/not-a-repo"
+    mkdir -p "$bogus"
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>&1" _ myorg myrepo 42 "$bogus"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Not a git repo"* ]]
+}
+
+@test "pr-worktree provision: fails when PR ref is absent from origin" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>&1" _ myorg myrepo 999 "$CLONE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Fetch failed"* ]]
+}
+
+@test "pr-worktree provision: rejects org with path traversal" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>&1" _ ".." myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid org"* ]]
+}
+
+@test "pr-worktree provision: rejects repo with slashes" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>&1" _ myorg "bad/repo" 42 "$CLONE_DIR"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid repo"* ]]
+}
+
+@test "pr-worktree provision: updates worktree when PR ref moves" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+
+    # Author pushes a new commit to refs/pull/42/head.
+    local seed2="$TEST_DIR/seed2"
+    git clone --quiet "$BARE_ORIGIN" "$seed2"
+    git -C "$seed2" config commit.gpgsign false
+    git -C "$seed2" config user.email "test@example.com"
+    git -C "$seed2" config user.name "Test User"
+    git -C "$seed2" fetch --quiet origin "refs/pull/42/head:pr42"
+    git -C "$seed2" checkout --quiet pr42
+    echo "newer" >> "$seed2/file.txt"
+    git -C "$seed2" commit --quiet -am "second pr commit"
+    git -C "$seed2" push --quiet origin "HEAD:refs/pull/42/head"
+    rm -rf "$seed2"
+
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    grep -q "newer" "$wt_path/file.txt"
+}
+
+@test "pr-worktree provision: falls back to unfiltered fetch when --filter=blob:none fails" {
+    # Wrap `git` via PATH so fetches that include --filter=blob:none fail, but
+    # every other git invocation (including the retry without --filter) passes
+    # through to the real git. This pins the fallback branch in pr-worktree.sh
+    # that the happy-path test doesn't exercise.
+    local fake_bin="$TEST_DIR/bin"
+    local real_git
+    real_git=$(command -v git)
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/git" << EOF
+#!/usr/bin/env bash
+for arg in "\$@"; do
+    if [[ "\$arg" == "--filter=blob:none" ]]; then
+        echo "fake git: rejecting --filter=blob:none" >&2
+        exit 128
+    fi
+done
+exec "$real_git" "\$@"
+EOF
+    chmod +x "$fake_bin/git"
+
+    PATH="$fake_bin:$PATH" run "$SCRIPT" provision myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Partial-clone fetch failed"* ]]
+
+    # Worktree was created, so the unfiltered-fetch fallback succeeded.
+    local canonical_root
+    canonical_root=$(cd "$WORKTREE_ROOT" && pwd -P)
+    [ -f "$canonical_root/myorg/myrepo/pr-42/file.txt" ]
+}
+
+@test "pr-worktree provision: recovers when reused worktree has dirty files" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+
+    # Simulate a crashed prior review: edit a tracked file in the worktree.
+    echo "stale in-progress edit" > "$wt_path/file.txt"
+
+    # Push a new commit so reuse must actually do a checkout.
+    local seed3="$TEST_DIR/seed3"
+    git clone --quiet "$BARE_ORIGIN" "$seed3"
+    git -C "$seed3" config commit.gpgsign false
+    git -C "$seed3" config user.email "test@example.com"
+    git -C "$seed3" config user.name "Test User"
+    git -C "$seed3" fetch --quiet origin "refs/pull/42/head:pr42"
+    git -C "$seed3" checkout --quiet pr42
+    echo "post-crash" >> "$seed3/file.txt"
+    git -C "$seed3" commit --quiet -am "third pr commit"
+    git -C "$seed3" push --quiet origin "HEAD:refs/pull/42/head"
+    rm -rf "$seed3"
+
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+
+    # Worktree now reflects the PR ref, not the dirty edit.
+    [ ! "$(cat "$wt_path/file.txt")" = "stale in-progress edit" ]
+    grep -q "post-crash" "$wt_path/file.txt"
+}
+
+# =============================================================================
+# teardown
+# =============================================================================
+
+@test "pr-worktree teardown: removes registered worktree" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+    [ -d "$wt_path" ]
+
+    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" != *"$wt_path"* ]]
+}
+
+@test "pr-worktree teardown: no-op when worktree already absent" {
+    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# path layout
+# =============================================================================
+
+@test "pr-worktree provision: path layout follows worktree_path_for convention" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ MyOrg MyRepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path canonical_root
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+    canonical_root=$(cd "$WORKTREE_ROOT" && pwd -P)
+    [ "$wt_path" = "$canonical_root/myorg/myrepo/pr-42" ]
+}

--- a/tests/unit/test-repos-config.bats
+++ b/tests/unit/test-repos-config.bats
@@ -1,0 +1,263 @@
+#!/usr/bin/env bats
+# Tests for helpers/repos-config.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HELPER="$PROJECT_ROOT/skills/review-code/scripts/helpers/repos-config.sh"
+    export PROJECT_ROOT HELPER
+
+    TEST_DIR=$(mktemp -d)
+    # Isolate from the real home so the default repos.conf location
+    # (~/.claude/skills/review-code/repos.conf) doesn't bleed into tests.
+    export HOME="$TEST_DIR/fakehome"
+    mkdir -p "$HOME"
+
+    CLONE_DIR="$TEST_DIR/myclone"
+    git init --quiet "$CLONE_DIR"
+    git -C "$CLONE_DIR" config commit.gpgsign false
+    git -C "$CLONE_DIR" config user.email "test@example.com"
+    git -C "$CLONE_DIR" config user.name "Test User"
+
+    BARE_DIR="$TEST_DIR/mybare.git"
+    git init --bare --quiet "$BARE_DIR"
+
+    CONF_DIR="$TEST_DIR/conf"
+    mkdir -p "$CONF_DIR"
+    cat > "$CONF_DIR/repos.conf" << EOF
+# comment line
+posthog/posthog  $CLONE_DIR
+someorg/bareone  $BARE_DIR
+
+MixedCase/MixedRepo   $CLONE_DIR
+missing/path     /does/not/exist
+EOF
+
+    export TEST_DIR CLONE_DIR BARE_DIR CONF_DIR
+    unset REVIEW_CODE_CONFIG_DIR || true
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+run_resolve() {
+    # shellcheck source=/dev/null
+    source "$HELPER"
+    resolve_local_clone "$@"
+}
+
+run_find() {
+    # shellcheck source=/dev/null
+    source "$HELPER"
+    find_repos_config
+}
+
+# =============================================================================
+# resolve_local_clone
+# =============================================================================
+
+@test "resolve_local_clone: returns path for configured non-bare repo" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve posthog posthog)
+    [ "$result" = "$CLONE_DIR" ]
+}
+
+@test "resolve_local_clone: returns path for configured bare repo" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve someorg bareone)
+    [ "$result" = "$BARE_DIR" ]
+}
+
+@test "resolve_local_clone: returns empty for missing key" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve nosuch repo)
+    [ -z "$result" ]
+}
+
+@test "resolve_local_clone: ignores comments and blank lines" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve posthog posthog)
+    [ "$result" = "$CLONE_DIR" ]
+}
+
+@test "resolve_local_clone: case-insensitive match on config entries" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve mixedcase mixedrepo)
+    [ "$result" = "$CLONE_DIR" ]
+}
+
+@test "resolve_local_clone: returns empty when configured path is not a git repo" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve missing path)
+    [ -z "$result" ]
+}
+
+@test "resolve_local_clone: expands leading tilde" {
+    local suffix="rc-test-$$-$RANDOM"
+    local homed="$HOME/$suffix"
+    git init --quiet "$homed"
+
+    cat > "$CONF_DIR/repos.conf" << EOF
+tilde/repo  ~/$suffix
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve tilde repo)
+    rm -rf "$homed"
+    [ "$result" = "$homed" ]
+}
+
+@test "resolve_local_clone: empty org or repo arg returns empty" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve "" "")
+    [ -z "$result" ]
+}
+
+# =============================================================================
+# find_repos_config
+# =============================================================================
+
+@test "find_repos_config: REVIEW_CODE_CONFIG_DIR wins" {
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    cd "$TEST_DIR"
+    result=$(run_find)
+    [ "$result" = "$CONF_DIR/repos.conf" ]
+}
+
+@test "find_repos_config: falls back to ~/.claude/skills/review-code/repos.conf" {
+    local default_dir="$HOME/.claude/skills/review-code"
+    mkdir -p "$default_dir"
+    cp "$CONF_DIR/repos.conf" "$default_dir/repos.conf"
+    result=$(run_find)
+    [ "$result" = "$default_dir/repos.conf" ]
+}
+
+@test "find_repos_config: REVIEW_CODE_CONFIG_DIR wins over the default location" {
+    local default_dir="$HOME/.claude/skills/review-code"
+    mkdir -p "$default_dir"
+    echo "# default file" > "$default_dir/repos.conf"
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_find)
+    [ "$result" = "$CONF_DIR/repos.conf" ]
+}
+
+@test "find_repos_config: returns empty when nothing found" {
+    # No REVIEW_CODE_CONFIG_DIR, no default file under the fake HOME.
+    result=$(run_find || true)
+    [ -z "$result" ]
+}
+
+@test "find_repos_config: REVIEW_CODE_CONFIG_DIR without a repos.conf does not fall back to the default" {
+    # If the override points at a directory with no repos.conf, treat the
+    # override as an explicit commitment and return nothing. Otherwise a
+    # typo'd override would silently read the host's real config.
+    local default_dir="$HOME/.claude/skills/review-code"
+    mkdir -p "$default_dir"
+    echo "# default file" > "$default_dir/repos.conf"
+
+    local empty_dir="$TEST_DIR/empty-override"
+    mkdir -p "$empty_dir"
+    export REVIEW_CODE_CONFIG_DIR="$empty_dir"
+
+    result=$(run_find || true)
+    [ -z "$result" ]
+}
+
+# =============================================================================
+# Bare-repo detection
+# =============================================================================
+
+@test "resolve_local_clone: rejects dir with objects/ but no HEAD" {
+    local fake="$TEST_DIR/fake-bare"
+    mkdir -p "$fake/objects"
+    cat > "$CONF_DIR/repos.conf" << EOF
+fake/bare  $fake
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve fake bare)
+    [ -z "$result" ]
+}
+
+@test "resolve_local_clone: accepts dir with both objects/ and HEAD" {
+    local fake="$TEST_DIR/fake-bare-head"
+    mkdir -p "$fake/objects"
+    touch "$fake/HEAD"
+    cat > "$CONF_DIR/repos.conf" << EOF
+fake/bare  $fake
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve fake bare)
+    [ "$result" = "$fake" ]
+}
+
+@test "resolve_local_clone: accepts worktree-style repo where .git is a file" {
+    local worktree="$TEST_DIR/worktree-repo"
+    local gitdir="$TEST_DIR/worktree-gitdir"
+    mkdir -p "$worktree" "$gitdir/objects"
+    printf 'ref: refs/heads/main\n' > "$gitdir/HEAD"
+    printf 'gitdir: %s\n' "$gitdir" > "$worktree/.git"
+    cat > "$CONF_DIR/repos.conf" << EOF
+fake/worktree  $worktree
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve fake worktree)
+    [ "$result" = "$worktree" ]
+}
+
+@test "resolve_local_clone: accepts worktree whose gitdir uses commondir instead of objects" {
+    local worktree="$TEST_DIR/linked-worktree"
+    local gitdir="$TEST_DIR/linked-gitdir"
+    mkdir -p "$worktree" "$gitdir"
+    printf 'ref: refs/heads/main\n' > "$gitdir/HEAD"
+    printf '%s\n' "$TEST_DIR/shared.git" > "$gitdir/commondir"
+    printf 'gitdir: %s\n' "$gitdir" > "$worktree/.git"
+    cat > "$CONF_DIR/repos.conf" << EOF
+fake/linked  $worktree
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve fake linked)
+    [ "$result" = "$worktree" ]
+}
+
+@test "resolve_local_clone: rejects .git file with stale gitdir pointer" {
+    local worktree="$TEST_DIR/stale-worktree"
+    mkdir -p "$worktree"
+    printf 'gitdir: %s/does-not-exist\n' "$TEST_DIR" > "$worktree/.git"
+    cat > "$CONF_DIR/repos.conf" << EOF
+fake/stale  $worktree
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve fake stale)
+    [ -z "$result" ]
+}
+
+@test "resolve_local_clone: rejects relative paths" {
+    cat > "$CONF_DIR/repos.conf" << EOF
+rel/path  some/relative/repo
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    result=$(run_resolve rel path)
+    [ -z "$result" ]
+}
+
+@test "resolve_local_clone: ignores malformed single-token line" {
+    cat > "$CONF_DIR/repos.conf" << EOF
+onlyname
+posthog/posthog  $CLONE_DIR
+EOF
+    export REVIEW_CODE_CONFIG_DIR="$CONF_DIR"
+    # Good entry after the malformed line still resolves.
+    result=$(run_resolve posthog posthog)
+    [ "$result" = "$CLONE_DIR" ]
+}
+
+@test "find_repos_config: exits 1 when nothing found" {
+    unset REVIEW_CODE_CONFIG_DIR
+    (
+        # shellcheck disable=SC1090
+        source "$HELPER"
+        if find_repos_config > /dev/null; then
+            echo "expected non-zero exit"
+            exit 2
+        fi
+    )
+}

--- a/tests/unit/test-review-orchestrator.bats
+++ b/tests/unit/test-review-orchestrator.bats
@@ -57,6 +57,82 @@ teardown() {
     echo "$output" | jq -e '.status == "ready"'
 }
 
+# Shape-only tests for the jq expression that handle_pr_review uses to build
+# the cross-repo git_context. These invoke the jq expression directly rather
+# than handle_pr_review itself (which needs a gh stub), so they catch typos
+# in the expression but will not catch refactors that replace the expression
+# with different source logic. A true integration test would stub
+# pr-context.sh + pr-worktree.sh and drive handle_pr_review end-to-end.
+
+@test "build_git_context jq expression: emits nulls when no worktree and no clone" {
+    run jq -n \
+        --arg org "otherorg" \
+        --arg repo "otherrepo" \
+        --arg branch "feature" \
+        --arg working_dir "" \
+        --arg clone "" \
+        '{
+            org: $org,
+            repo: $repo,
+            branch: $branch,
+            commit: null,
+            working_dir: (if $working_dir == "" then null else $working_dir end),
+            has_changes: false,
+            local_clone: (if $working_dir == "" or $clone == "" then null else $clone end)
+        }'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.working_dir == null' > /dev/null
+    echo "$output" | jq -e '.local_clone == null' > /dev/null
+    echo "$output" | jq -e '.has_changes == false' > /dev/null
+    echo "$output" | jq -e '.commit == null' > /dev/null
+    echo "$output" | jq -e '.org == "otherorg"' > /dev/null
+}
+
+@test "build_git_context jq expression: populates working_dir and local_clone when worktree is provisioned" {
+    run jq -n \
+        --arg org "otherorg" \
+        --arg repo "otherrepo" \
+        --arg branch "feature" \
+        --arg working_dir "/tmp/worktrees/otherorg/otherrepo/pr-42" \
+        --arg clone "/home/user/dev/otherorg/otherrepo" \
+        '{
+            org: $org,
+            repo: $repo,
+            branch: $branch,
+            commit: null,
+            working_dir: (if $working_dir == "" then null else $working_dir end),
+            has_changes: false,
+            local_clone: (if $working_dir == "" or $clone == "" then null else $clone end)
+        }'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.working_dir == "/tmp/worktrees/otherorg/otherrepo/pr-42"' > /dev/null
+    echo "$output" | jq -e '.local_clone == "/home/user/dev/otherorg/otherrepo"' > /dev/null
+}
+
+@test "build_git_context jq expression: nulls local_clone when clone is resolved but provisioning failed" {
+    # Pins the contract that local_clone signals a successfully provisioned
+    # worktree, not merely a configured clone. Aligns with handler docs in
+    # review.md which treat local_clone as a success signal.
+    run jq -n \
+        --arg org "otherorg" \
+        --arg repo "otherrepo" \
+        --arg branch "feature" \
+        --arg working_dir "" \
+        --arg clone "/home/user/dev/otherorg/otherrepo" \
+        '{
+            org: $org,
+            repo: $repo,
+            branch: $branch,
+            commit: null,
+            working_dir: (if $working_dir == "" then null else $working_dir end),
+            has_changes: false,
+            local_clone: (if $working_dir == "" or $clone == "" then null else $clone end)
+        }'
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.working_dir == null' > /dev/null
+    echo "$output" | jq -e '.local_clone == null' > /dev/null
+}
+
 @test "review-orchestrator.sh: local mode includes git context" {
     echo "change" > file.txt
     run "$PROJECT_ROOT/skills/review-code/scripts/review-orchestrator.sh"

--- a/tests/unit/test-session-manager.bats
+++ b/tests/unit/test-session-manager.bats
@@ -295,6 +295,159 @@ teardown() {
     [ -f "$path2" ]
 }
 
+# Set up a temp script dir containing copies of session-manager.sh, the real
+# review-code cleanup hook, the worktree-layout helper, and a stub
+# pr-worktree.sh that records its args and the REVIEW_CODE_WORKTREE_DIR env
+# var on each invocation. The hook is copied verbatim so the jq-based session
+# parsing and the <org>/<repo>/pr-<N> suffix validation are exercised. The
+# stub pr-worktree.sh replaces the real teardown logic so tests don't need a
+# live git clone. Exports STUB_SCRIPT_DIR and STUB_LOG so subsequent
+# `bash -c` blocks can source the copied session-manager.sh and inspect the
+# log via `cat "$STUB_LOG"`.
+_with_pr_worktree_stub() {
+    local script_tmp="$BATS_TEST_TMPDIR/scripts"
+    local stub_log="$BATS_TEST_TMPDIR/pr-worktree.log"
+    mkdir -p "$script_tmp/session-hooks" "$script_tmp/helpers"
+    cp "$PROJECT_ROOT/skills/review-code/scripts/session-manager.sh" "$script_tmp/"
+    cp "$PROJECT_ROOT/skills/review-code/scripts/session-hooks/review-code-cleanup.sh" \
+        "$script_tmp/session-hooks/"
+    cp "$PROJECT_ROOT/skills/review-code/scripts/helpers/worktree-layout.sh" \
+        "$script_tmp/helpers/"
+
+    cat > "$script_tmp/pr-worktree.sh" << EOF
+#!/usr/bin/env bash
+echo "args: \$*" >> "$stub_log"
+echo "env: REVIEW_CODE_WORKTREE_DIR=\${REVIEW_CODE_WORKTREE_DIR:-}" >> "$stub_log"
+EOF
+    chmod +x "$script_tmp/pr-worktree.sh"
+
+    export STUB_SCRIPT_DIR="$script_tmp"
+    export STUB_LOG="$stub_log"
+}
+
+@test "session_cleanup: invokes pr-worktree teardown with worktree root derived from wt_path" {
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        sid=$(session_init "review-code" "{
+            \"git\":{\"org\":\"o\",\"repo\":\"r\",\"local_clone\":\"/tmp/c\",\"working_dir\":\"/tmp/wtroot/o/r/pr-42\"},
+            \"pr\":{\"number\":\"42\"}
+        }")
+        session_cleanup "$sid"
+    '
+    [ -f "$STUB_LOG" ]
+    grep -q "^args: teardown o r 42 /tmp/c$" "$STUB_LOG"
+    # Worktree root must match the three-dirnames-up ancestor of wt_path so
+    # teardown operates on the same layout pr-worktree.sh used at provision.
+    grep -q "^env: REVIEW_CODE_WORKTREE_DIR=/tmp/wtroot$" "$STUB_LOG"
+}
+
+@test "session_cleanup: skips teardown when wt_path does not end with <org>/<repo>/pr-<N>" {
+    # Pins the leaf-validation guard: a corrupted session file cannot redirect
+    # teardown (which trusts REVIEW_CODE_WORKTREE_DIR) to an unrelated root.
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-mismatch" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-mismatch" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        sid=$(session_init "review-code" "{
+            \"git\":{\"org\":\"o\",\"repo\":\"r\",\"local_clone\":\"/tmp/c\",\"working_dir\":\"/tmp/attacker/a/b/pr-42\"},
+            \"pr\":{\"number\":\"42\"}
+        }")
+        session_cleanup "$sid"
+    '
+    [ ! -f "$STUB_LOG" ]
+}
+
+@test "session_cleanup: skips teardown when wt_path is relative" {
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-rel" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-rel" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        sid=$(session_init "review-code" "{
+            \"git\":{\"org\":\"o\",\"repo\":\"r\",\"local_clone\":\"/tmp/c\",\"working_dir\":\"rel/o/r/pr-42\"},
+            \"pr\":{\"number\":\"42\"}
+        }")
+        session_cleanup "$sid"
+    '
+    [ ! -f "$STUB_LOG" ]
+}
+
+@test "session_cleanup: deletes session file even when session JSON is malformed" {
+    # Regression guard: a jq failure inside the cleanup hook must not abort
+    # session_cleanup before the session file is removed. The read <<< variant
+    # in review-code-cleanup.sh isolates the hook from the parent set -e.
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-corrupt" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-corrupt" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        mkdir -p "$SESSION_DIR/review-code"
+        sid="review-code-$$-$(date +%s)"
+        printf "not-valid-json" > "$SESSION_DIR/review-code/$sid.json"
+        session_cleanup "$sid"
+        [ ! -f "$SESSION_DIR/review-code/$sid.json" ]
+    '
+    [ ! -f "$STUB_LOG" ]
+}
+
+@test "session_cleanup: skips teardown when worktree fields are absent" {
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub2" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub2" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        sid=$(session_init "review-code" "{\"git\":{\"org\":\"o\"}}")
+        session_cleanup "$sid"
+    '
+    [ ! -f "$STUB_LOG" ]
+}
+
+@test "session_cleanup: skips teardown for non-review-code sessions" {
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub3" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub3" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        sid=$(session_init "other-cmd" "{
+            \"git\":{\"org\":\"o\",\"repo\":\"r\",\"local_clone\":\"/tmp/c\",\"working_dir\":\"/tmp/w\"},
+            \"pr\":{\"number\":\"42\"}
+        }")
+        session_cleanup "$sid"
+    '
+    [ ! -f "$STUB_LOG" ]
+}
+
+@test "session_cleanup_old: routes stale review-code sessions through session_cleanup" {
+    _with_pr_worktree_stub
+
+    SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub4" \
+    CLAUDE_SESSION_DIR="$BATS_TEST_TMPDIR/test-sessions-stub4" \
+    bash -c '
+        source "'"$STUB_SCRIPT_DIR"'/session-manager.sh"
+        mkdir -p "$SESSION_DIR/review-code"
+        sid="review-code-1-1000000000"
+        echo "{\"git\":{\"org\":\"o\",\"repo\":\"r\",\"local_clone\":\"/tmp/c\",\"working_dir\":\"/tmp/wtroot/o/r/pr-42\"},\"pr\":{\"number\":\"42\"}}" \
+            > "$SESSION_DIR/review-code/$sid.json"
+        touch -t $(date -v-2H +%Y%m%d%H%M 2>/dev/null) "$SESSION_DIR/review-code/$sid.json" 2>/dev/null \
+            || touch -d "2 hours ago" "$SESSION_DIR/review-code/$sid.json" 2>/dev/null \
+            || exit 2
+        session_cleanup_old
+        [ ! -f "$SESSION_DIR/review-code/$sid.json" ]
+    ' || skip "Cannot set file timestamp"
+    [ -f "$STUB_LOG" ]
+    grep -q "^args: teardown o r 42 /tmp/c$" "$STUB_LOG"
+}
+
 # =============================================================================
 # session_cleanup_old tests
 # =============================================================================

--- a/tests/unit/test-worktree-layout.bats
+++ b/tests/unit/test-worktree-layout.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+# Tests for helpers/worktree-layout.sh - the single source of truth for the
+# PR worktree filesystem layout.
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    HELPER="$PROJECT_ROOT/skills/review-code/scripts/helpers/worktree-layout.sh"
+    export PROJECT_ROOT HELPER
+
+    # shellcheck source=../../skills/review-code/scripts/helpers/worktree-layout.sh
+    source "$HELPER"
+}
+
+@test "worktree_root: falls back to ~/.claude/skills/review-code/worktrees by default" {
+    unset REVIEW_CODE_WORKTREE_DIR
+    run worktree_root
+    [ "$status" -eq 0 ]
+    [ "$output" = "$HOME/.claude/skills/review-code/worktrees" ]
+}
+
+@test "worktree_root: honors REVIEW_CODE_WORKTREE_DIR" {
+    REVIEW_CODE_WORKTREE_DIR=/tmp/custom run worktree_root
+    [ "$output" = "/tmp/custom" ]
+}
+
+@test "worktree_leaf_for: lowercases org and repo" {
+    run worktree_leaf_for "Acme" "Widget" 42
+    [ "$output" = "acme/widget/pr-42" ]
+}
+
+@test "worktree_leaf_for: preserves PR number verbatim" {
+    run worktree_leaf_for "acme" "widget" 1234
+    [ "$output" = "acme/widget/pr-1234" ]
+}
+
+@test "worktree_path_for: joins root and leaf" {
+    REVIEW_CODE_WORKTREE_DIR=/tmp/wt run worktree_path_for "acme" "widget" 7
+    [ "$output" = "/tmp/wt/acme/widget/pr-7" ]
+}
+
+@test "worktree_layout_depth: reports 3 (one for each path segment)" {
+    run worktree_layout_depth
+    [ "$output" = "3" ]
+}


### PR DESCRIPTION
## Summary

- Reviews for PRs outside the current repo now provision a short-lived git worktree off a local clone, giving agents native `Read`/`Grep`/`Glob` access instead of falling back to diff-only.
- Adds `~/.claude/skills/review-code/repos.conf` as the opt-in mapping from `org/repo` to a local clone path. Without a mapping, reviews still work via diff-only (with a warning).
- Worktrees live under `~/.claude/skills/review-code/worktrees/<org>/<repo>/pr-<N>` and are torn down at session cleanup; crashed reviews get re-used on the next run, with a dirty-state recreate path as a fallback.
- Hardens input validation (org/repo name sanitization, rejecting relative paths in `repos.conf`) and factors shared repo-detection into `helpers/repo-detection.sh`.

## Test plan

- [ ] `bin/test` passes (new bats coverage for `pr-worktree.sh`, `repos-config.sh`, `session-manager.sh`, and the orchestrator's git_context emission).
- [ ] With `repos.conf` mapping `posthog/posthog` to a local clone, `/review-code <PR#>` from a different repo provisions a worktree and agents can read source files.
- [ ] Without any mapping, the same flow falls back to diff-only and prints a warning.
- [ ] Reviewing the same PR twice reuses the existing worktree; manually dirtying the worktree and reviewing again triggers the recreate path.
- [ ] `bin/setup` reports worktrees under the skill root (both active and orphan entries) without auto-deleting them.