### PR TITLE
Make review-code stack-aware for branch reviews

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -46,6 +46,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 - `--self` - Allow creating draft review on your own PR (for testing)
 - `--overwrite` - Replace existing review file without prompting
 - `--append` - Append to existing review file without prompting
+- `--parent <ref>` - Override the base branch used for branch / current-branch reviews. By default, branches with a recorded stack parent (Graphite or `branch.<name>.parent` in git config) review against that parent; use `--parent` to force a different base, e.g. `--parent main`.
 
 **Optional File Pattern:**
 

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -19,9 +19,19 @@ APPLY_MODE="false"
 LEARN_MODE="false"
 OVERWRITE_MODE="false"
 APPEND_MODE="false"
+PARENT_OVERRIDE=""
 remaining_args=()
+expect_value=""
 
 for arg_item in "$@"; do
+    if [[ -n "${expect_value}" ]]; then
+        case "${expect_value}" in
+            parent) PARENT_OVERRIDE="${arg_item}" ;;
+        esac
+        expect_value=""
+        continue
+    fi
+
     if [[ "${arg_item}" == "--force" ]] || [[ "${arg_item}" == "-f" ]]; then
         FORCE_MODE="true"
     elif [[ "${arg_item}" == "--draft" ]] || [[ "${arg_item}" == "-d" ]]; then
@@ -34,6 +44,10 @@ for arg_item in "$@"; do
         OVERWRITE_MODE="true"
     elif [[ "${arg_item}" == "--append" ]]; then
         APPEND_MODE="true"
+    elif [[ "${arg_item}" == "--parent" ]]; then
+        expect_value="parent"
+    elif [[ "${arg_item}" == --parent=* ]]; then
+        PARENT_OVERRIDE="${arg_item#--parent=}"
     else
         remaining_args+=("${arg_item}")
     fi
@@ -82,27 +96,71 @@ ref_exists() {
     git rev-parse --verify --quiet "${ref}" > /dev/null 2>&1
 }
 
-# Helper: Get base branch with smart fallback
-# Prefers origin/ refs (updated by fetch) over potentially-stale local branches.
-# When origin/HEAD is unavailable, picks the closest candidate by commit distance.
+# Helper: Echo origin/<ref> if it exists, else local <ref>, else nothing.
+prefer_remote_ref() {
+    local ref=$1
+    if ref_exists "origin/${ref}"; then
+        echo "origin/${ref}"
+    elif ref_exists "${ref}"; then
+        echo "${ref}"
+    fi
+}
+
+# Helper: Detect a stacked-branch parent for the given branch.
+# Echoes a usable ref (preferring origin/) or nothing when no stack parent is
+# recorded. Tries `gt parent` (current checkout only), then `git config
+# branch.<name>.parent`, which gt writes for tracked branches.
+# Args: $1 = branch name (or "HEAD" to mean the current branch)
+get_stack_parent() {
+    local branch="${1:-HEAD}"
+    local current
+    current=$(git symbolic-ref --quiet --short HEAD 2> /dev/null) || current=""
+    [[ "${branch}" == "HEAD" ]] && branch="${current}"
+    [[ -z "${branch}" ]] && return 0
+
+    local parent=""
+    if [[ "${current}" == "${branch}" ]] && command -v gt > /dev/null 2>&1; then
+        parent=$(gt parent 2> /dev/null | tr -d '[:space:]') || parent=""
+    fi
+    if [[ -z "${parent}" ]]; then
+        parent=$(git config --get "branch.${branch}.parent" 2> /dev/null) || parent=""
+    fi
+
+    [[ -z "${parent}" || "${parent}" == "${branch}" ]] && return 0
+
+    # Trunk should resolve through the default-branch logic, not through here.
+    local default_branch_name
+    default_branch_name=$(git symbolic-ref refs/remotes/origin/HEAD 2> /dev/null | sed 's@^refs/remotes/origin/@@')
+    [[ -n "${default_branch_name}" && "${parent}" == "${default_branch_name}" ]] && return 0
+
+    prefer_remote_ref "${parent}"
+}
+
+# Helper: Get base branch with smart fallback.
+# When the target branch sits on a stack, prefers its recorded parent so the
+# review diff matches the eventual PR. Otherwise prefers origin/ refs (updated
+# by fetch) over potentially-stale local branches, and when origin/HEAD is
+# unavailable picks the closest trunk candidate by commit distance.
 # Args: $1 (optional) = target ref for distance calculation (default: HEAD)
 get_base_branch() {
     local target_ref="${1:-HEAD}"
-    # Get the default branch name from remote origin/HEAD
+
+    # Stack-aware: prefer a recorded parent over trunk.
+    local stack_parent
+    stack_parent=$(get_stack_parent "${target_ref}")
+    if [[ -n "${stack_parent}" ]]; then
+        echo "${stack_parent}"
+        return 0
+    fi
+
     local default_branch_name
     default_branch_name=$(git symbolic-ref refs/remotes/origin/HEAD 2> /dev/null | sed 's@^refs/remotes/origin/@@')
 
-    # If we got a default branch name, try to use it
     if [[ -n "${default_branch_name}" ]]; then
-        # Prefer remote tracking branch (most up-to-date via fetch)
-        if ref_exists "origin/${default_branch_name}"; then
-            echo "origin/${default_branch_name}"
-            return 0
-        fi
-
-        # Fall back to local branch
-        if ref_exists "${default_branch_name}"; then
-            echo "${default_branch_name}"
+        local resolved
+        resolved=$(prefer_remote_ref "${default_branch_name}")
+        if [[ -n "${resolved}" ]]; then
+            echo "${resolved}"
             return 0
         fi
     fi
@@ -130,6 +188,16 @@ get_base_branch() {
 
     # Last resort: just return "main" and let caller handle the error
     echo "main"
+}
+
+# Helper: Resolve the base branch, honoring an explicit --parent override.
+# Args: $1 (optional) = target ref forwarded to get_base_branch
+resolve_base_branch() {
+    if [[ -n "${PARENT_OVERRIDE:-}" ]]; then
+        echo "${PARENT_OVERRIDE}"
+        return 0
+    fi
+    get_base_branch "$@"
 }
 
 # Helper: Build JSON output with optional file_pattern and find_mode
@@ -231,6 +299,18 @@ validate_apply_mode() {
 validate_overwrite_append_mode() {
     if [[ "${OVERWRITE_MODE}" == "true" ]] && [[ "${APPEND_MODE}" == "true" ]]; then
         build_json_error "--overwrite and --append are mutually exclusive. Use one or the other."
+        exit 1
+    fi
+}
+
+# Helper: Validate --parent received a real value, not a missing arg or another flag
+validate_parent_override() {
+    if [[ -n "${expect_value}" ]]; then
+        build_json_error "--parent requires a value (e.g. --parent main)"
+        exit 1
+    fi
+    if [[ -n "${PARENT_OVERRIDE}" && "${PARENT_OVERRIDE}" == --* ]]; then
+        build_json_error "--parent requires a value (got '${PARENT_OVERRIDE}')"
         exit 1
     fi
 }
@@ -361,7 +441,7 @@ detect_git_ref() {
     fi
 
     local base_branch
-    base_branch=$(get_base_branch "${arg}")
+    base_branch=$(resolve_base_branch "${arg}")
 
     # Handle non-ambiguous cases first
     if [[ "${is_branch}" == "true" ]] && [[ "${is_current}" == "false" ]]; then
@@ -397,7 +477,7 @@ detect_no_arg() {
         current_branch=$(git rev-parse --short HEAD 2> /dev/null || echo "unknown")
     fi
     local base_branch
-    base_branch=$(get_base_branch)
+    base_branch=$(resolve_base_branch)
 
     # Check for uncommitted changes
     local has_uncommitted=false
@@ -514,6 +594,9 @@ detect_no_arg() {
 
 # Main execution (only run if script is executed directly, not sourced)
 if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+    # Validate --parent received a real value
+    validate_parent_override
+
     # Validate --apply flag is only used with learn mode (early check)
     validate_apply_mode
 

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -20,6 +20,7 @@ LEARN_MODE="false"
 OVERWRITE_MODE="false"
 APPEND_MODE="false"
 PARENT_OVERRIDE=""
+PARENT_FLAG_SEEN="false"
 remaining_args=()
 expect_value=""
 
@@ -45,8 +46,10 @@ for arg_item in "$@"; do
     elif [[ "${arg_item}" == "--append" ]]; then
         APPEND_MODE="true"
     elif [[ "${arg_item}" == "--parent" ]]; then
+        PARENT_FLAG_SEEN="true"
         expect_value="parent"
     elif [[ "${arg_item}" == --parent=* ]]; then
+        PARENT_FLAG_SEEN="true"
         PARENT_OVERRIDE="${arg_item#--parent=}"
     else
         remaining_args+=("${arg_item}")
@@ -303,9 +306,14 @@ validate_overwrite_append_mode() {
     fi
 }
 
-# Helper: Validate --parent received a real value, not a missing arg or another flag
+# Helper: Validate --parent received a real value, not a missing arg, empty
+# string, or another flag.
 validate_parent_override() {
     if [[ -n "${expect_value}" ]]; then
+        build_json_error "--parent requires a value (e.g. --parent main)"
+        exit 1
+    fi
+    if [[ "${PARENT_FLAG_SEEN}" == "true" && -z "${PARENT_OVERRIDE}" ]]; then
         build_json_error "--parent requires a value (e.g. --parent main)"
         exit 1
     fi

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -833,3 +833,185 @@ reset_globals() {
     [ "$status" -eq 0 ]
     [ "$output" = "master" ]
 }
+
+# =============================================================================
+# get_stack_parent tests
+# =============================================================================
+
+@test "get_stack_parent: returns nothing when no parent recorded" {
+    setup_test_git_repo
+
+    git checkout -q -b feature-a
+    echo "a" > a.txt && git add a.txt && git commit -q -m "A"
+
+    run get_stack_parent feature-a
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "get_stack_parent: reads branch.<name>.parent and prefers origin/ ref" {
+    setup_test_git_repo
+
+    git checkout -q -b parent-branch
+    echo "p" > p.txt && git add p.txt && git commit -q -m "P"
+    git update-ref refs/remotes/origin/parent-branch HEAD
+
+    git checkout -q -b child-branch
+    echo "c" > c.txt && git add c.txt && git commit -q -m "C"
+    git config branch.child-branch.parent parent-branch
+
+    # Run from main to ensure we're not querying gt about the current branch.
+    git checkout -q main
+    run get_stack_parent child-branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/parent-branch" ]
+}
+
+@test "get_stack_parent: falls back to local ref when origin/<parent> missing" {
+    setup_test_git_repo
+
+    git checkout -q -b parent-only-local
+    echo "p" > p.txt && git add p.txt && git commit -q -m "P"
+
+    git checkout -q -b child
+    git config branch.child.parent parent-only-local
+
+    git checkout -q main
+    run get_stack_parent child
+    [ "$status" -eq 0 ]
+    [ "$output" = "parent-only-local" ]
+}
+
+@test "get_stack_parent: ignores parent when it equals the trunk" {
+    setup_test_git_repo
+
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    git checkout -q -b feature
+    git config branch.feature.parent main
+
+    run get_stack_parent feature
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "get_stack_parent: ignores self-referential parent" {
+    setup_test_git_repo
+
+    git checkout -q -b loopy
+    git config branch.loopy.parent loopy
+
+    run get_stack_parent loopy
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+# =============================================================================
+# get_base_branch + stack parent integration
+# =============================================================================
+
+@test "get_base_branch: returns stack parent when target branch has one" {
+    setup_test_git_repo
+
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    git checkout -q -b parent-branch
+    echo "p" > p.txt && git add p.txt && git commit -q -m "P"
+    git update-ref refs/remotes/origin/parent-branch HEAD
+
+    git checkout -q -b child-branch
+    echo "c" > c.txt && git add c.txt && git commit -q -m "C"
+    git config branch.child-branch.parent parent-branch
+
+    git checkout -q main
+    run get_base_branch child-branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/parent-branch" ]
+}
+
+@test "get_base_branch: falls through to trunk when parent equals default branch" {
+    setup_test_git_repo
+
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    git checkout -q -b feature
+    git config branch.feature.parent main
+
+    run get_base_branch feature
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/main" ]
+}
+
+# =============================================================================
+# resolve_base_branch / --parent override
+# =============================================================================
+
+@test "resolve_base_branch: PARENT_OVERRIDE wins over computed base" {
+    setup_test_git_repo
+
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    git checkout -q -b feature
+    git config branch.feature.parent main
+
+    PARENT_OVERRIDE="origin/some-other-branch"
+    run resolve_base_branch feature
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/some-other-branch" ]
+}
+
+@test "resolve_base_branch: empty PARENT_OVERRIDE delegates to get_base_branch" {
+    setup_test_git_repo
+
+    git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    PARENT_OVERRIDE=""
+    run resolve_base_branch
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/main" ]
+}
+
+# =============================================================================
+# --parent flag parsing
+# =============================================================================
+
+@test "--parent: PARENT_OVERRIDE empty by default" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh"
+    [ "$PARENT_OVERRIDE" = "" ]
+}
+
+@test "--parent: separate-token form sets PARENT_OVERRIDE" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--parent" "main" "feature"
+    [ "$PARENT_OVERRIDE" = "main" ]
+    [ "$arg" = "feature" ]
+}
+
+@test "--parent: equals form sets PARENT_OVERRIDE" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--parent=origin/feat-x" "feature"
+    [ "$PARENT_OVERRIDE" = "origin/feat-x" ]
+    [ "$arg" = "feature" ]
+}
+
+@test "--parent: combines with --force" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--force" "--parent" "main" "feature"
+    [ "$FORCE_MODE" = "true" ]
+    [ "$PARENT_OVERRIDE" = "main" ]
+    [ "$arg" = "feature" ]
+}
+
+@test "--parent: rejects flag-looking value via main script" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --parent --force feature 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--parent requires a value"* ]]
+}
+
+@test "--parent: rejects missing trailing value via main script" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --parent 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--parent requires a value"* ]]
+}

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -1015,3 +1015,15 @@ reset_globals() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"--parent requires a value"* ]]
 }
+
+@test "--parent: rejects empty value via equals form" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --parent= feature 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--parent requires a value"* ]]
+}
+
+@test "--parent: rejects empty quoted value via separate-token form" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --parent '' feature 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--parent requires a value"* ]]
+}


### PR DESCRIPTION
## Summary

When `/review-code` reviews a branch (with no arg, or `/review-code <branch>`), it now diffs against the branch's recorded stack parent if one exists, instead of always diffing against trunk. The review then covers just the slice that will become its own PR — matching what tools like Graphite produce.

Before: on a stack `main → feature-a → feature-b`, `/review-code feature-b` diffed `origin/main..feature-b` (both `feature-a`'s and `feature-b`'s commits).
After: same invocation diffs `origin/feature-a..feature-b` (just `feature-b`'s commits).

PR-mode reviews (`/review-code <PR#>`) are unchanged — they already use `baseRefName` from the GitHub PR, which Graphite sets correctly.

## Behavior

`get_stack_parent` checks two sources in order:

1. `gt parent` (only when querying the current checkout — gt's CLI doesn't take a branch arg).
2. `git config branch.<name>.parent` (gt writes this for tracked branches, and several other stack tools use it too).

Trunk parents are ignored so the existing default-branch logic still produces `origin/main`. Parents that resolve to nothing (e.g. unpushed local-only) fall back to trunk.

## --parent override

New flag for explicit control:

- `/review-code feature-b --parent main` — review against trunk regardless of recorded parent.
- `/review-code feature-b --parent origin/feature-a` — review against an arbitrary ref.

`--parent` validation rejects missing values and flag-looking values (`--parent --force feature-b` errors instead of silently consuming `--force`).

## Test plan

- [x] Existing 808 tests still green.
- [x] 14 new unit tests covering `get_stack_parent`, `get_base_branch` integration, `resolve_base_branch` override, and `--parent` flag parsing (including rejection cases).
- [x] `bin/fmt`, `bin/lint`, full `bin/test` suite (1254 tests) all green.
- [ ] Manual: run `/review-code` on a branch with `branch.<name>.parent` set in git config; confirm the review banner shows the parent ref, not `origin/main`.
- [ ] Manual: run `/review-code <branch> --parent main`; confirm the override wins.