### PR TITLE
Add --fix flag to /review-code

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ The `learn` subcommand analyzes outcomes of past PR reviews (what was acted on, 
 - `--force` / `-f` — Skip the pre-flight context clear prompt.
 - `--overwrite` — Replace an existing review file without prompting.
 - `--append` — Append to an existing review file without prompting.
+- `--fix` — After the review, apply fixes for findings the agent can resolve cleanly. Edits the working tree directly; the Fix Summary section in the saved review lists anything skipped and any judgment calls made. Not compatible with `learn` or `find`.
 
 ### Filter by File Pattern
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -46,6 +46,7 @@ Run specialized code review agent(s) with comprehensive context on local changes
 - `--self` - Allow creating draft review on your own PR (for testing)
 - `--overwrite` - Replace existing review file without prompting
 - `--append` - Append to existing review file without prompting
+- `--fix` - After the review, apply fixes for findings the agent can resolve cleanly. Edits the working tree directly. Items not fixed (and the choice made on any judgment-call fixes) are listed in a Fix Summary section in the review. Not compatible with `learn` or `find`.
 - `--parent <ref>` - Override the base branch used for branch / current-branch reviews. By default, branches with a recorded stack parent (Graphite or `branch.<name>.parent` in git config) review against that parent; use `--parent` to force a different base, e.g. `--parent main`.
 
 **Optional File Pattern:**

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -753,6 +753,113 @@ The Voice Pass step runs in all review modes (quick and comprehensive) when find
 
 Use the same `debug-artifact-writer.sh` bridge pattern as the `11b-copilot-meta-review` stage.
 
+### Apply Fixes (--fix flag)
+
+If the session JSON has `fix: true`, apply fixes for the surviving findings before composing the review document. Skip this step entirely when `fix` is absent or false.
+
+The goal: act like a principal engineer doing a careful local cleanup pass. Fix what's clearly right; explain what you skipped or where you had to make a judgment call. The fix step never posts to GitHub: it edits the working tree only.
+
+**Preconditions:**
+
+1. The surviving finding pool is non-empty. If it's empty, skip the fix step and note "No findings to fix" in the Fix Summary section of the review document.
+2. A writeable working tree contains the reviewed code. Decide using this table:
+
+   | `mode`                               | `file_ref` set? | `git.local_clone` set? | Apply fixes? | Target / reason it's skipped |
+   |--------------------------------------|-----------------|------------------------|--------------|------------------------------|
+   | `local`, `branch`, `commit`, `range` | n/a             | n/a                    | yes          | `git.working_dir`            |
+   | `area`                               | n/a             | n/a                    | yes          | `git.working_dir`            |
+   | `pr`                                 | no              | n/a                    | yes          | `git.working_dir`            |
+   | `pr`                                 | yes             | yes                    | no           | working tree is a disposable provisioned worktree; edits would be reaped at session end |
+   | `pr`                                 | yes             | no                     | no           | user's working tree is on a different branch; edits would silently corrupt unrelated branch state |
+
+3. The working tree directory exists and is writable.
+
+If any precondition fails, skip applying fixes but still produce the Fix Summary section with a one-line reason.
+
+**Classification (per finding):**
+
+For each finding that survived synthesis, validation, Copilot meta-review, and voice pass, classify it into one of three buckets. The finding has `severity` (blocking/suggestion/nit/question), `file`, `line`, `description`, `proposed_fix`, and `confidence`.
+
+- **`fix_high_confidence`** — apply without commentary in the summary. All of:
+  - One of: `severity` is `blocking` or `suggestion` and `confidence >= 80%`; OR `severity` is `nit` and `proposed_fix` is a single-line or single-identifier change.
+  - `proposed_fix` is concrete (a diff, replacement code, or precise textual change), self-contained in one file, and unambiguous.
+  - The change does not alter a public API, exported type, function signature, or stable identifier that other callers depend on.
+  - The change does not require touching files outside the diff's modified files.
+
+- **`fix_with_judgment`** — apply, then record the choice in the summary. Any of:
+  - `confidence` is 60–79%.
+  - `proposed_fix` exists but needs adaptation (style, naming, placement) before it fits the surrounding code.
+  - There are 2+ reasonable approaches and you chose one. Pick the one a principal engineer would defend: clearest read, fewest moving parts, lowest blast radius. Avoid clever or speculative refactors.
+  - The fix touches a small amount of related code outside the immediate line (e.g., adding a helper, removing a now-unused import) where doing so leaves the codebase cleaner than the minimal patch.
+
+- **`skip`** — do not apply. Any of:
+  - `severity` is `question` (the author needs to decide) or the finding is `nit` without a trivial in-place fix.
+  - `confidence < 60%`.
+  - No concrete `proposed_fix` is available.
+  - The fix would change a public API, exported symbol, or behavior contract.
+  - The fix requires domain knowledge or product intent you don't have from the diff and architectural context.
+  - The fix would touch files outside the modified set, or would create new files, in a way that goes beyond the finding's stated scope.
+  - Applying the fix would create or worsen a conflict with another finding's fix.
+
+When two findings conflict (different fixes proposed for the same lines), pick the one with higher confidence; if tied, prefer `blocking` over `suggestion`. Mark the dropped finding as `skip` with reason "conflicts with higher-priority fix at <file:line>".
+
+**Applying fixes:**
+
+Maintain a `$fix_outcomes` map keyed by finding `id` (the voice-pass step mints sequential integer ids on each finding) with shape `{ status, file, line, severity, description, reason?, choice? }` where:
+- `status` is the bucket name: `fix_high_confidence`, `fix_with_judgment`, or `skip`.
+- `reason` is required when `status` is `skip`.
+- `choice` is required when `status` is `fix_with_judgment` and explains the option taken and the alternatives considered.
+
+For each finding classified `fix_high_confidence` or `fix_with_judgment`:
+
+1. Read the file named by the finding's `file` to capture the current text.
+2. Locate a unique textual anchor for the change using identifiers in the finding's `description` and `proposed_fix`; do not trust the diff's literal line numbers (the working tree may have drifted). If no unique anchor exists, reclassify the finding as `skip` with reason "could not locate fix target after working-tree drift".
+3. Apply the change with the Edit tool, using the anchor as `old_string`. Make the smallest edit that fully addresses the finding; do not bundle unrelated cleanups into the same edit. Edit's exact-match contract verifies the change atomically; if it errors, drop the finding to `skip` with the error as the reason.
+4. Record the outcome in `$fix_outcomes`.
+
+Group findings by file. Within one file, apply edits sequentially (the Edit tool's exact-match contract makes parallel same-file edits race) and re-read the file before each subsequent edit so anchors reflect prior fixes. Across files, you may dispatch edits in parallel.
+
+After all fixes are applied, do not run formatters, linters, or test suites automatically. The user will review the changes themselves.
+
+**Fix Summary section:**
+
+Build a `## Fix Summary` section. The "Compose the Review Document" step below places it immediately after the metadata header (and after the Review Scope note when one is present) and before the per-agent sections.
+
+The summary's opening line is one of two forms:
+
+- When fixes ran: `_Applied via `--fix`. <N> findings reviewed: <H> auto-fixed, <J> fixed with judgment calls below, <S> skipped._`
+- When preconditions failed: `_`--fix` was requested but no fixes were applied: <one-line reason>._`
+
+After the opening line, render the two subsections below. Omit each subsection entirely when its list would be empty.
+
+```markdown
+## Fix Summary
+
+<opening line, per the rules above>
+
+### Judgment Calls
+
+- **`<file>:<line>`** (`<severity>`) — <one-sentence description of what changed>.
+  <One or two sentences naming the chosen approach and the alternatives considered, in plain English.>
+
+### Skipped
+
+- **`<file>:<line>`** (`<severity>`) — <one-sentence description>.
+  Skipped: <reason in plain English>.
+```
+
+List judgment-call and skipped items in priority order. High-confidence fixes are not listed; the diff in the working tree is their record. Counts in the opening line reflect the actual outcomes regardless of which subsections are rendered.
+
+The user-facing summary message picks up the fix counts in the "Compose the Review Document" step below. No action needed here.
+
+**Debug instrumentation:** When `$debug_session_dir` is set, save artifacts under stage `11d-fix-pass`:
+
+- `classification.json`: per-finding `{id, status, reason?, choice?}` decisions.
+- `edits.json`: per-edit record `{finding_id, file, line, before_excerpt, after_excerpt}` capturing what was changed.
+- `outcomes.json`: the final `$fix_outcomes` map.
+
+Use the same `debug-artifact-writer.sh` bridge pattern as the `11b-copilot-meta-review` and `11c-voice-rewrite` stages.
+
 ### Compose the Review Document
 
 **Title by mode:**
@@ -783,6 +890,8 @@ If `is_chunked` is true, add a "Review Scope" note at the top of the review docu
 ```markdown
 > **Review Scope:** This review covered $chunk_count chunks ($total_file_count files total).
 ```
+
+If the session has `fix: true`, place the `## Fix Summary` section (built in the "Apply Fixes" step above) directly after the metadata header (and after the Review Scope note, when present) and before the per-agent sections.
 
 Include the metadata header at the top of the file:
 
@@ -819,6 +928,12 @@ Review complete!
 Pull Request: $pr_url
 
 Review saved to: $review_file
+
+{If session has fix: true and fixes were applied:}
+Fixes applied: $H high-confidence, $J judgment calls, $S skipped. See "Fix Summary" in the review for details.
+
+{If session has fix: true and preconditions failed:}
+Fixes were requested but not applied: $reason. See "Fix Summary" in the review.
 
 You can open it directly: file://$review_file
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -762,7 +762,7 @@ The goal: act like a principal engineer doing a careful local cleanup pass. Fix 
 **Preconditions:**
 
 1. The surviving finding pool is non-empty. If it's empty, skip the fix step and note "No findings to fix" in the Fix Summary section of the review document.
-2. A writeable working tree contains the reviewed code. Decide using this table:
+2. A writable working tree contains the reviewed code. Decide using this table:
 
    | `mode`                               | `file_ref` set? | `git.local_clone` set? | Apply fixes? | Target / reason it's skipped |
    |--------------------------------------|-----------------|------------------------|--------------|------------------------------|

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -19,6 +19,7 @@ APPLY_MODE="false"
 LEARN_MODE="false"
 OVERWRITE_MODE="false"
 APPEND_MODE="false"
+FIX_MODE="false"
 PARENT_OVERRIDE=""
 PARENT_FLAG_SEEN="false"
 remaining_args=()
@@ -45,6 +46,8 @@ for arg_item in "$@"; do
         OVERWRITE_MODE="true"
     elif [[ "${arg_item}" == "--append" ]]; then
         APPEND_MODE="true"
+    elif [[ "${arg_item}" == "--fix" ]]; then
+        FIX_MODE="true"
     elif [[ "${arg_item}" == "--parent" ]]; then
         PARENT_FLAG_SEEN="true"
         expect_value="parent"
@@ -269,6 +272,11 @@ build_json_output() {
         jq_args+=("--arg" "append_mode" "true")
     fi
 
+    # Add fix_mode if enabled
+    if [[ "${FIX_MODE}" == "true" ]]; then
+        jq_args+=("--arg" "fix_mode" "true")
+    fi
+
     jq -nc "${jq_args[@]}" "${jq_filter}"
 }
 
@@ -302,6 +310,20 @@ validate_apply_mode() {
 validate_overwrite_append_mode() {
     if [[ "${OVERWRITE_MODE}" == "true" ]] && [[ "${APPEND_MODE}" == "true" ]]; then
         build_json_error "--overwrite and --append are mutually exclusive. Use one or the other."
+        exit 1
+    fi
+}
+
+# Helper: Validate --fix is not used with incompatible subcommands.
+# `learn` and `find` do not produce findings to act on, so --fix is meaningless.
+validate_fix_mode() {
+    [[ "${FIX_MODE}" != "true" ]] && return 0
+    if [[ "${LEARN_MODE}" == "true" ]]; then
+        build_json_error "--fix is not compatible with learn mode."
+        exit 1
+    fi
+    if [[ "${FIND_MODE}" == "true" ]]; then
+        build_json_error "--fix is not compatible with find mode."
         exit 1
     fi
 }
@@ -610,6 +632,9 @@ if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
 
     # Validate --overwrite and --append are mutually exclusive
     validate_overwrite_append_mode
+
+    # Validate --fix is not used with incompatible subcommands
+    validate_fix_mode
 
     # 0. Learn Mode (Highest Priority - before review modes)
     if detect_learn_mode; then

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -206,7 +206,9 @@ resolve_base_branch() {
     get_base_branch "$@"
 }
 
-# Helper: Build JSON output with optional file_pattern and find_mode
+# Helper: Build JSON output for a parsed invocation. Always emits `mode` plus
+# any supplied key/value pairs, and conditionally appends `file_pattern` and
+# every `<flag>_mode` field whose corresponding `<FLAG>_MODE` global is "true".
 # Usage: build_json_output mode key1 val1 [key2 val2 ...]
 build_json_output() {
     local mode=$1

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -55,6 +55,8 @@ main() {
     overwrite_mode=$(echo "${parse_result}" | jq -r '.overwrite_mode // "false"')
     local append_mode
     append_mode=$(echo "${parse_result}" | jq -r '.append_mode // "false"')
+    local fix_mode
+    fix_mode=$(echo "${parse_result}" | jq -r '.fix_mode // "false"')
 
     # Extract org/repo early for git-based modes
     # Cache git org/repo to avoid redundant operations
@@ -497,12 +499,12 @@ build_review_data() {
     # Add mode-specific arguments
     jq_args+=("$@")
 
-    # Add force_mode, draft_mode, self_mode, overwrite_mode, append_mode, and debug_session_dir to jq args
     jq_args+=(--arg force_mode "${force_mode}")
     jq_args+=(--arg draft_mode "${draft_mode}")
     jq_args+=(--arg self_mode "${self_mode}")
     jq_args+=(--arg overwrite_mode "${overwrite_mode}")
     jq_args+=(--arg append_mode "${append_mode}")
+    jq_args+=(--arg fix_mode "${fix_mode}")
     jq_args+=(--arg debug_session_dir "${DEBUG_SESSION_DIR:-}")
     jq_args+=(--argjson diff_tokens "${diff_tokens}")
     jq_args+=(--arg commit_messages "${commit_messages}")
@@ -535,6 +537,7 @@ build_review_data() {
         + (if $self_mode == "true" then {self: true} else {} end)
         + (if $overwrite_mode == "true" then {overwrite: true} else {} end)
         + (if $append_mode == "true" then {append: true} else {} end)
+        + (if $fix_mode == "true" then {fix: true} else {} end)
         + (if $pr[0] != null then {pr: $pr[0], reviewer_username: $reviewer_username, is_own_pr: ($is_own_pr == "true")} else {} end)
         + (if $chunks[0] != null then {chunks: $chunks[0], chunk_metadata: $chunk_metadata} else {} end)
         + (if $debug_session_dir != "" then {debug_session_dir: $debug_session_dir} else {} end)

--- a/tests/unit/test-parse-review-arg-functions.bats
+++ b/tests/unit/test-parse-review-arg-functions.bats
@@ -753,6 +753,110 @@ reset_globals() {
 }
 
 # =============================================================================
+# Fix mode tests
+# =============================================================================
+
+@test "fix mode: FIX_MODE is false by default" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh"
+    [ "$FIX_MODE" = "false" ]
+}
+
+@test "fix mode: --fix sets FIX_MODE" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--fix" "123"
+    [ "$FIX_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "fix mode: --fix as second argument" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "123" "--fix"
+    [ "$FIX_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "fix mode: build_json_output includes fix_mode when set" {
+    file_pattern=""
+    FIX_MODE="true"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"fix_mode":"true"'* ]]
+}
+
+@test "fix mode: build_json_output excludes fix_mode when false" {
+    file_pattern=""
+    FIX_MODE="false"
+    run build_json_output "test" "key" "val"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'"fix_mode"'* ]]
+}
+
+@test "fix mode: combines with --force and --draft" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--force" "--fix" "--draft" "123"
+    [ "$FORCE_MODE" = "true" ]
+    [ "$FIX_MODE" = "true" ]
+    [ "$DRAFT_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "fix mode: validate_fix_mode passes when --fix is unset" {
+    FIX_MODE="false"
+    LEARN_MODE="true"
+    run validate_fix_mode
+    [ "$status" -eq 0 ]
+}
+
+@test "fix mode: validate_fix_mode rejects --fix with learn" {
+    FIX_MODE="true"
+    LEARN_MODE="true"
+    FIND_MODE="false"
+    run validate_fix_mode
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not compatible with learn"* ]]
+}
+
+@test "fix mode: validate_fix_mode rejects --fix with find" {
+    FIX_MODE="true"
+    LEARN_MODE="false"
+    FIND_MODE="true"
+    run validate_fix_mode
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not compatible with find"* ]]
+}
+
+@test "fix mode: validate_fix_mode passes for normal review" {
+    FIX_MODE="true"
+    LEARN_MODE="false"
+    FIND_MODE="false"
+    run validate_fix_mode
+    [ "$status" -eq 0 ]
+}
+
+@test "fix mode: combines with --overwrite" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--fix" "--overwrite" "123"
+    [ "$FIX_MODE" = "true" ]
+    [ "$OVERWRITE_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "fix mode: combines with --append" {
+    source "$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh" "--fix" "--append" "123"
+    [ "$FIX_MODE" = "true" ]
+    [ "$APPEND_MODE" = "true" ]
+    [ "$arg" = "123" ]
+}
+
+@test "fix mode: --fix learn rejected via main script" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --fix learn 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not compatible with learn"* ]]
+}
+
+@test "fix mode: --fix find rejected via main script" {
+    run bash -c "bash '$PROJECT_ROOT/skills/review-code/scripts/parse-review-arg.sh' --fix find 123 2>&1"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not compatible with find"* ]]
+}
+
+# =============================================================================
 # get_base_branch tests
 # =============================================================================
 


### PR DESCRIPTION
The new `--fix` flag tells `/review-code` to apply fixes for the findings it produces. After the existing pipeline (synthesis, validation, Copilot meta-review, voice pass), a new Apply Fixes step classifies each surviving finding as `fix_high_confidence` (apply silently), `fix_with_judgment` (apply, document the choice in the review), or `skip` (don't apply, document the reason). The handler edits the working tree via the Edit tool and writes a `## Fix Summary` section into the review document.

`--fix` is rejected when combined with `learn` or `find`, since neither produces findings to act on. It works in any mode that has a writeable target: `local`, `branch`, `commit`, `range`, `area`, and `pr` when the user's working tree is actually on the PR's branch. For PR mode with a provisioned worktree or a cross-branch checkout, the fix step skips and records the reason.

Plumbing follows the existing flag pattern: `FIX_MODE` in `parse-review-arg.sh`, `fix_mode` in the parse JSON, `{fix: true}` in the session JSON, gated handler section in `review.md`.

I ran `/review-code --force --fix` against this branch as the first real test. It produced 23 findings across 7 agents (zero blocking), auto-applied 4, applied 7 as judgment calls, and skipped 12 with reasons. The Fix Summary section in `~/.claude/skills/review-code/reviews/haacked/review-code/haacked-fix.md` records the choices.

## Test plan

- [ ] Run `bats tests/unit/test-parse-review-arg-functions.bats`; 116 tests pass.
- [ ] Run `bats tests/unit/test-review-orchestrator.bats`; 71 tests pass.
- [ ] Run `bin/setup` and verify `~/.claude/skills/review-code/handlers/review.md` contains the new Apply Fixes section.
- [ ] Try `/review-code --fix` on a small uncommitted change in any repo; verify the working tree is edited and the saved review has a Fix Summary section.
- [ ] Try `/review-code learn --fix`; verify it errors with "not compatible with learn".
- [ ] Try `/review-code find --fix`; verify it errors with "not compatible with find".