### PR TITLE
Fix /review-code pre-flight loop, auto-resume after /clear

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -193,6 +193,23 @@ install_skill() {
     info "Installed skill: review-code (${script_count} scripts)"
 }
 
+install_session_clear_hook() {
+    # Register a global SessionStart hook (matcher: clear) so /clear writes
+    # a marker the skill can read on its next invocation. This breaks the
+    # pre-flight prompt loop that otherwise asks the user to /clear forever.
+    local manager="${SKILL_DIR}/scripts/manage-session-hook.sh"
+    if [[ ! -x "${manager}" ]]; then
+        warn "Skipping SessionStart hook install: ${manager} not found"
+        return 0
+    fi
+
+    if "${manager}" install; then
+        info "Registered SessionStart hook in ~/.claude/settings.json"
+    else
+        warn "Failed to register SessionStart hook (the skill still works, but the pre-flight prompt may loop)"
+    fi
+}
+
 install_agents() {
     local agents=(
         "code-review-context-explorer"
@@ -615,6 +632,7 @@ main() {
     echo ""
     info "Installing review-code components…"
     install_skill
+    install_session_clear_hook
     install_agents
     install_context
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -119,6 +119,14 @@ Code reviews are context-heavy and work best with a fresh context.
 
 **If `--force` was specified:** Skip this step entirely and proceed to Step 3.
 
+**Check the pending-clear marker first.** A global `SessionStart` hook with `matcher: "clear"` (installed by `bin/setup`) writes this marker whenever the user runs `/clear`. If the user just cleared and re-invoked `/review-code`, the marker tells us to skip the prompt so we don't loop.
+
+```bash
+~/.claude/skills/review-code/scripts/clear-marker.sh check
+```
+
+If the output is `skip`, proceed directly to Step 3 — the user already cleared.
+
 **Otherwise**, use AskUserQuestion:
 - Question: "Code reviews work best with a fresh context. Clear conversation history before starting?"
 - Options:
@@ -129,7 +137,7 @@ Code reviews are context-heavy and work best with a fresh context.
 
 If user selects "Yes, clear and review":
 - Tell the user: "Please run `/clear` and then run the review command again."
-- Stop here.
+- Stop here. (The SessionStart hook will mark the clear, so the next invocation skips this prompt.)
 
 If user selects "No, continue anyway", proceed to Step 3.
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -119,7 +119,7 @@ Code reviews are context-heavy and work best with a fresh context.
 
 **If `--force` was specified:** Skip this step entirely and proceed to Step 3.
 
-**Check the pending-clear marker first.** A global `SessionStart` hook with `matcher: "clear"` (installed by `bin/setup`) writes this marker whenever the user runs `/clear`. If the user just cleared and re-invoked `/review-code`, the marker tells us to skip the prompt so we don't loop.
+**Check the pending-clear marker first.** A global `SessionStart` hook with `matcher: "startup|clear"` (installed by `bin/setup`) writes this marker on a fresh `claude` launch or whenever the user runs `/clear`. If the user just cleared and re-invoked `/review-code`, the marker tells us to skip the prompt so we don't loop.
 
 ```bash
 ~/.claude/skills/review-code/scripts/clear-marker.sh check

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -140,7 +140,7 @@ If user selects the "Stop here" option:
   ```bash
   ~/.claude/skills/review-code/scripts/pending-resume.sh set-string "$ARGUMENTS"
   ```
-- Tell the user: "Run `/clear`, then send any message (e.g. `go`) and I'll resume `/review-code $ARGUMENTS` with fresh context."
+- Tell the user to run `/clear`, then send any message (e.g. `go`) so the SessionStart hook can resume the review with fresh context. When `$ARGUMENTS` is non-empty, mention the args explicitly (e.g. "I'll resume `/review-code 55298 --draft`"); when empty, say "I'll resume `/review-code` (default review)".
 - Stop here. The SessionStart hook on `/clear` writes the skip-prompt marker and injects an instruction so the next message auto-runs the review.
 
 If user selects "No, continue anyway", proceed to Step 3.

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -130,14 +130,18 @@ If the output is `skip`, proceed directly to Step 3 — the user already cleared
 **Otherwise**, use AskUserQuestion:
 - Question: "Code reviews work best with a fresh context. Clear conversation history before starting?"
 - Options:
-  1. "Yes, clear and review (Recommended)" - Clear context, then start the review
+  1. "Stop here so I can /clear, then resume (Recommended)" - Stops the skill so the user can run /clear; the SessionStart hook will auto-resume the review with the same args on their next message
      Description: "Ensures clean review without prior conversation influencing results"
   2. "No, continue anyway" - Keep current context and proceed
      Description: "Use only if you need to reference earlier conversation"
 
-If user selects "Yes, clear and review":
-- Tell the user: "Please run `/clear` and then run the review command again."
-- Stop here. (The SessionStart hook will mark the clear, so the next invocation skips this prompt.)
+If user selects the "Stop here" option:
+- Record the original arguments so the SessionStart hook can resume them after `/clear`:
+  ```bash
+  ~/.claude/skills/review-code/scripts/pending-resume.sh set-string "$ARGUMENTS"
+  ```
+- Tell the user: "Run `/clear`, then send any message (e.g. `go`) and I'll resume `/review-code $ARGUMENTS` with fresh context."
+- Stop here. The SessionStart hook on `/clear` writes the skip-prompt marker and injects an instruction so the next message auto-runs the review.
 
 If user selects "No, continue anyway", proceed to Step 3.
 

--- a/skills/review-code/scripts/clear-marker.sh
+++ b/skills/review-code/scripts/clear-marker.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Pre-flight /clear marker — breaks the infinite-loop where the recommended
+# option in Step 2 of SKILL.md ("Yes, clear and review") sends the user to
+# /clear, but on re-invocation the skill has no way to know they just cleared
+# and asks again, looping forever.
+#
+# Flow:
+#   1. User runs /review-code; Step 2 asks "Clear conversation history?"
+#   2. User picks "Yes, clear and review" → `clear-marker.sh set`, skill tells
+#      user to /clear and re-invoke.
+#   3. After /clear, user re-runs /review-code; Step 2 calls
+#      `clear-marker.sh check`, finds a recent marker, consumes it, prints
+#      "skip", and the skill proceeds directly to Step 3.
+#
+# The marker has a 10-minute TTL so abandoned markers expire and the prompt
+# returns to its normal behavior. Override the directory with
+# REVIEW_CODE_MARKER_DIR for tests.
+
+set -euo pipefail
+
+MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
+MARKER_FILE="${MARKER_DIR}/.pending-clear"
+MARKER_TTL_SECONDS=600
+
+cmd_set() {
+    mkdir -p "${MARKER_DIR}"
+    : > "${MARKER_FILE}"
+}
+
+# stat flag differs between BSD (macOS) and GNU (Linux); try both.
+marker_mtime() {
+    stat -f %m "${MARKER_FILE}" 2> /dev/null \
+        || stat -c %Y "${MARKER_FILE}" 2> /dev/null
+}
+
+cmd_check() {
+    [[ -f "${MARKER_FILE}" ]] || return 0
+
+    local mtime
+    if ! mtime=$(marker_mtime); then
+        # Couldn't read mtime — fail safe by removing the marker and not skipping.
+        rm -f "${MARKER_FILE}"
+        return 0
+    fi
+
+    local now age
+    now=$(date +%s)
+    age=$((now - mtime))
+
+    # Consume the marker either way so a single "set" never satisfies multiple
+    # invocations.
+    rm -f "${MARKER_FILE}"
+
+    if ((age <= MARKER_TTL_SECONDS)); then
+        echo "skip"
+    fi
+}
+
+main() {
+    local subcommand="${1:-}"
+    case "${subcommand}" in
+        set)
+            cmd_set
+            ;;
+        check)
+            cmd_check
+            ;;
+        *)
+            echo "ERROR: Unknown subcommand: '${subcommand}'. Usage: $0 {set|check}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/clear-marker.sh
+++ b/skills/review-code/scripts/clear-marker.sh
@@ -1,22 +1,22 @@
 #!/usr/bin/env bash
-# Pre-flight /clear marker — breaks the infinite-loop where the recommended
-# option in Step 2 of SKILL.md ("Yes, clear and review") sends the user to
-# /clear, but on re-invocation the skill has no way to know they just cleared
-# and asks again, looping forever.
+# Pre-flight /clear marker for /review-code.
 #
-# Flow:
-#   1. User runs /review-code; Step 2 asks "Clear conversation history?"
-#   2. User picks "Yes, clear and review" → `clear-marker.sh set`, skill tells
-#      user to /clear and re-invoke.
-#   3. After /clear, user re-runs /review-code; Step 2 calls
-#      `clear-marker.sh check`, finds a recent marker, consumes it, prints
-#      "skip", and the skill proceeds directly to Step 3.
+# Inputs/outputs:
+#   set    — touch ${MARKER_DIR}/.pending-clear (created on demand)
+#   check  — print "skip" and consume the marker if fresh (within TTL);
+#            silent otherwise
 #
-# The marker has a 10-minute TTL so abandoned markers expire and the prompt
-# returns to its normal behavior. Override the directory with
+# The SessionStart hook (session-clear-hook.sh) calls `set` on every /clear
+# or session-start, and Step 2 of SKILL.md calls `check` before deciding
+# whether to prompt the user about clearing context. The TTL bounds stale
+# markers from an abandoned flow. Override the directory with
 # REVIEW_CODE_MARKER_DIR for tests.
 
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/date-helpers.sh
+source "${SCRIPT_DIR}/helpers/date-helpers.sh"
 
 MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
 MARKER_FILE="${MARKER_DIR}/.pending-clear"
@@ -27,17 +27,12 @@ cmd_set() {
     : > "${MARKER_FILE}"
 }
 
-# stat flag differs between BSD (macOS) and GNU (Linux); try both.
-marker_mtime() {
-    stat -f %m "${MARKER_FILE}" 2> /dev/null \
-        || stat -c %Y "${MARKER_FILE}" 2> /dev/null
-}
-
 cmd_check() {
     [[ -f "${MARKER_FILE}" ]] || return 0
 
     local mtime
-    if ! mtime=$(marker_mtime); then
+    mtime=$(get_file_mtime "${MARKER_FILE}")
+    if [[ -z "${mtime}" ]]; then
         # Couldn't read mtime — fail safe by removing the marker and not skipping.
         rm -f "${MARKER_FILE}"
         return 0

--- a/skills/review-code/scripts/manage-session-hook.sh
+++ b/skills/review-code/scripts/manage-session-hook.sh
@@ -70,12 +70,16 @@ strip_our_hook() {
 }
 
 cmd_install() {
+    # Match both `startup` (fresh `claude` launch) and `clear` (/clear) so the
+    # marker is set in any "context is fresh" scenario. The skill's pre-flight
+    # check consumes the marker one-shot, so subsequent invocations in the
+    # same session still prompt — by then the user has accumulated context.
     local updated
     updated=$(read_settings | strip_our_hook | jq --arg cmd "${HOOK_COMMAND}" '
         .hooks //= {} |
         .hooks.SessionStart //= [] |
         .hooks.SessionStart += [{
-            matcher: "clear",
+            matcher: "startup|clear",
             hooks: [{ type: "command", command: $cmd }]
         }]
     ')

--- a/skills/review-code/scripts/manage-session-hook.sh
+++ b/skills/review-code/scripts/manage-session-hook.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Idempotently install/uninstall a global SessionStart hook in
+# ~/.claude/settings.json that fires on `/clear`. The hook writes a marker
+# so the /review-code skill can detect "user just cleared" on its next
+# invocation and skip the pre-flight prompt instead of looping.
+#
+# Why this is global and not in SKILL.md frontmatter: skill-frontmatter
+# hooks are scoped to skill lifetime, so they don't fire after /clear when
+# the skill isn't loaded. SessionStart needs to fire before the skill loads,
+# which means a global registration.
+#
+# Identity: we identify our hook entry by its exact `command` string. Install
+# strips any matching entry first then appends, so repeated installs converge
+# on a single entry. Uninstall removes the same entry. Both operations
+# preserve unrelated hooks the user or other tools may have configured.
+#
+# Usage:
+#   manage-session-hook.sh install
+#   manage-session-hook.sh uninstall
+
+set -euo pipefail
+
+SETTINGS_FILE="${CLAUDE_SETTINGS_FILE:-${HOME}/.claude/settings.json}"
+HOOK_COMMAND="${REVIEW_CODE_HOOK_COMMAND:-${HOME}/.claude/skills/review-code/scripts/clear-marker.sh set}"
+
+read_settings() {
+    if [[ -f "${SETTINGS_FILE}" ]]; then
+        cat "${SETTINGS_FILE}"
+    else
+        echo "{}"
+    fi
+}
+
+write_settings() {
+    local new_content="$1"
+    mkdir -p "$(dirname "${SETTINGS_FILE}")"
+    local tmp="${SETTINGS_FILE}.tmp.$$"
+    printf '%s\n' "${new_content}" > "${tmp}"
+    mv "${tmp}" "${SETTINGS_FILE}"
+}
+
+# Strip our hook entry from .hooks.SessionStart, dropping any blocks whose
+# `hooks` array becomes empty as a result. Returns full settings JSON.
+strip_our_hook() {
+    jq --arg cmd "${HOOK_COMMAND}" '
+        if (.hooks // {}).SessionStart then
+            .hooks.SessionStart |= (
+                map(
+                    if has("hooks") then
+                        .hooks |= map(select((.command // "") != $cmd))
+                    else . end
+                )
+                | map(select((.hooks // []) | length > 0))
+            )
+        else . end
+    '
+}
+
+cmd_install() {
+    local updated
+    updated=$(read_settings | strip_our_hook | jq --arg cmd "${HOOK_COMMAND}" '
+        .hooks //= {} |
+        .hooks.SessionStart //= [] |
+        .hooks.SessionStart += [{
+            matcher: "clear",
+            hooks: [{ type: "command", command: $cmd }]
+        }]
+    ')
+    write_settings "${updated}"
+}
+
+cmd_uninstall() {
+    local updated
+    updated=$(read_settings | strip_our_hook | jq '
+        if (.hooks // {}).SessionStart and ((.hooks.SessionStart | length) == 0) then
+            del(.hooks.SessionStart)
+        else . end
+        | if (.hooks // null) == {} then del(.hooks) else . end
+    ')
+    write_settings "${updated}"
+}
+
+main() {
+    local subcommand="${1:-}"
+    case "${subcommand}" in
+        install)
+            cmd_install
+            ;;
+        uninstall)
+            cmd_uninstall
+            ;;
+        *)
+            echo "ERROR: Unknown subcommand: '${subcommand}'. Usage: $0 {install|uninstall}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/manage-session-hook.sh
+++ b/skills/review-code/scripts/manage-session-hook.sh
@@ -21,7 +21,12 @@
 set -euo pipefail
 
 SETTINGS_FILE="${CLAUDE_SETTINGS_FILE:-${HOME}/.claude/settings.json}"
-HOOK_COMMAND="${REVIEW_CODE_HOOK_COMMAND:-${HOME}/.claude/skills/review-code/scripts/clear-marker.sh set}"
+HOOK_COMMAND="${REVIEW_CODE_HOOK_COMMAND:-${HOME}/.claude/skills/review-code/scripts/session-clear-hook.sh}"
+# Substring used to identify hook entries we own. Any command whose path
+# contains this marker is considered ours and is stripped on install /
+# uninstall. This handles migration when the hook script gets renamed (e.g.
+# the legacy clear-marker.sh entry from an earlier install).
+HOOK_PATH_MARKER="${REVIEW_CODE_HOOK_PATH_MARKER:-/skills/review-code/scripts/}"
 
 read_settings() {
     if [[ -f "${SETTINGS_FILE}" ]]; then
@@ -39,15 +44,23 @@ write_settings() {
     mv "${tmp}" "${SETTINGS_FILE}"
 }
 
-# Strip our hook entry from .hooks.SessionStart, dropping any blocks whose
+# Strip our hook entries from .hooks.SessionStart, dropping any blocks whose
 # `hooks` array becomes empty as a result. Returns full settings JSON.
+#
+# "Ours" means any command whose path contains HOOK_PATH_MARKER, OR matches
+# HOOK_COMMAND exactly. The substring side catches migrations (e.g. legacy
+# entries from older script names); the exact-match side lets tests override
+# HOOK_COMMAND to an arbitrary path that doesn't include the marker.
 strip_our_hook() {
-    jq --arg cmd "${HOOK_COMMAND}" '
+    jq --arg cmd "${HOOK_COMMAND}" --arg marker "${HOOK_PATH_MARKER}" '
         if (.hooks // {}).SessionStart then
             .hooks.SessionStart |= (
                 map(
                     if has("hooks") then
-                        .hooks |= map(select((.command // "") != $cmd))
+                        .hooks |= map(select(
+                            (.command // "") as $c
+                            | ($c != $cmd) and (($c | contains($marker)) | not)
+                        ))
                     else . end
                 )
                 | map(select((.hooks // []) | length > 0))

--- a/skills/review-code/scripts/pending-resume.sh
+++ b/skills/review-code/scripts/pending-resume.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Stores the args a user wants to resume after /clear.
+#
+# When the /review-code pre-flight prompt fires and the user picks
+# "clear and resume", the skill records the original $ARGUMENTS here.
+# The SessionStart hook on /clear reads this file and emits
+# additionalContext so Claude auto-invokes /review-code with those args
+# on the user's next message.
+#
+# Usage:
+#   pending-resume.sh set <args...>   # Record args (multi-arg form, joined with spaces)
+#   pending-resume.sh set-string "arg string"   # Record a pre-joined string verbatim
+#   pending-resume.sh get             # Print args (does NOT delete the file)
+#   pending-resume.sh consume         # Print args, then delete the file
+#   pending-resume.sh clear           # Delete the file
+
+set -euo pipefail
+
+MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
+PENDING_RESUME_FILE="${MARKER_DIR}/.pending-resume"
+
+# 10-minute TTL matches the clear-marker so a stale resume can't auto-fire
+# the next time a user clears for unrelated reasons.
+PENDING_RESUME_TTL_SECONDS=600
+
+cmd_set() {
+    mkdir -p "${MARKER_DIR}"
+    printf '%s' "$*" > "${PENDING_RESUME_FILE}"
+}
+
+# Same as `set` but treats the first positional as a single pre-joined
+# string. SKILL.md uses this form so we get the args verbatim from
+# Claude's $ARGUMENTS expansion without word-splitting.
+cmd_set_string() {
+    mkdir -p "${MARKER_DIR}"
+    printf '%s' "${1-}" > "${PENDING_RESUME_FILE}"
+}
+
+# Print mtime in epoch seconds; tries BSD then GNU stat.
+file_mtime() {
+    stat -f %m "${PENDING_RESUME_FILE}" 2> /dev/null \
+        || stat -c %Y "${PENDING_RESUME_FILE}" 2> /dev/null
+}
+
+fresh_or_die() {
+    [[ -f "${PENDING_RESUME_FILE}" ]] || return 1
+    local mtime
+    if ! mtime=$(file_mtime); then
+        rm -f "${PENDING_RESUME_FILE}"
+        return 1
+    fi
+    local now age
+    now=$(date +%s)
+    age=$((now - mtime))
+    if ((age > PENDING_RESUME_TTL_SECONDS)); then
+        rm -f "${PENDING_RESUME_FILE}"
+        return 1
+    fi
+    return 0
+}
+
+cmd_get() {
+    if fresh_or_die; then
+        cat "${PENDING_RESUME_FILE}"
+    fi
+}
+
+cmd_consume() {
+    if fresh_or_die; then
+        cat "${PENDING_RESUME_FILE}"
+        rm -f "${PENDING_RESUME_FILE}"
+    fi
+}
+
+cmd_clear() {
+    rm -f "${PENDING_RESUME_FILE}"
+}
+
+main() {
+    local subcommand="${1:-}"
+    case "${subcommand}" in
+        set)
+            shift
+            cmd_set "$@"
+            ;;
+        set-string)
+            shift
+            cmd_set_string "${1-}"
+            ;;
+        get)
+            cmd_get
+            ;;
+        consume)
+            cmd_consume
+            ;;
+        clear)
+            cmd_clear
+            ;;
+        *)
+            echo "ERROR: Unknown subcommand: '${subcommand}'. Usage: $0 {set|set-string|get|consume|clear}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/pending-resume.sh
+++ b/skills/review-code/scripts/pending-resume.sh
@@ -65,11 +65,16 @@ cmd_get() {
     fi
 }
 
+# Print args (possibly empty) and delete the file; exit 0 if there was a
+# fresh pending resume, exit 1 otherwise. The exit code is the source of
+# truth — empty contents (no-args invocation) still count as "yes, resume".
 cmd_consume() {
     if fresh_or_die; then
         cat "${PENDING_RESUME_FILE}"
         rm -f "${PENDING_RESUME_FILE}"
+        return 0
     fi
+    return 1
 }
 
 cmd_clear() {

--- a/skills/review-code/scripts/pending-resume.sh
+++ b/skills/review-code/scripts/pending-resume.sh
@@ -16,6 +16,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/date-helpers.sh
+source "${SCRIPT_DIR}/helpers/date-helpers.sh"
+
 MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
 PENDING_RESUME_FILE="${MARKER_DIR}/.pending-resume"
 
@@ -36,16 +40,11 @@ cmd_set_string() {
     printf '%s' "${1-}" > "${PENDING_RESUME_FILE}"
 }
 
-# Print mtime in epoch seconds; tries BSD then GNU stat.
-file_mtime() {
-    stat -f %m "${PENDING_RESUME_FILE}" 2> /dev/null \
-        || stat -c %Y "${PENDING_RESUME_FILE}" 2> /dev/null
-}
-
 fresh_or_die() {
     [[ -f "${PENDING_RESUME_FILE}" ]] || return 1
     local mtime
-    if ! mtime=$(file_mtime); then
+    mtime=$(get_file_mtime "${PENDING_RESUME_FILE}")
+    if [[ -z "${mtime}" ]]; then
         rm -f "${PENDING_RESUME_FILE}"
         return 1
     fi

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -28,21 +28,30 @@ PENDING_RESUME_SH="${SCRIPT_DIR}/pending-resume.sh"
 #    we don't want hook failures to block /clear.
 "${CLEAR_MARKER_SH}" set 2> /dev/null || true
 
-# 2. Consume the pending-resume args (if any, and if fresh).
-ARGS=$("${PENDING_RESUME_SH}" consume 2> /dev/null || true)
-
-if [[ -n "${ARGS}" ]]; then
+# 2. Consume the pending-resume args (if any, and if fresh). Use the exit
+#    code to decide whether to inject — `pending-resume.sh consume` exits 0
+#    only when there was a fresh pending entry, even if its args were empty
+#    (a no-args /review-code invocation is still worth auto-resuming).
+if ARGS=$("${PENDING_RESUME_SH}" consume 2> /dev/null); then
     jq -n --arg args "${ARGS}" '
     {
       hookSpecificOutput: {
         hookEventName: "SessionStart",
         additionalContext: (
-          "The user just cleared conversation context to resume a /review-code invocation. "
-          + "They previously invoked `/review-code " + $args + "`. "
-          + "Their next message — whatever its literal content — means \"resume that command now.\" "
-          + "Invoke the /review-code skill with arguments `" + $args + "` immediately. "
-          + "Do not address the literal content of their message and do not ask for confirmation; "
-          + "treat any input as a signal to proceed with the review."
+          if $args == "" then
+            "The user just cleared conversation context to resume a /review-code invocation with no arguments (the default review of local/branch changes). "
+            + "Their next message — whatever its literal content — means \"resume that command now.\" "
+            + "Invoke the /review-code skill immediately with no arguments. "
+            + "Do not address the literal content of their message and do not ask for confirmation; "
+            + "treat any input as a signal to proceed with the review."
+          else
+            "The user just cleared conversation context to resume a /review-code invocation. "
+            + "They previously invoked `/review-code " + $args + "`. "
+            + "Their next message — whatever its literal content — means \"resume that command now.\" "
+            + "Invoke the /review-code skill with arguments `" + $args + "` immediately. "
+            + "Do not address the literal content of their message and do not ask for confirmation; "
+            + "treat any input as a signal to proceed with the review."
+          end
         )
       }
     }

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# SessionStart hook (matcher: "clear") for /review-code.
+#
+# Fires when the user runs /clear. Does two things:
+#
+# 1. Always: writes the skip-prompt marker so /review-code's next
+#    pre-flight prompt is skipped instead of looping forever.
+#
+# 2. If the user picked "clear and resume" in a recent /review-code
+#    invocation: emits SessionStart additionalContext that instructs
+#    Claude to auto-invoke /review-code with the original args on the
+#    user's next message. This is the closest interactive Claude Code
+#    gets to "clear AND review" in one step — Claude can't act until
+#    the user submits something, but the user only has to send any
+#    message (e.g. "go") and the review starts with the original args.
+#
+# Hook output schema:
+#   { "hookSpecificOutput": { "hookEventName": "SessionStart",
+#     "additionalContext": "..." } }
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLEAR_MARKER_SH="${SCRIPT_DIR}/clear-marker.sh"
+PENDING_RESUME_SH="${SCRIPT_DIR}/pending-resume.sh"
+
+# 1. Always set the skip-prompt marker. If it fails, swallow the error —
+#    we don't want hook failures to block /clear.
+"${CLEAR_MARKER_SH}" set 2> /dev/null || true
+
+# 2. Consume the pending-resume args (if any, and if fresh).
+ARGS=$("${PENDING_RESUME_SH}" consume 2> /dev/null || true)
+
+if [[ -n "${ARGS}" ]]; then
+    jq -n --arg args "${ARGS}" '
+    {
+      hookSpecificOutput: {
+        hookEventName: "SessionStart",
+        additionalContext: (
+          "The user just cleared conversation context to resume a /review-code invocation. "
+          + "They previously invoked `/review-code " + $args + "`. "
+          + "Their next message — whatever its literal content — means \"resume that command now.\" "
+          + "Invoke the /review-code skill with arguments `" + $args + "` immediately. "
+          + "Do not address the literal content of their message and do not ask for confirmation; "
+          + "treat any input as a signal to proceed with the review."
+        )
+      }
+    }
+    '
+fi

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# SessionStart hook (matcher: "clear") for /review-code.
+# SessionStart hook (matcher: "startup|clear") for /review-code.
 #
-# Fires when the user runs /clear. Does two things:
+# Fires on a fresh `claude` launch or when the user runs /clear. Does two
+# things:
 #
 # 1. Always: writes the skip-prompt marker so /review-code's next
 #    pre-flight prompt is skipped instead of looping forever.

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -23,6 +23,20 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLEAR_MARKER_SH="${SCRIPT_DIR}/clear-marker.sh"
 PENDING_RESUME_SH="${SCRIPT_DIR}/pending-resume.sh"
+LOG_FILE="${REVIEW_CODE_HOOK_LOG:-${HOME}/.claude/skills/review-code/sessions/.session-clear-hook.log}"
+
+# Append one line per invocation so we can confirm the hook actually fires
+# on /clear and inspect what it emitted. Bounded to ~50 entries.
+log_line() {
+    local msg="$1"
+    mkdir -p "$(dirname "${LOG_FILE}")"
+    printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${msg}" >> "${LOG_FILE}"
+    if [[ -f "${LOG_FILE}" ]]; then
+        tail -50 "${LOG_FILE}" > "${LOG_FILE}.tmp" 2> /dev/null && mv "${LOG_FILE}.tmp" "${LOG_FILE}" || true
+    fi
+}
+
+log_line "fired (cwd=$(pwd))"
 
 # 1. Always set the skip-prompt marker. If it fails, swallow the error —
 #    we don't want hook failures to block /clear.
@@ -33,27 +47,24 @@ PENDING_RESUME_SH="${SCRIPT_DIR}/pending-resume.sh"
 #    only when there was a fresh pending entry, even if its args were empty
 #    (a no-args /review-code invocation is still worth auto-resuming).
 if ARGS=$("${PENDING_RESUME_SH}" consume 2> /dev/null); then
+    log_line "consumed pending-resume (args='${ARGS}') — emitting additionalContext"
     jq -n --arg args "${ARGS}" '
     {
       hookSpecificOutput: {
         hookEventName: "SessionStart",
         additionalContext: (
-          if $args == "" then
-            "The user just cleared conversation context to resume a /review-code invocation with no arguments (the default review of local/branch changes). "
-            + "Their next message — whatever its literal content — means \"resume that command now.\" "
-            + "Invoke the /review-code skill immediately with no arguments. "
-            + "Do not address the literal content of their message and do not ask for confirmation; "
-            + "treat any input as a signal to proceed with the review."
-          else
-            "The user just cleared conversation context to resume a /review-code invocation. "
-            + "They previously invoked `/review-code " + $args + "`. "
-            + "Their next message — whatever its literal content — means \"resume that command now.\" "
-            + "Invoke the /review-code skill with arguments `" + $args + "` immediately. "
-            + "Do not address the literal content of their message and do not ask for confirmation; "
-            + "treat any input as a signal to proceed with the review."
-          end
+          ("/review-code" + (if $args == "" then "" else " " + $args end)) as $cmd |
+          "RESUME REQUEST — non-negotiable: the user just ran /clear immediately after picking \"clear and resume\" in the /review-code pre-flight prompt. "
+          + "Their previous invocation was `" + $cmd + "`"
+          + (if $args == "" then " (no arguments — the default review of local/branch changes). " else ". " end)
+          + "Their next message — whatever its literal text — is the agreed-upon trigger to proceed; treat it as if they had typed `" + $cmd + "` again. "
+          + "Your first action on the next turn MUST be to invoke the review-code skill via the Skill tool, passing args=\"" + $args + "\". "
+          + "Do not respond to the literal content of their next message, do not ask for confirmation, and do not offer alternatives. "
+          + "If for any reason you cannot invoke the skill, say so explicitly and quote this resume request — do not silently default to a normal response."
         )
       }
     }
     '
+else
+    log_line "no pending-resume found — skip-prompt marker set, no additionalContext"
 fi

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -58,7 +58,7 @@ if ARGS=$("${PENDING_RESUME_SH}" consume 2> /dev/null); then
           + "Their previous invocation was `" + $cmd + "`"
           + (if $args == "" then " (no arguments — the default review of local/branch changes). " else ". " end)
           + "Their next message — whatever its literal text — is the agreed-upon trigger to proceed; treat it as if they had typed `" + $cmd + "` again. "
-          + "Your first action on the next turn MUST be to invoke the review-code skill via the Skill tool, passing args=\"" + $args + "\". "
+          + "Your first action on the next turn MUST be to invoke the review-code skill via the Skill tool, passing args=" + ($args | tojson) + ". "
           + "Do not respond to the literal content of their next message, do not ask for confirmation, and do not offer alternatives. "
           + "If for any reason you cannot invoke the skill, say so explicitly and quote this resume request — do not silently default to a normal response."
         )

--- a/tests/unit/test-clear-marker.bats
+++ b/tests/unit/test-clear-marker.bats
@@ -71,7 +71,11 @@ set_mtime() {
     [ "$status" -eq 0 ]
 
     local mtime now
-    mtime=$(stat -f %m "$MARKER_FILE" 2> /dev/null || stat -c %Y "$MARKER_FILE")
+    if [[ "${OSTYPE}" == "darwin"* ]]; then
+        mtime=$(stat -f %m "$MARKER_FILE")
+    else
+        mtime=$(stat -c %Y "$MARKER_FILE")
+    fi
     now=$(date +%s)
     # New mtime should be close to "now", not the ancient one.
     [ $((now - mtime)) -lt 10 ]

--- a/tests/unit/test-clear-marker.bats
+++ b/tests/unit/test-clear-marker.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# Tests for clear-marker.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/clear-marker.sh"
+    export SCRIPT
+
+    # Isolated marker directory per test
+    MARKER_DIR=$(mktemp -d)
+    export REVIEW_CODE_MARKER_DIR="$MARKER_DIR"
+    MARKER_FILE="$MARKER_DIR/.pending-clear"
+    export MARKER_FILE
+}
+
+teardown() {
+    rm -rf "$MARKER_DIR"
+}
+
+# Touch with a specific epoch mtime; tries BSD then GNU syntax.
+set_mtime() {
+    local file="$1"
+    local epoch="$2"
+    # BSD: -t [[CC]YY]MMDDhhmm[.SS]
+    if touch -t "$(date -r "$epoch" +%Y%m%d%H%M.%S 2> /dev/null)" "$file" 2> /dev/null; then
+        return 0
+    fi
+    # GNU: -d @epoch
+    touch -d "@$epoch" "$file"
+}
+
+# =============================================================================
+# Subcommand validation
+# =============================================================================
+
+@test "clear-marker.sh: rejects missing subcommand" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown subcommand"* ]]
+}
+
+@test "clear-marker.sh: rejects unknown subcommand" {
+    run "$SCRIPT" wat
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown subcommand"* ]]
+}
+
+# =============================================================================
+# set subcommand
+# =============================================================================
+
+@test "clear-marker.sh set: creates marker file" {
+    run "$SCRIPT" set
+    [ "$status" -eq 0 ]
+    [ -f "$MARKER_FILE" ]
+}
+
+@test "clear-marker.sh set: creates marker dir if missing" {
+    rm -rf "$MARKER_DIR"
+    run "$SCRIPT" set
+    [ "$status" -eq 0 ]
+    [ -f "$MARKER_FILE" ]
+}
+
+@test "clear-marker.sh set: refreshes marker mtime on repeat call" {
+    "$SCRIPT" set
+    set_mtime "$MARKER_FILE" 1000000000
+    run "$SCRIPT" set
+    [ "$status" -eq 0 ]
+
+    local mtime now
+    mtime=$(stat -f %m "$MARKER_FILE" 2> /dev/null || stat -c %Y "$MARKER_FILE")
+    now=$(date +%s)
+    # New mtime should be close to "now", not the ancient one.
+    [ $((now - mtime)) -lt 10 ]
+}
+
+# =============================================================================
+# check subcommand
+# =============================================================================
+
+@test "clear-marker.sh check: prints nothing when no marker exists" {
+    run "$SCRIPT" check
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "clear-marker.sh check: prints 'skip' for a fresh marker" {
+    "$SCRIPT" set
+    run "$SCRIPT" check
+    [ "$status" -eq 0 ]
+    [ "$output" = "skip" ]
+}
+
+@test "clear-marker.sh check: consumes marker on success" {
+    "$SCRIPT" set
+    "$SCRIPT" check
+    [ ! -f "$MARKER_FILE" ]
+}
+
+@test "clear-marker.sh check: one set satisfies only one check" {
+    "$SCRIPT" set
+    run "$SCRIPT" check
+    [ "$output" = "skip" ]
+
+    run "$SCRIPT" check
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "clear-marker.sh check: does not skip for an expired marker" {
+    "$SCRIPT" set
+    # TTL is 600s — set mtime to 700s ago.
+    set_mtime "$MARKER_FILE" "$(($(date +%s) - 700))"
+
+    run "$SCRIPT" check
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -f "$MARKER_FILE" ]
+}
+
+@test "clear-marker.sh check: skips for a marker just inside TTL" {
+    "$SCRIPT" set
+    # 500s old — well within the 600s TTL.
+    set_mtime "$MARKER_FILE" "$(($(date +%s) - 500))"
+
+    run "$SCRIPT" check
+    [ "$status" -eq 0 ]
+    [ "$output" = "skip" ]
+}

--- a/tests/unit/test-manage-session-hook.bats
+++ b/tests/unit/test-manage-session-hook.bats
@@ -42,11 +42,11 @@ teardown() {
     [ -f "$CLAUDE_SETTINGS_FILE" ]
 }
 
-@test "install: writes SessionStart hook with matcher 'clear'" {
+@test "install: writes SessionStart hook with matcher 'startup|clear'" {
     "$SCRIPT" install
     local matcher
     matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$CLAUDE_SETTINGS_FILE")
-    [ "$matcher" = "clear" ]
+    [ "$matcher" = "startup|clear" ]
 }
 
 @test "install: writes our command into the hook entry" {

--- a/tests/unit/test-manage-session-hook.bats
+++ b/tests/unit/test-manage-session-hook.bats
@@ -10,7 +10,7 @@ setup() {
 
     TMPDIR_TEST=$(mktemp -d)
     export CLAUDE_SETTINGS_FILE="$TMPDIR_TEST/settings.json"
-    export REVIEW_CODE_HOOK_COMMAND="/test/path/clear-marker.sh set"
+    export REVIEW_CODE_HOOK_COMMAND="/test/path/session-clear-hook.sh"
 }
 
 teardown() {
@@ -53,7 +53,7 @@ teardown() {
     "$SCRIPT" install
     local cmd
     cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
-    [ "$cmd" = "/test/path/clear-marker.sh set" ]
+    [ "$cmd" = "/test/path/session-clear-hook.sh" ]
 }
 
 # =============================================================================
@@ -124,7 +124,7 @@ JSON
     "$SCRIPT" uninstall
 
     local has_ours
-    has_ours=$(jq '[.hooks.SessionStart // [] | .[] | .hooks[]? | select(.command=="/test/path/clear-marker.sh set")] | length' "$CLAUDE_SETTINGS_FILE")
+    has_ours=$(jq '[.hooks.SessionStart // [] | .[] | .hooks[]? | select(.command=="/test/path/session-clear-hook.sh")] | length' "$CLAUDE_SETTINGS_FILE")
     [ "$has_ours" = "0" ]
 }
 
@@ -164,6 +164,35 @@ JSON
     [ "$(jq -r '.theme' "$CLAUDE_SETTINGS_FILE")" = "dark" ]
 }
 
+@test "install: replaces a legacy review-code entry (different script name in same dir)" {
+    # Simulate a previous install that registered the old clear-marker.sh path.
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "clear",
+        "hooks": [
+          {"type": "command", "command": "/legacy/skills/review-code/scripts/clear-marker.sh set"}
+        ]
+      }
+    ]
+  }
+}
+JSON
+    # Match by substring "/skills/review-code/scripts/" so the legacy entry is recognized.
+    REVIEW_CODE_HOOK_PATH_MARKER="/skills/review-code/scripts/" "$SCRIPT" install
+
+    # Legacy entry should be gone; new entry (the test command) should be present.
+    local legacy current total
+    legacy=$(jq '[.hooks.SessionStart[]?.hooks[]? | select(.command == "/legacy/skills/review-code/scripts/clear-marker.sh set")] | length' "$CLAUDE_SETTINGS_FILE")
+    current=$(jq -r '.hooks.SessionStart[].hooks[].command' "$CLAUDE_SETTINGS_FILE")
+    total=$(jq '[.hooks.SessionStart[]?.hooks[]?] | length' "$CLAUDE_SETTINGS_FILE")
+    [ "$legacy" = "0" ]
+    [ "$current" = "/test/path/session-clear-hook.sh" ]
+    [ "$total" = "1" ]
+}
+
 @test "uninstall: only removes our command, not the whole block, when block has other hooks" {
     cat > "$CLAUDE_SETTINGS_FILE" <<JSON
 {
@@ -173,7 +202,7 @@ JSON
         "matcher": "clear",
         "hooks": [
           {"type": "command", "command": "their-script"},
-          {"type": "command", "command": "/test/path/clear-marker.sh set"}
+          {"type": "command", "command": "/test/path/session-clear-hook.sh"}
         ]
       }
     ]

--- a/tests/unit/test-manage-session-hook.bats
+++ b/tests/unit/test-manage-session-hook.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+# Tests for manage-session-hook.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/manage-session-hook.sh"
+    export SCRIPT
+
+    TMPDIR_TEST=$(mktemp -d)
+    export CLAUDE_SETTINGS_FILE="$TMPDIR_TEST/settings.json"
+    export REVIEW_CODE_HOOK_COMMAND="/test/path/clear-marker.sh set"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST"
+}
+
+# =============================================================================
+# Subcommand validation
+# =============================================================================
+
+@test "manage-session-hook.sh: rejects missing subcommand" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Unknown subcommand"* ]]
+}
+
+@test "manage-session-hook.sh: rejects unknown subcommand" {
+    run "$SCRIPT" reset
+    [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# install: starting from no file
+# =============================================================================
+
+@test "install: creates settings.json when missing" {
+    run "$SCRIPT" install
+    [ "$status" -eq 0 ]
+    [ -f "$CLAUDE_SETTINGS_FILE" ]
+}
+
+@test "install: writes SessionStart hook with matcher 'clear'" {
+    "$SCRIPT" install
+    local matcher
+    matcher=$(jq -r '.hooks.SessionStart[0].matcher' "$CLAUDE_SETTINGS_FILE")
+    [ "$matcher" = "clear" ]
+}
+
+@test "install: writes our command into the hook entry" {
+    "$SCRIPT" install
+    local cmd
+    cmd=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    [ "$cmd" = "/test/path/clear-marker.sh set" ]
+}
+
+# =============================================================================
+# install: idempotency
+# =============================================================================
+
+@test "install: repeated runs do not duplicate the entry" {
+    "$SCRIPT" install
+    "$SCRIPT" install
+    "$SCRIPT" install
+    local count
+    count=$(jq '.hooks.SessionStart | length' "$CLAUDE_SETTINGS_FILE")
+    [ "$count" = "1" ]
+}
+
+# =============================================================================
+# install: preserves unrelated content
+# =============================================================================
+
+@test "install: preserves top-level keys" {
+    echo '{"theme": "dark", "model": "sonnet"}' > "$CLAUDE_SETTINGS_FILE"
+    "$SCRIPT" install
+
+    [ "$(jq -r '.theme' "$CLAUDE_SETTINGS_FILE")" = "dark" ]
+    [ "$(jq -r '.model' "$CLAUDE_SETTINGS_FILE")" = "sonnet" ]
+}
+
+@test "install: preserves unrelated SessionStart entries" {
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "startup", "hooks": [{"type": "command", "command": "other-script"}]}
+    ]
+  }
+}
+JSON
+    "$SCRIPT" install
+
+    local count other
+    count=$(jq '.hooks.SessionStart | length' "$CLAUDE_SETTINGS_FILE")
+    other=$(jq -r '.hooks.SessionStart[] | select(.matcher=="startup") | .hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    [ "$count" = "2" ]
+    [ "$other" = "other-script" ]
+}
+
+@test "install: preserves unrelated hook types" {
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [{"matcher": "Bash", "hooks": [{"type": "command", "command": "/some/safety.sh"}]}]
+  }
+}
+JSON
+    "$SCRIPT" install
+
+    local pre
+    pre=$(jq -r '.hooks.PreToolUse[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    [ "$pre" = "/some/safety.sh" ]
+}
+
+# =============================================================================
+# uninstall
+# =============================================================================
+
+@test "uninstall: removes our entry" {
+    "$SCRIPT" install
+    "$SCRIPT" uninstall
+
+    local has_ours
+    has_ours=$(jq '[.hooks.SessionStart // [] | .[] | .hooks[]? | select(.command=="/test/path/clear-marker.sh set")] | length' "$CLAUDE_SETTINGS_FILE")
+    [ "$has_ours" = "0" ]
+}
+
+@test "uninstall: preserves unrelated SessionStart entries" {
+    cat > "$CLAUDE_SETTINGS_FILE" <<'JSON'
+{
+  "hooks": {
+    "SessionStart": [
+      {"matcher": "startup", "hooks": [{"type": "command", "command": "other-script"}]}
+    ]
+  }
+}
+JSON
+    "$SCRIPT" install
+    "$SCRIPT" uninstall
+
+    local count other
+    count=$(jq '.hooks.SessionStart | length' "$CLAUDE_SETTINGS_FILE")
+    other=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    [ "$count" = "1" ]
+    [ "$other" = "other-script" ]
+}
+
+@test "uninstall: drops SessionStart key when no entries remain" {
+    "$SCRIPT" install
+    "$SCRIPT" uninstall
+
+    local has_key
+    has_key=$(jq 'has("hooks")' "$CLAUDE_SETTINGS_FILE")
+    [ "$has_key" = "false" ]
+}
+
+@test "uninstall: is a no-op when our hook isn't installed" {
+    echo '{"theme": "dark"}' > "$CLAUDE_SETTINGS_FILE"
+    "$SCRIPT" uninstall
+
+    [ "$(jq -r '.theme' "$CLAUDE_SETTINGS_FILE")" = "dark" ]
+}
+
+@test "uninstall: only removes our command, not the whole block, when block has other hooks" {
+    cat > "$CLAUDE_SETTINGS_FILE" <<JSON
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "clear",
+        "hooks": [
+          {"type": "command", "command": "their-script"},
+          {"type": "command", "command": "/test/path/clear-marker.sh set"}
+        ]
+      }
+    ]
+  }
+}
+JSON
+    "$SCRIPT" uninstall
+
+    local their count
+    their=$(jq -r '.hooks.SessionStart[0].hooks[0].command' "$CLAUDE_SETTINGS_FILE")
+    count=$(jq '.hooks.SessionStart[0].hooks | length' "$CLAUDE_SETTINGS_FILE")
+    [ "$their" = "their-script" ]
+    [ "$count" = "1" ]
+}

--- a/tests/unit/test-pending-resume.bats
+++ b/tests/unit/test-pending-resume.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# Tests for pending-resume.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/pending-resume.sh"
+    export SCRIPT
+
+    MARKER_DIR=$(mktemp -d)
+    export REVIEW_CODE_MARKER_DIR="$MARKER_DIR"
+    FILE="$MARKER_DIR/.pending-resume"
+    export FILE
+}
+
+teardown() {
+    rm -rf "$MARKER_DIR"
+}
+
+# Touch with a specific epoch mtime; tries BSD then GNU syntax.
+set_mtime() {
+    local file="$1"
+    local epoch="$2"
+    if touch -t "$(date -r "$epoch" +%Y%m%d%H%M.%S 2> /dev/null)" "$file" 2> /dev/null; then
+        return 0
+    fi
+    touch -d "@$epoch" "$file"
+}
+
+# =============================================================================
+# set / set-string
+# =============================================================================
+
+@test "set: stores args joined with spaces" {
+    "$SCRIPT" set 55298 --draft
+    [ "$(cat "$FILE")" = "55298 --draft" ]
+}
+
+@test "set-string: stores the argument verbatim" {
+    "$SCRIPT" set-string '55298 "src/**/*.ts"'
+    [ "$(cat "$FILE")" = '55298 "src/**/*.ts"' ]
+}
+
+@test "set-string: handles an empty string" {
+    "$SCRIPT" set-string ""
+    [ -f "$FILE" ]
+    [ -z "$(cat "$FILE")" ]
+}
+
+# =============================================================================
+# get / consume / clear
+# =============================================================================
+
+@test "get: prints args without deleting" {
+    "$SCRIPT" set-string "abc"
+    run "$SCRIPT" get
+    [ "$output" = "abc" ]
+    [ -f "$FILE" ]
+}
+
+@test "get: prints nothing when file missing" {
+    run "$SCRIPT" get
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "consume: prints args and deletes the file" {
+    "$SCRIPT" set-string "abc"
+    run "$SCRIPT" consume
+    [ "$output" = "abc" ]
+    [ ! -f "$FILE" ]
+}
+
+@test "consume: second call is a no-op" {
+    "$SCRIPT" set-string "abc"
+    "$SCRIPT" consume
+    run "$SCRIPT" consume
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "clear: deletes the file" {
+    "$SCRIPT" set-string "abc"
+    "$SCRIPT" clear
+    [ ! -f "$FILE" ]
+}
+
+# =============================================================================
+# TTL
+# =============================================================================
+
+@test "get: returns nothing once the file has aged past TTL" {
+    "$SCRIPT" set-string "abc"
+    set_mtime "$FILE" "$(($(date +%s) - 700))"
+    run "$SCRIPT" get
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+    [ ! -f "$FILE" ]
+}
+
+@test "get: still returns inside TTL" {
+    "$SCRIPT" set-string "abc"
+    set_mtime "$FILE" "$(($(date +%s) - 500))"
+    run "$SCRIPT" get
+    [ "$output" = "abc" ]
+}
+
+# =============================================================================
+# Subcommand validation
+# =============================================================================
+
+@test "rejects missing subcommand" {
+    run "$SCRIPT"
+    [ "$status" -eq 1 ]
+}
+
+@test "rejects unknown subcommand" {
+    run "$SCRIPT" wut
+    [ "$status" -eq 1 ]
+}

--- a/tests/unit/test-pending-resume.bats
+++ b/tests/unit/test-pending-resume.bats
@@ -68,16 +68,29 @@ set_mtime() {
 @test "consume: prints args and deletes the file" {
     "$SCRIPT" set-string "abc"
     run "$SCRIPT" consume
+    [ "$status" -eq 0 ]
     [ "$output" = "abc" ]
     [ ! -f "$FILE" ]
 }
 
-@test "consume: second call is a no-op" {
-    "$SCRIPT" set-string "abc"
-    "$SCRIPT" consume
+@test "consume: exit 0 with empty output when args were empty" {
+    "$SCRIPT" set-string ""
     run "$SCRIPT" consume
     [ "$status" -eq 0 ]
     [ -z "$output" ]
+    [ ! -f "$FILE" ]
+}
+
+@test "consume: exit 1 when nothing was pending" {
+    run "$SCRIPT" consume
+    [ "$status" -eq 1 ]
+}
+
+@test "consume: exit 1 when only an expired file remains" {
+    "$SCRIPT" set-string "abc"
+    set_mtime "$FILE" "$(($(date +%s) - 700))"
+    run "$SCRIPT" consume
+    [ "$status" -eq 1 ]
 }
 
 @test "clear: deletes the file" {

--- a/tests/unit/test-session-clear-hook.bats
+++ b/tests/unit/test-session-clear-hook.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# Tests for session-clear-hook.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    HOOK="$PROJECT_ROOT/skills/review-code/scripts/session-clear-hook.sh"
+    PR="$PROJECT_ROOT/skills/review-code/scripts/pending-resume.sh"
+    CM="$PROJECT_ROOT/skills/review-code/scripts/clear-marker.sh"
+    export HOOK PR CM
+
+    MARKER_DIR=$(mktemp -d)
+    export REVIEW_CODE_MARKER_DIR="$MARKER_DIR"
+}
+
+teardown() {
+    rm -rf "$MARKER_DIR"
+}
+
+# =============================================================================
+# Default path: no pending resume
+# =============================================================================
+
+@test "no pending resume: produces no JSON output" {
+    run "$HOOK"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "no pending resume: still writes the skip-prompt marker" {
+    "$HOOK"
+    run "$CM" check
+    [ "$output" = "skip" ]
+}
+
+# =============================================================================
+# Resume path
+# =============================================================================
+
+@test "with pending resume: outputs valid JSON" {
+    "$PR" set-string "55298 --draft"
+    run "$HOOK"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.' > /dev/null
+}
+
+@test "with pending resume: targets SessionStart" {
+    "$PR" set-string "55298"
+    run "$HOOK"
+    local hook_event
+    hook_event=$(echo "$output" | jq -r '.hookSpecificOutput.hookEventName')
+    [ "$hook_event" = "SessionStart" ]
+}
+
+@test "with pending resume: additionalContext mentions the args" {
+    "$PR" set-string "55298 --draft"
+    run "$HOOK"
+    echo "$output" | jq -r '.hookSpecificOutput.additionalContext' | grep -q "55298 --draft"
+}
+
+@test "with pending resume: still writes the skip-prompt marker" {
+    "$PR" set-string "55298"
+    "$HOOK" > /dev/null
+    run "$CM" check
+    [ "$output" = "skip" ]
+}
+
+@test "with pending resume: consumes the pending file" {
+    "$PR" set-string "55298"
+    "$HOOK" > /dev/null
+    [ ! -f "$MARKER_DIR/.pending-resume" ]
+}
+
+@test "with pending resume: file paths in args round-trip" {
+    "$PR" set-string '55298 "src/**/*.ts"'
+    run "$HOOK"
+    local args
+    args=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$args" == *'src/**/*.ts'* ]]
+}
+
+# =============================================================================
+# Robustness
+# =============================================================================
+
+@test "hook does not fail when marker dir is missing" {
+    rm -rf "$MARKER_DIR"
+    run "$HOOK"
+    [ "$status" -eq 0 ]
+}

--- a/tests/unit/test-session-clear-hook.bats
+++ b/tests/unit/test-session-clear-hook.bats
@@ -72,6 +72,18 @@ teardown() {
     [ ! -f "$MARKER_DIR/.pending-resume" ]
 }
 
+@test "with pending resume: empty args still trigger auto-resume" {
+    "$PR" set-string ""
+    run "$HOOK"
+    [ "$status" -eq 0 ]
+    # Should output JSON instructing Claude to resume the default review
+    echo "$output" | jq -e '.' > /dev/null
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    [[ "$ctx" == *"no arguments"* ]]
+    [[ "$ctx" == *"/review-code"* ]]
+}
+
 @test "with pending resume: file paths in args round-trip" {
     "$PR" set-string '55298 "src/**/*.ts"'
     run "$HOOK"

--- a/tests/unit/test-session-clear-hook.bats
+++ b/tests/unit/test-session-clear-hook.bats
@@ -12,6 +12,7 @@ setup() {
 
     MARKER_DIR=$(mktemp -d)
     export REVIEW_CODE_MARKER_DIR="$MARKER_DIR"
+    export REVIEW_CODE_HOOK_LOG="$MARKER_DIR/.session-clear-hook.log"
 }
 
 teardown() {

--- a/tests/unit/test-session-clear-hook.bats
+++ b/tests/unit/test-session-clear-hook.bats
@@ -87,9 +87,14 @@ teardown() {
 @test "with pending resume: file paths in args round-trip" {
     "$PR" set-string '55298 "src/**/*.ts"'
     run "$HOOK"
-    local args
-    args=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
-    [[ "$args" == *'src/**/*.ts'* ]]
+    local ctx
+    ctx=$(echo "$output" | jq -r '.hookSpecificOutput.additionalContext')
+    # Substring check confirms the path appears somewhere in the directive.
+    [[ "$ctx" == *'src/**/*.ts'* ]]
+    # Embedded double quotes must reach Claude in escaped form so the
+    # `args=...` framing carries the complete argument string. The jq
+    # template uses `tojson` to produce the JSON-encoded literal below.
+    [[ "$ctx" == *'args="55298 \"src/**/*.ts\""'* ]]
 }
 
 # =============================================================================

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -35,6 +35,18 @@ error() {
     echo -e "${RED}✗${NC} $1"
 }
 
+remove_session_clear_hook() {
+    # Run BEFORE remove_skill so the manage-session-hook.sh script still exists.
+    local manager="${SKILL_DIR}/scripts/manage-session-hook.sh"
+    if [[ -x "${manager}" ]]; then
+        if "${manager}" uninstall; then
+            info "Removed SessionStart hook from ~/.claude/settings.json"
+        else
+            warn "Failed to remove SessionStart hook from ~/.claude/settings.json"
+        fi
+    fi
+}
+
 remove_skill() {
     local removed=0
 
@@ -167,6 +179,7 @@ main() {
 
     # Remove components
     info "Removing review-code components…"
+    remove_session_clear_hook
     remove_skill
     remove_agents
 


### PR DESCRIPTION
## Summary

- Fix the infinite-loop in the `/review-code` pre-flight prompt. The recommended "clear conversation history" option used to send the user to `/clear`, but the skill had no way to detect they had cleared, so the prompt fired again forever. A global `SessionStart` hook in `~/.claude/settings.json` now writes a one-shot marker whenever `/clear` or session-start fires, and Step 2 of `SKILL.md` consumes the marker and skips the prompt.
- Add auto-resume so the chosen option actually resumes the original `/review-code` invocation. When the user picks "Stop here so I can /clear, then resume," the skill writes the original args to `sessions/.pending-resume`. The hook reads that file on the next `/clear` and emits `SessionStart.additionalContext` instructing Claude to invoke the skill with those args. The user only has to send any next message to trigger the resumed review.
- Add four new scripts (`clear-marker.sh`, `pending-resume.sh`, `manage-session-hook.sh`, `session-clear-hook.sh`), idempotent install/uninstall hooks in `bin/setup` and `uninstall.sh`, and bats unit tests for each.

## Test plan

- Run `bin/test` and confirm all unit tests pass (1294 tests, including the four new bats suites).
- Run `bin/setup` and confirm `~/.claude/settings.json` gains a `SessionStart` hook entry with matcher `startup|clear` and command pointing at `session-clear-hook.sh`.
- Run `/review-code`, pick "Stop here so I can /clear, then resume", run `/clear`, then send any message. The review should auto-resume with the original args.
- Confirm `/review-code 123 "src/**/*.ts"` round-trips through auto-resume with the glob pattern intact.
- Run `uninstall.sh` and confirm the hook entry is removed and unrelated hooks are preserved.