### PR TITLE
Fix create-draft-review.sh emitting null side field

### DIFF
--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -209,7 +209,7 @@ main() {
             .path != null and .line != null and .body != null and
             (.side == null or .side == "LEFT" or .side == "RIGHT");
         {
-            valid: [.[] | select(is_valid) | {path, line, side, body}],
+            valid: [.[] | select(is_valid) | {path, line, body} + (if .side then {side: .side} else {} end)],
             invalid: [.[] | select(is_valid | not)]
         }')
     comments=$(echo "${validation_result}" | jq -c '.valid')


### PR DESCRIPTION
## Summary

When a caller of `create-draft-review.sh` omits `side` on a comment, the validation jq filter still materializes `side: null` in the output payload. GitHub's PR review API rejects null `side` with HTTP 422 (`is not a member of ["LEFT", "RIGHT"]`). The script deletes any existing pending review before creating the replacement, so this leaves the user with no pending review at all.

The fix conditionally includes `side` in the constructed object, so it's only present when the input has a non-null value:

```diff
-valid: [.[] | select(is_valid) | {path, line, side, body}],
+valid: [.[] | select(is_valid) | {path, line, body} + (if .side then {side: .side} else {} end)],
```

## Test plan

- [x] jq filter handles: missing `side`, `side: null`, `side: "RIGHT"`, `side: "BOTH"` (invalid), missing `line` (invalid). Valid comments without `side` produce objects with no `side` key; explicit `"RIGHT"`/`"LEFT"` is preserved.
- [ ] End to end against a dummy PR: pipe an input with a comment missing `side` to `create-draft-review.sh`, confirm the API returns 200 with `state: PENDING`.

## Not in this PR

The plan also identifies a hardening fix worth doing separately: reorder so the existing pending review is deleted after the new one is created, or at least after the payload is validated. That needs verification that GitHub allows two PENDING reviews per user per PR.