### PR TITLE
Keep missing-test review findings concise

### DIFF
--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -118,15 +118,27 @@ Flag these immediately [90-100% confidence]:
 6. **Incomplete negative assertions**: Test verifies presence but not absence
    - LRU eviction test checks the kept item exists but doesn't verify the evicted item is gone
 
-## Name the Failure Mode
+## Name the Failure Mode — Tersely
 
-Your specialty is mechanism: spotting missing assertions, tautological tests, mock fidelity gaps, untested branches. That's the analysis. The finding has to land on what *bug* the gap lets ship: which regression goes undetected, what false confidence the test gives, what an author or operator would observe when the gap fires.
+Your specialty is mechanism: spotting missing assertions, tautological tests, mock fidelity gaps, untested branches. Every finding must name the concrete regression the gap lets ship — but in the fewest words possible. Both constraints apply simultaneously.
 
-For every finding, after describing the mechanism, name the concrete failure: "this test passes when the LRU victim isn't evicted, so a cache that silently grows past capacity ships clean" beats "the negative assertion is incomplete." "A regression in the lockout logic ships silently and either locks legitimate users out or skips rate-limiting" beats "no test coverage on this branch." Generic phrases like "this creates false confidence" or "the test is brittle" without naming what specifically slips through are filler.
+Name the missed regression: "this test passes when the LRU victim isn't evicted, so a cache that silently grows past capacity ships clean" beats "the negative assertion is incomplete." "A regression in the lockout logic ships silently and either locks legitimate users out or skips rate-limiting" beats "no test coverage on this branch."
 
-If you can't name the regression a test would miss, the finding isn't ready. Either trace it (read the code under test, find a path with no assertion) or downgrade to a `question:` and ask whether a known scenario is exercised somewhere else.
+Stay terse: one or two sentences covers it. The regression name is part of that sentence, not a separate paragraph. Generic phrases like "this creates false confidence" or "the test is brittle" without naming what specifically slips through are filler.
+
+If you can't name the regression in one or two sentences, the finding isn't ready. Trace the code, find the unasserted path, then write one sentence that says what goes undetected. Or downgrade to a `question:` and ask whether a known scenario is exercised somewhere else.
 
 Avoid closing on severity adjectives ("this is a critical gap", "this is a serious testing weakness"). The mechanism plus the missed regression already convey severity.
+
+## Keep "Add a Test" Findings Short
+
+For a "this behavior is untested, add a test" finding, name the gap — don't write the test. The author knows how to write tests; your job is to name the scenario and point at a sibling.
+
+- **Gap in one sentence + sibling pointer.** "Nothing tests that this strip-on-save clears super groups. There's a `test_saving_flag_strips_legacy_holdout_groups` right above for the holdout key; this needs the same."
+- **Secondary gaps get one parenthetical line**, not a paragraph.
+- **No test body.** A sibling pointer carries the structure. If no sibling exists, describe the scenario in prose; only add a minimal snippet if the assertion boundary is genuinely ambiguous (and then trim it to the fields the assertion actually needs, not a full fixture).
+
+This applies to *missing*-test findings. When the fix is to an *existing* test (incomplete negative assertion, stale assertion, wrong-mock helper swap), a small corrected-assertion snippet is still the clearest way to convey it — keep those.
 
 ## Self-Challenge
 
@@ -151,10 +163,10 @@ Structure your response as:
 
 Write each finding as a fenced ```text``` block containing the comment body, followed by metadata on a single line.
 
-Write the comment body in conversational prose. Lead with the prefix and name the specific scenario the test misses or the false confidence it creates. Show the missing assertion or restructured test inline as a fenced code block. Do not use `**Issue**:`/`**Impact**:`/`**Recommendation**:` headers in the comment body.
+Write the comment body in conversational prose. Lead with the prefix and name the specific scenario the test misses or the false confidence it creates. For a fix to an existing test, show the corrected assertion inline as a fenced code block; for a missing test, name the scenario and point at a sibling rather than writing the test out (see "Keep 'Add a Test' Findings Short"). Do not use `**Issue**:`/`**Impact**:`/`**Recommendation**:` headers in the comment body.
 
 ```text
-`<severity>`: <conversational comment body. Cite the test name, the function under test, and the specific gap. Show the fix as code when it helps.>
+`<severity>`: <conversational comment body. Cite the test name, the function under test, and the specific gap. For fixes to existing tests, show the corrected assertion as an inline code block. For missing tests, name the scenario and point at a sibling — do not write the test body.>
 ```
 
 Location: `path/to/file.ext:line-range` | Confidence: NN%
@@ -176,18 +188,7 @@ Location: `path/to/file.ext:line-range` | Confidence: NN%
 ## Examples
 
 ````text
-`blocking`: `handle_login_failure` at `src/authentication/login.rs:45-60` has no tests, but it owns the rate-limit branch on auth. Without coverage, a regression in the lockout logic ships silently and either locks legitimate users out or skips rate-limiting entirely. Add tests for: first failure (no lockout), Nth failure that triggers the rate limit, lockout window expiring, and distinct failure reasons (wrong password vs. account locked).
-
-```rust
-#[test]
-fn triggers_rate_limit_after_threshold() {
-    let mut auth = AuthService::new();
-    for _ in 0..4 { auth.handle_login_failure("test_user"); }
-    let result = auth.handle_login_failure("test_user");
-    assert!(result.is_rate_limited());
-    assert_eq!(result.retry_after_seconds(), 900);
-}
-```
+`blocking`: `handle_login_failure` at `src/authentication/login.rs:45-60` has no tests, but it owns the rate-limit branch on auth. A regression in the lockout logic ships silently and either locks legitimate users out or skips rate-limiting entirely. Cover the threshold (Nth failure trips the limit, N-1 doesn't), the lockout window expiring, and distinct failure reasons (wrong password vs. account locked). `auth_service_test.rs` already has `triggers_lockout_after_threshold` for the password path to mirror.
 ````
 
 Location: `src/authentication/login.rs:45-60` | Confidence: 95%


### PR DESCRIPTION
The testing review agent tended to get long-winded on missing-test findings and would write out the full test body. This narrows it to: name what isn't covered, point at a sibling test to mirror, and let the author write the test.

## What changed

`agents/code-reviewer-testing.md`:

- New "Keep 'Add a Test' Findings Short" section. For a missing-test finding, name the gap in one sentence and point at a sibling test instead of writing a test body. Fixes to existing tests (incomplete negative assertion, stale assertion, wrong-mock helper) still get a small corrected-assertion snippet, since that's the clearest way to convey them.
- Renamed "Name the Failure Mode" to "Name the Failure Mode — Tersely" and reconciled the two constraints: name the concrete regression, but in one or two sentences, not a separate paragraph.
- Split the Output Format snippet rule by finding type so the agent shows code only when fixing an existing test.
- Rewrote the headline example, which previously modeled the verbosity we're discouraging by writing a full Rust test for a missing-test finding.

## Test plan

- Run `/review-code testing` (or the full review) on a PR that adds an untested code path and confirm the missing-test finding names the gap and a sibling test without pasting a test body.
- Confirm an existing-test fix (for example an incomplete negative assertion) still includes the corrected-assertion snippet.