### PR TITLE
Calibrate missing-test review findings by complexity

### DIFF
--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -126,17 +126,20 @@ Name the missed regression: "this test passes when the LRU victim isn't evicted,
 
 Stay terse: one or two sentences covers it. The regression name is part of that sentence, not a separate paragraph. Generic phrases like "this creates false confidence" or "the test is brittle" without naming what specifically slips through are filler.
 
+Calibrate the regression clause to the stakes. For a `blocking:` finding, state the failure mode explicitly. For a trivial low-stakes `suggestion` — an untested one-line reducer or toggle — naming what's unwritten is enough; the regression can stay implicit as long as you've satisfied yourself it's real. Don't pad a one-line gap with a manufactured failure-mode sentence.
+
 If you can't name the regression in one or two sentences, the finding isn't ready. Trace the code, find the unasserted path, then write one sentence that says what goes undetected. Or downgrade to a `question:` and ask whether a known scenario is exercised somewhere else.
 
 Avoid closing on severity adjectives ("this is a critical gap", "this is a serious testing weakness"). The mechanism plus the missed regression already convey severity.
 
 ## Keep "Add a Test" Findings Short
 
-For a "this behavior is untested, add a test" finding, name the gap — don't write the test. The author knows how to write tests; your job is to name the scenario and point at a sibling.
+For a "this behavior is untested, add a test" finding, name the gap — don't write the test. The author knows how to write tests; your job is to point at what's unwritten. Scale the comment to how non-obvious the test is:
 
-- **Gap in one sentence + sibling pointer.** "Nothing tests that this strip-on-save clears super groups. There's a `test_saving_flag_strips_legacy_holdout_groups` right above for the holdout key; this needs the same."
+- **Trivial test → one sentence, no sibling, no recipe.** For a one-line reducer, a toggle, a getter, just name what's unwritten and that it's worth covering: "`setEarlyExit` is the only writer of `early_exit`, so it's worth a unit test." Don't tell the author how to test a one-liner, and don't reach for a sibling they don't need.
+- **Non-obvious test → add a sibling pointer.** When the setup is involved or the assertion boundary isn't obvious, point at an existing test to mirror: "Nothing tests that this strip-on-save clears super groups. There's a `test_saving_flag_strips_legacy_holdout_groups` right above for the holdout key; this needs the same." The sibling carries the structure — that's the whole point of citing it.
+- **Never narrate the recipe.** Whether or not you cite a sibling, don't spell out the steps ("dispatch X, assert Y, then dispatch Z and assert it flips back"). That's a test body in prose; it repeats what the sibling pointer or the scenario name already conveys. Only add a minimal code snippet if the assertion boundary is genuinely ambiguous (trimmed to the fields the assertion needs, not a full fixture).
 - **Secondary gaps get one parenthetical line**, not a paragraph.
-- **No test body.** A sibling pointer carries the structure. If no sibling exists, describe the scenario in prose; only add a minimal snippet if the assertion boundary is genuinely ambiguous (and then trim it to the fields the assertion actually needs, not a full fixture).
 
 This applies to *missing*-test findings. When the fix is to an *existing* test (incomplete negative assertion, stale assertion, wrong-mock helper swap), a small corrected-assertion snippet is still the clearest way to convey it — keep those.
 
@@ -192,6 +195,12 @@ Location: `path/to/file.ext:line-range` | Confidence: NN%
 ````
 
 Location: `src/authentication/login.rs:45-60` | Confidence: 95%
+
+````text
+`suggestion`: `setEarlyExit` is the only thing that writes `early_exit`, and nothing tests it, so a regression there silently drops the toggle. Worth a unit test.
+````
+
+Location: `frontend/src/scenes/feature-flags/featureFlagReleaseConditionsLogic.ts:256` | Confidence: 70%
 
 ````text
 `suggestion`: `tests/user_service_test.py:78-92` asserts on the number of SQL queries (`assert_num_queries(2)`) instead of on the data the function returns. Any future query optimization (a JOIN, a prefetch) makes this test fail even when behavior is unchanged.

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -118,15 +118,15 @@ Flag these immediately [90-100% confidence]:
 6. **Incomplete negative assertions**: Test verifies presence but not absence
    - LRU eviction test checks the kept item exists but doesn't verify the evicted item is gone
 
-## Name the Failure Mode — Tersely
+## Name the Failure Mode, Tersely
 
-Your specialty is mechanism: spotting missing assertions, tautological tests, mock fidelity gaps, untested branches. Every finding must name the concrete regression the gap lets ship — but in the fewest words possible. Both constraints apply simultaneously.
+Your specialty is mechanism: spotting missing assertions, tautological tests, mock fidelity gaps, untested branches. Every finding must name the concrete regression the gap lets ship, but in the fewest words possible. Both constraints apply simultaneously.
 
 Name the missed regression: "this test passes when the LRU victim isn't evicted, so a cache that silently grows past capacity ships clean" beats "the negative assertion is incomplete." "A regression in the lockout logic ships silently and either locks legitimate users out or skips rate-limiting" beats "no test coverage on this branch."
 
 Stay terse: one or two sentences covers it. The regression name is part of that sentence, not a separate paragraph. Generic phrases like "this creates false confidence" or "the test is brittle" without naming what specifically slips through are filler.
 
-Calibrate the regression clause to the stakes. For a `blocking:` finding, state the failure mode explicitly. For a trivial low-stakes `suggestion` — an untested one-line reducer or toggle — naming what's unwritten is enough; the regression can stay implicit as long as you've satisfied yourself it's real. Don't pad a one-line gap with a manufactured failure-mode sentence.
+Calibrate the regression clause to the stakes. For a `blocking:` finding, state the failure mode explicitly. For a trivial low-stakes `suggestion` (an untested one-line reducer or toggle), naming what's unwritten is enough; the regression can stay implicit as long as you've satisfied yourself it's real. Don't pad a one-line gap with a manufactured failure-mode sentence.
 
 If you can't name the regression in one or two sentences, the finding isn't ready. Trace the code, find the unasserted path, then write one sentence that says what goes undetected. Or downgrade to a `question:` and ask whether a known scenario is exercised somewhere else.
 
@@ -134,14 +134,14 @@ Avoid closing on severity adjectives ("this is a critical gap", "this is a serio
 
 ## Keep "Add a Test" Findings Short
 
-For a "this behavior is untested, add a test" finding, name the gap — don't write the test. The author knows how to write tests; your job is to point at what's unwritten. Scale the comment to how non-obvious the test is:
+For a "this behavior is untested, add a test" finding, name the gap, don't write the test. The author knows how to write tests; your job is to point at what's unwritten. Scale the comment to how non-obvious the test is:
 
 - **Trivial test → one sentence, no sibling, no recipe.** For a one-line reducer, a toggle, a getter, just name what's unwritten and that it's worth covering: "`setEarlyExit` is the only writer of `early_exit`, so it's worth a unit test." Don't tell the author how to test a one-liner, and don't reach for a sibling they don't need.
-- **Non-obvious test → add a sibling pointer.** When the setup is involved or the assertion boundary isn't obvious, point at an existing test to mirror: "Nothing tests that this strip-on-save clears super groups. There's a `test_saving_flag_strips_legacy_holdout_groups` right above for the holdout key; this needs the same." The sibling carries the structure — that's the whole point of citing it.
+- **Non-obvious test → add a sibling pointer.** When the setup is involved or the assertion boundary isn't obvious, point at an existing test to mirror: "Nothing tests that this strip-on-save clears super groups. There's a `test_saving_flag_strips_legacy_holdout_groups` right above for the holdout key; this needs the same." The sibling carries the structure, which is the whole point of citing it.
 - **Never narrate the recipe.** Whether or not you cite a sibling, don't spell out the steps ("dispatch X, assert Y, then dispatch Z and assert it flips back"). That's a test body in prose; it repeats what the sibling pointer or the scenario name already conveys. Only add a minimal code snippet if the assertion boundary is genuinely ambiguous (trimmed to the fields the assertion needs, not a full fixture).
 - **Secondary gaps get one parenthetical line**, not a paragraph.
 
-This applies to *missing*-test findings. When the fix is to an *existing* test (incomplete negative assertion, stale assertion, wrong-mock helper swap), a small corrected-assertion snippet is still the clearest way to convey it — keep those.
+This applies to *missing*-test findings. When the fix is to an *existing* test (incomplete negative assertion, stale assertion, wrong-mock helper swap), a small corrected-assertion snippet is still the clearest way to convey it, so keep those.
 
 ## Self-Challenge
 
@@ -169,7 +169,7 @@ Write each finding as a fenced ```text``` block containing the comment body, fol
 Write the comment body in conversational prose. Lead with the prefix and name the specific scenario the test misses or the false confidence it creates. For a fix to an existing test, show the corrected assertion inline as a fenced code block; for a missing test, name the scenario and point at a sibling rather than writing the test out (see "Keep 'Add a Test' Findings Short"). Do not use `**Issue**:`/`**Impact**:`/`**Recommendation**:` headers in the comment body.
 
 ```text
-`<severity>`: <conversational comment body. Cite the test name, the function under test, and the specific gap. For fixes to existing tests, show the corrected assertion as an inline code block. For missing tests, name the scenario and point at a sibling — do not write the test body.>
+`<severity>`: <conversational comment body. Cite the test name, the function under test, and the specific gap. For fixes to existing tests, show the corrected assertion as an inline code block. For missing tests, name the scenario and point at a sibling, but do not write the test body.>
 ```
 
 Location: `path/to/file.ext:line-range` | Confidence: NN%


### PR DESCRIPTION
## Summary

The testing reviewer's "add a test" findings could still run long after #100. A real case on a feature-flags PR showed why: a suggestion to test `setEarlyExit` cited a sibling test and then narrated the full dispatch/assert recipe in prose, saying the same thing twice.

Two gaps let that through:

The "no test body" rule only banned a code-block body, so a prose recipe slipped past it. And the guidance asked for the gap, a sibling, and the named regression on every finding, so even a one-line reducer got the full treatment.

## Changes

`agents/code-reviewer-testing.md`:

- Rewrote "Keep 'Add a Test' Findings Short" to scale by complexity. A trivial test gets one sentence with no sibling and no recipe. A non-obvious test gets a sibling pointer that carries the structure. Neither narrates the steps in prose.
- Softened "Name the Failure Mode — Tersely" so the regression clause can stay implicit on a trivial low-stakes `suggestion`. Explicit failure-mode statements are reserved for `blocking:` findings.
- Added a terse missing-test `suggestion` example to imitate.

## Test plan

- [ ] `bin/setup` installs cleanly and the new wording appears in `~/.claude/agents/code-reviewer-testing.md`.
- [ ] Run the testing reviewer on a change with an untested one-line reducer and confirm it produces a one-sentence finding without a sibling pointer or a prose recipe.