### PR TITLE
Cut metaphor-jargon from review comment voice

### DIFF
--- a/agents/code-reviewer-voice.md
+++ b/agents/code-reviewer-voice.md
@@ -28,6 +28,7 @@ Apply these to the prose only, never to code blocks, inline code, or quoted stri
 
 - **Lead with what the code does or breaks.** "This rename leaves the cache stale for up to an hour after deploy" beats "This is a real upgrade-window risk." Do not open with severity adjectives.
 - **Plain English over jargon.** "Stays at 22" not "remains at its prior value". "Doesn't catch" not "fails to handle". "Runs once" not "is invoked a single time". "On every request" not "with each invocation".
+- **No metaphor-jargon.** Don't label code with metaphors that mean different things in different contexts: "load-bearing", "code smell", "foot-gun", "happy path" (in prose). State the concrete behavior instead. Not "this import is load-bearing", but "this import has to stay inside the function: moving it to the top would create a circular import".
 - **No em dashes.** Replace with commas, colons, semicolons, parentheses, or split into separate sentences. The em dash character is `—` (U+2014). The hyphen `-` and en dash `–` are fine.
 - **No headers in the body.** Strip `**Issue**:`, `**Impact**:`, `**Recommendation**:`, `**Fix**:`, `**Problem**:`, `**Solution**:`, `**Vulnerability**:`. The prose should flow as natural sentences.
 - **One idea per sentence.** If a sentence has stacked clauses ("X happens because Y, which causes Z, although W"), break it apart.

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -438,6 +438,7 @@ Cut on sight (the label → say the thing instead):
 | "the headline behavior", "the core path here", "the key thing" | name it: "counting events by the team's local day is the whole point here" |
 | "weak positive assertion", "tautology", "invariant violation" | the scenario: "the count stays 22 and the test still passes" |
 | coined hyphen-jargon: "migrated-forward home", "missing-timestamp side" | plain: "the case where one side has no timestamp" |
+| metaphor-jargon: "load-bearing", "code smell", "foot-gun" | the concrete behavior: "has to stay inside the function or it's a circular import" |
 | "fails to handle", "remains at its prior value", "is invoked a single time" | "doesn't catch", "stays at 22", "runs once" |
 | "this is critical", "real risk", "meaningful state change" | say what concretely breaks |
 | "It's not just X, it's Y", "Great work", "Just a thought, but…", "Hope that helps!" | cut it (the prefix already signals priority) |


### PR DESCRIPTION
Adds a rule against metaphors that mean different things in different contexts ("load-bearing", "code smell", "foot-gun") so review comments state the concrete behavior instead.

Two layers, since the term can creep in at either stage:

- `skills/review-code/handlers/review.md`: new row in the synthesis-time "cut on sight" table, catching it where the comment is first written.
- `agents/code-reviewer-voice.md`: a dedicated voice rule right after "Plain English over jargon", as the final-pass backstop.

Both name the fix the way you'd phrase it: say the import has to stay inside the function or it's a circular import, rather than labeling it "load-bearing".

## Test plan

- [ ] `bin/test` passes (1308 unit tests).