### PR TITLE
Switch review agents to Fable 5

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-architecture
 description: "Use this agent when you need high-level design and architecture review of code changes. Focuses exclusively on necessity, simplicity, established patterns, and code reuse. Examples: Before adding new dependencies, when implementing new features, for refactoring efforts. Use this to question premises and suggest better approaches."
-model: opus
+model: fable
 color: blue
 ---
 

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-compatibility
 description: "Use this agent for backwards compatibility analysis of code changes. Focuses exclusively on breaking changes to code already shipped in the default branch (main/master). Use before deploying API changes, modifying public interfaces, or making database schema updates."
-model: opus
+model: fable
 color: purple
 ---
 

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-correctness
 description: "Use this agent to verify code actually works as intended. Focuses on functional correctness: does the code do what the PR claims, integrate correctly at system boundaries, and preserve existing behavior intentionally? Best for code that crosses system boundaries (cache, queue, API), makes specific claims in the PR description, or interacts with other components."
-model: opus
+model: fable
 color: orange
 ---
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-frontend
 description: "Use this agent for deep frontend code review: React components, Kea state management, hooks patterns, accessibility, and TypeScript type safety. Invoke before deploying UI changes, when modifying React components, or for accessibility-critical features."
-model: opus
+model: fable
 color: cyan
 ---
 

--- a/agents/code-reviewer-infra-config.md
+++ b/agents/code-reviewer-infra-config.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-infra-config
 description: "Use this agent for infrastructure config review: Helm values, Kubernetes manifests, Terraform, ArgoCD configs, CI/CD pipelines. Focuses on cross-environment consistency, route/service correctness, operational safety, and config validation."
-model: opus
+model: fable
 color: cyan
 ---
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-maintainability
 description: "Use this agent when you need deep maintainability analysis of code changes. Focuses exclusively on readability, clarity, simplicity, and long-term code health. Examples: Before refactoring, when reviewing complex logic, when code will be maintained by others, when functions exceed 50 lines or have high cyclomatic complexity."
-model: opus
+model: fable
 color: green
 ---
 

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-performance
 description: "Use this agent when you need deep performance analysis of code changes. Focuses exclusively on bottlenecks, inefficiencies, and optimization opportunities. Examples: Before deploying database query changes, when implementing high-traffic endpoints, for performance-critical features like event processing or analytics. Use this for thorough performance review beyond the general code-reviewer's coverage."
-model: opus
+model: fable
 color: orange
 ---
 

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-security
 description: "Use this agent when you need deep security analysis of code changes. Focuses exclusively on vulnerabilities, exploits, and security hardening. Examples: Before deploying authentication changes, when handling sensitive data or user input, for security-critical features like payment processing or admin panels. Use this for thorough security review beyond the general code-reviewer's coverage."
-model: opus
+model: fable
 color: red
 ---
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-testing
 description: "Deep test quality analysis of code changes. Focuses exclusively on test coverage, test patterns, and ensuring comprehensive testing. Use before merging features without tests, when fixing bugs without regression tests, or when reviewing test suites."
-model: opus
+model: fable
 color: yellow
 ---
 

--- a/agents/finding-validator.md
+++ b/agents/finding-validator.md
@@ -1,7 +1,7 @@
 ---
 name: finding-validator
 description: "Adversarial validation agent that attempts to disprove blocking findings from code review. Receives a finding and the code, then tries to construct the strongest argument that the finding is wrong, theoretical, or not a real issue."
-model: opus
+model: fable
 color: magenta
 ---
 


### PR DESCRIPTION
- Switches all 10 judgment agents (the 9 `code-reviewer-*` reviewers plus `finding-validator`) from `model: opus` to `model: fable` so reviews run on Claude Fable 5, the new top intelligence tier.
- `code-reviewer-voice` stays on `haiku` (mechanical rewriting) and `code-review-context-explorer` keeps inheriting the session model (exploration, not judgment).
- The agent prompts already use the report-with-confidence pattern with downstream validation, so no prompt changes are needed for the more literal instruction-following of Fable-tier models.

Fable 5 is included free on Max plans through June 22; after that it draws usage credits at roughly 2x Opus weight, so a full review run costs about double the quota. If that proves too expensive, the fallback is keeping `fable` only on `finding-validator`, `code-reviewer-security`, and `code-reviewer-correctness` (one-word frontmatter edits).

## Test plan

- [ ] Run `bin/setup` and confirm `~/.claude/agents/*.md` frontmatter shows `model: fable` for the 10 agents and `model: haiku` for `code-reviewer-voice`
- [ ] Run `/review-code` on a PR and confirm the reviewer subagents spawn on Fable 5