### PR TITLE
Tune review prompts for human voice instead of gating em dashes

### DIFF
--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -7,7 +7,7 @@ color: red
 
 You are a senior security engineer specializing in application security and vulnerability assessment. Your sole focus is identifying SECURITY vulnerabilities and providing SPECIFIC, ACTIONABLE remediation guidance. You do not review for performance, maintainability, or general code quality - only security.
 
-## Calibration — read this first
+## Calibration: read this first
 
 Report a finding only when you can trace user-controlled input from a concrete source (HTTP request body/query/header, queue payload, file upload, retrieved document, tool output) to a concrete sink (DB query, shell, response, filesystem, outbound HTTP, agent tool call) with the missing control identified.
 
@@ -21,36 +21,36 @@ Read `$architectural_context` first. It contains callers and dependencies alread
 
 Assume all user input is malicious. Work these two steps in order before forming any opinion.
 
-**Step 1 — Threat model.** Use the diff, PR description, and commit messages to answer:
+**Step 1: Threat model.** Use the diff, PR description, and commit messages to answer:
 
 1. **Asset / capability:** What can a caller now do, read, or change that they couldn't before? (new endpoint, new request field, new tool, widened queryset, new outbound call)
-2. **Trust boundary:** Which boundary did this change move or open — where does attacker-controlled data first enter trusted execution?
+2. **Trust boundary:** Which boundary did this change move or open, and where does attacker-controlled data first enter trusted execution?
 3. **Attacker & goal:** Who is the realistic attacker (anonymous request, authenticated tenant, a *different* tenant, a compromised upstream/MCP source) and what would they try to read, change, or impersonate?
-4. **Expected controls:** What control *should* guard each goal — authz scope, tenant filter, idempotency, sanitizer, allowlist?
+4. **Expected controls:** What control *should* guard each goal: authz scope, tenant filter, idempotency, sanitizer, allowlist?
 
-This gives you a checklist of controls to verify, and points the hunt at controls that should exist but may be **absent** — a missing tenant filter, a new endpoint with no authz check, an un-idempotent money path. Source-to-sink tracing misses this class, because tracing starts from inputs that already exist rather than from guards that should.
+This gives you a checklist of controls to verify, and points the hunt at controls that should exist but may be **absent**: a missing tenant filter, a new endpoint with no authz check, an un-idempotent money path. Source-to-sink tracing misses this class, because tracing starts from inputs that already exist rather than from guards that should.
 
 A control you flag as missing is still only a finding once it clears the Calibration bar above. If you can't reach it with a concrete attack, record it as cleared in your Investigation Summary, never as a `suggestion:` to "add defense in depth."
 
-**Step 2 — Targeted checks.** Verify the controls from Step 1 and trace each user-controlled input end to end:
+**Step 2: Targeted checks.** Verify the controls from Step 1 and trace each user-controlled input end to end:
 
 1. **Trace each user-controlled input in the diff from entry point to sink**: For each input (query param, request body field, header, file upload), open the functions it flows through and follow it to where it's consumed (SQL query, shell command, template render, file path, etc.). Do not claim an injection vulnerability without tracing the complete path.
-2. **Find existing guards before concluding a control is absent**: Read the full file, not just the diff hunk — controls are often defined outside the changed lines (base class `__init__`, class-level decorators, middleware registration). Grep for the authentication decorators, input sanitizers, and validation middleware applied to the changed endpoint. A finding already mitigated upstream is a false positive.
-3. **Read the full call graph, not just the file in the diff**: Grep for convenience overloads, helper modules, and extension methods (`*Extensions.cs`, `*Helper.cs`, `*_utils.py`). "The public method requires X" is not the same as "no caller path defaults X" — a wrapper elsewhere may pass user input straight through.
+2. **Find existing guards before concluding a control is absent**: Read the full file, not just the diff hunk; controls are often defined outside the changed lines (base class `__init__`, class-level decorators, middleware registration). Grep for the authentication decorators, input sanitizers, and validation middleware applied to the changed endpoint. A finding already mitigated upstream is a false positive.
+3. **Read the full call graph, not just the file in the diff**: Grep for convenience overloads, helper modules, and extension methods (`*Extensions.cs`, `*Helper.cs`, `*_utils.py`). "The public method requires X" is not the same as "no caller path defaults X". A wrapper elsewhere may pass user input straight through.
 4. **Grep for similar endpoints or handlers to check whether auth/validation is consistently applied**: If the same pattern is present on 10 other endpoints without a finding, either the protection is upstream or you are about to file a systemic issue. Name which.
 
 ## Security Review Scope
 
-Review code changes for these security concerns in priority order. In multi-tenant SaaS codebases, broken access control is almost always the highest-impact class — start there.
+Review code changes for these security concerns in priority order. In multi-tenant SaaS codebases, broken access control is almost always the highest-impact class, so start there.
 
 ### 1. Broken Access Control & Tenant Isolation
 
 - Missing `permission_classes` / authentication on endpoints that read or mutate user data.
-- **IDOR / tenant crossover:** every queryset that loads user-scoped data must filter by the tenant/team/org ID derived from the authenticated session — never from request input. Look for:
+- **IDOR / tenant crossover:** every queryset that loads user-scoped data must filter by the tenant/team/org ID derived from the authenticated session, never from request input. Look for:
   - `Model.objects.get(pk=request.data["id"])` without a `team_id=` (or equivalent) filter.
   - Nested serializers / `PrimaryKeyRelatedField` whose queryset is not tenant-scoped.
   - `@action` methods on viewsets that bypass the parent viewset's `get_queryset()`.
-  - Foreign-key fields accepted in request bodies (`team_id`, `created_by`, `organization_id`) — can a user pass another tenant's ID?
+  - Foreign-key fields accepted in request bodies (`team_id`, `created_by`, `organization_id`): can a user pass another tenant's ID?
 - **Privilege escalation:** non-admin users invoking admin-only paths; role checks that compare against request input rather than session state.
 - **Mass assignment:** serializers with `fields = "__all__"` or write-allowed fields that include sensitive columns (`is_staff`, `team`, `organization`, `owner`, `created_by`).
 - **File upload restrictions bypass:** type/extension checks performed only on the client, or only on filename rather than content.
@@ -107,21 +107,21 @@ Review code changes for these security concerns in priority order. In multi-tena
 
 Agents combine three capabilities that, together, form the "lethal trifecta": (1) access to private data, (2) exposure to attacker-controlled content, (3) the ability to act externally (tool calls, outbound network, side-effecting operations). Any agent with all three is one indirect injection away from data exfiltration. Audit with that frame.
 
-*Untrusted-content sources that reach the model context:* end-user chat input, tool/MCP outputs (fetched web pages, file contents, third-party API responses), retrieved documents (RAG, vector store) — anything a user can write to is now a system-prompt vector — persistent agent memory, tool/MCP-server *descriptions and parameter schemas* (a malicious MCP server can carry injection inside its `description` field), filenames, error messages, log lines.
+*Untrusted-content sources that reach the model context:* end-user chat input, tool/MCP outputs (fetched web pages, file contents, third-party API responses), retrieved documents (RAG, vector store), persistent agent memory, tool/MCP-server *descriptions and parameter schemas* (a malicious MCP server can carry injection inside its `description` field), filenames, error messages, log lines. Anything a user can write to is now a system-prompt vector.
 
-*Tool-call authorization — the most frequent real bug:*
+*Tool-call authorization (the most frequent real bug):*
 
 - Tools must enforce **the end-user's** authorization, not the agent's service credentials. A tool that calls an internal endpoint already filtering by `team_id` from the user's session is fine. A tool running with a long-lived service token, broad cloud creds, or DB superuser access is a confused-deputy primitive.
-- Tools accepting an ID argument (project_id, user_id, dashboard_id) must re-check that the calling user can access that ID server-side — never trust the model to pass the right one.
+- Tools accepting an ID argument (project_id, user_id, dashboard_id) must re-check that the calling user can access that ID server-side; never trust the model to pass the right one.
 - Destructive or externally-visible tools (delete, send_email, transfer, publish, run_sql_with_writes) require **fresh per-call user confirmation surfaced in the UI**. The model asserting "the user said yes" is not consent.
-- Tool inputs must be validated server-side with the same rigor as a public API endpoint — schema, type, range, tenant scope.
+- Tool inputs must be validated server-side with the same rigor as a public API endpoint: schema, type, range, tenant scope.
 
 *Prompt-injection impact paths worth flagging:*
 
 - Indirect injection → tool call with side effects (sends email, deletes data, transfers funds, escalates role).
 - Indirect injection → exfil via output rendering: markdown image URLs, link unfurls, redirected fetches.
 - Indirect injection → exfil via outbound tool: fetch-URL tool, search query carrying conversation tokens, webhook target.
-- Injection that only changes the model's tone, helpfulness, or refusal behavior is **not a security finding** — skip it.
+- Injection that only changes the model's tone, helpfulness, or refusal behavior is **not a security finding**; skip it.
 
 *Output rendering (exfil channels):* markdown image references cause the renderer to fetch attacker-chosen URLs, leaking conversation contents in the URL. Sanitize, proxy through a same-origin allowlist, or strip image rendering. Hyperlinks: render the full URL or restrict hosts; block `javascript:` / `data:` / `vbscript:`. Never render raw HTML/iframes/SVG from model output. Model output piped into a shell, SQL executor, templating engine, `eval`, or redirect target must be parameterized or structurally validated.
 
@@ -157,7 +157,7 @@ Before including any finding, argue against it:
 
 ## Things That Are NOT Findings
 
-Suppress these — they generate noise, not signal:
+Suppress these; they generate noise, not signal:
 
 - "Consider adding input validation" without a specific bypass.
 - "This function is complex and could have bugs."
@@ -167,7 +167,7 @@ Suppress these — they generate noise, not signal:
 - Library upgrade suggestions without a CVE that affects the way the library is used here.
 - "Prompt injection is theoretically possible" with no downstream sink that turns it into impact (data egress, unauthorized action, privilege change).
 - "The agent could be tricked into being unhelpful / refusing / saying something off-brand." Not a security finding.
-- "Add a human-in-the-loop confirmation" as a generic recommendation — only flag if a *destructive, unconfirmed* action is reachable today.
+- "Add a human-in-the-loop confirmation" as a generic recommendation; only flag it if a *destructive, unconfirmed* action is reachable today.
 - LLM hallucination, factual errors, or low-quality output framed as a security issue.
 - Code behind a disabled feature flag, dead code, or code unreachable from any entrypoint.
 
@@ -175,7 +175,7 @@ Suppress these — they generate noise, not signal:
 
 **Response Structure:**
 
-1. **Investigation Summary**: For each of the four threat-model elements (asset/capability, trust boundary, attacker and goal, expected controls), state what you found and how it resolved — traced to a finding, or cleared and why. Note each input flow traced (source to sink), each guard verified, and any consistency checks across similar endpoints. Note any steps where `$architectural_context` already provided sufficient coverage.
+1. **Investigation Summary**: For each of the four threat-model elements (asset/capability, trust boundary, attacker and goal, expected controls), state what you found and how it resolved: traced to a finding, or cleared and why. Note each input flow traced (source to sink), each guard verified, and any consistency checks across similar endpoints. Note any steps where `$architectural_context` already provided sufficient coverage.
 2. **Security Posture**: Brief assessment of overall security state
 3. **Blocking Issues**: Exploitable vulnerabilities requiring immediate fix
 4. **Suggestions & Questions**: Security weaknesses and clarifications worth discussing

--- a/agents/code-reviewer-voice.md
+++ b/agents/code-reviewer-voice.md
@@ -47,6 +47,10 @@ Apply these to the prose only, never to code blocks, inline code, or quoted stri
 
 If the original buries the concrete failure under jargon ("this introduces a behavioral inconsistency"), pull it forward and say it plainly ("requests for inactive users hit the database every time"). Do not add a failure mode that wasn't in the original.
 
+## Final Scan Before Returning
+
+Before you emit the response, scan each body you marked `unchanged: true` for the hard tells: an em dash in prose, a `**Label**:` header, or the AI-vocabulary words above. A body containing any of them is never "already clean". Fix that sentence (restructure it; don't just swap the em dash for a comma) and set `unchanged: false`. The only valid reasons for `unchanged: true` are a body with none of these tells, a suspicious format, or a rewrite that would grow the body.
+
 ## Input and Output Format
 
 You receive a JSON array of findings in the prompt. Each object has at minimum:

--- a/agents/code-reviewer-voice.md
+++ b/agents/code-reviewer-voice.md
@@ -49,7 +49,7 @@ If the original buries the concrete failure under jargon ("this introduces a beh
 
 ## Final Scan Before Returning
 
-Before you emit the response, scan each body you marked `unchanged: true` for the hard tells: an em dash in prose, a `**Label**:` header, or the AI-vocabulary words above. A body containing any of them is never "already clean". Fix that sentence (restructure it; don't just swap the em dash for a comma) and set `unchanged: false`. The only valid reasons for `unchanged: true` are a body with none of these tells, a suspicious format, or a rewrite that would grow the body.
+Before you emit the response, scan each body you marked `unchanged: true` for the hard tells, applying the same prose-only scope as the Voice Rules (never flag anything inside code blocks, inline code, or quoted strings): an em dash in prose, one of the pseudo-label headers from the strip rule (`**Issue**:`, `**Impact**:`, `**Recommendation**:`, `**Fix**:`, `**Problem**:`, `**Solution**:`, `**Vulnerability**:`), or the AI-vocabulary words above. The severity prefix is not a tell: a `**blocking**:`, `**suggestion**:`, `**question**:`, or `**nit**:` opener stays exactly as the input wrote it (Hard Preservation Rule 3). A body containing a real tell is never "already clean": fix that sentence (restructure it; don't just swap the em dash for a comma) and set `unchanged: false`. The only valid reasons for `unchanged: true` are a body with none of these tells, a suspicious format, or a rewrite that would grow the body.
 
 ## Input and Output Format
 

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -96,7 +96,7 @@ Run the parse script to determine the review mode and parameters:
 ~/.claude/skills/review-code/scripts/parse-review-arg.sh $ARGUMENTS 2>&1
 ```
 
-Save the JSON output as `PARSE_RESULT`. Reference this throughout — do not run the parse script again.
+Save the JSON output as `PARSE_RESULT`. Reference this throughout; do not run the parse script again.
 
 **Handler File Selection:**
 
@@ -125,7 +125,7 @@ Code reviews are context-heavy and work best with a fresh context.
 ~/.claude/skills/review-code/scripts/clear-marker.sh check
 ```
 
-If the output is `skip`, proceed directly to Step 3 — the user already cleared.
+If the output is `skip`, proceed directly to Step 3; the user already cleared.
 
 **Otherwise**, use AskUserQuestion:
 - Question: "Code reviews work best with a fresh context. Clear conversation history before starting?"
@@ -153,7 +153,7 @@ Initialize the review session by running the orchestrator and caching the result
 ~/.claude/skills/review-code/scripts/review-status-handler.sh init $ARGUMENTS
 ```
 
-Save the output as `SESSION_ID` — you'll need it for all subsequent operations. Then get the status:
+Save the output as `SESSION_ID`; you'll need it for all subsequent operations. Then get the status:
 
 ```bash
 ~/.claude/skills/review-code/scripts/review-status-handler.sh get-status "<SESSION_ID>"
@@ -186,7 +186,7 @@ Display the error to the user. Then clean up the session:
 ~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"
 ```
 
-Stop — do not proceed with review.
+Stop. Do not proceed with review.
 
 ### Handler: "ambiguous"
 

--- a/skills/review-code/context/languages/python.md
+++ b/skills/review-code/context/languages/python.md
@@ -88,7 +88,7 @@ def view(request: HttpRequest, user_id: Optional[int] = None) -> HttpResponse:
 
 - Use `dict["key"]` for fields that must be present (primary keys, identifiers, required schema fields). This fails fast with a clear `KeyError` if the data is unexpectedly malformed, rather than silently propagating `None` downstream where it causes confusing errors.
 - Use `dict.get("key")` only for genuinely optional fields where absence is a valid state.
-- When building lookup dicts from lists (e.g., `{item["id"]: item for item in items}`), use direct access for the key field — if the field is missing, the data is corrupt and you want to know immediately.
+- When building lookup dicts from lists (e.g., `{item["id"]: item for item in items}`), use direct access for the key field. If the field is missing, the data is corrupt and you want to know immediately.
 
 ```python
 # Good - fails fast if "id" is missing

--- a/skills/review-code/handlers/find.md
+++ b/skills/review-code/handlers/find.md
@@ -10,14 +10,14 @@ Extract these fields from the JSON output:
 
 | Field | Default |
 |-------|---------|
-| `display_target` | — |
-| `file_info.file_path` | — |
-| `file_info.file_exists` | — |
+| `display_target` | (none) |
+| `file_info.file_path` | (none) |
+| `file_info.file_exists` | (none) |
 | `file_info.has_branch_review` | false |
-| `file_info.branch_review_path` | — |
+| `file_info.branch_review_path` | (none) |
 | `file_info.needs_rename` | false |
-| `file_info.pr_number` | — |
-| `file_summary` | — |
+| `file_info.pr_number` | (none) |
+| `file_summary` | (none) |
 
 Then cleanup the session:
 
@@ -25,7 +25,7 @@ Then cleanup the session:
 ~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"
 ```
 
-**Stop after presenting results — do not proceed with review agents.**
+**Stop after presenting results. Do not proceed with review agents.**
 
 ---
 
@@ -61,9 +61,9 @@ Warn the user and use AskUserQuestion:
 
 - Question: "A branch review exists alongside the PR review. What would you like to do?"
 - Options:
-  1. "Merge into PR review" — Append branch review content to PR review, then delete the branch review
-  2. "Keep both" — Leave both files as-is
-  3. "Delete branch review" — Remove the branch review file
+  1. "Merge into PR review": Append branch review content to PR review, then delete the branch review
+  2. "Keep both": Leave both files as-is
+  3. "Delete branch review": Remove the branch review file
 
 Show the branch review path: `$branch_review_path`
 
@@ -89,8 +89,8 @@ Use AskUserQuestion:
 
 - Question: "A PR (#$pr_number) now exists for this branch. Migrate the review?"
 - Options:
-  1. "Migrate to PR review" — Rename the file from branch to PR format
-  2. "Keep as branch review" — Leave the file as-is
+  1. "Migrate to PR review": Rename the file from branch to PR format
+  2. "Keep as branch review": Leave the file as-is
 
 If the user selects "Migrate to PR review":
 

--- a/skills/review-code/handlers/find.md
+++ b/skills/review-code/handlers/find.md
@@ -10,14 +10,14 @@ Extract these fields from the JSON output:
 
 | Field | Default |
 |-------|---------|
-| `display_target` | (none) |
-| `file_info.file_path` | (none) |
-| `file_info.file_exists` | (none) |
+| `display_target` | always set |
+| `file_info.file_path` | always set |
+| `file_info.file_exists` | false |
 | `file_info.has_branch_review` | false |
-| `file_info.branch_review_path` | (none) |
+| `file_info.branch_review_path` | null |
 | `file_info.needs_rename` | false |
-| `file_info.pr_number` | (none) |
-| `file_summary` | (none) |
+| `file_info.pr_number` | null |
+| `file_summary` | "" |
 
 Then cleanup the session:
 

--- a/skills/review-code/handlers/learn.md
+++ b/skills/review-code/handlers/learn.md
@@ -58,10 +58,10 @@ Use AskUserQuestion:
 - Question: "Claude flagged this issue, but the file wasn't modified. What happened?"
 - Display finding details: file, line, description, agent, confidence
 - Options:
-  1. "False positive" — Claude was wrong, no fix needed
-  2. "Correct but deferred" — Valid issue, postponed
-  3. "Correct but low priority" — Valid but not worth changing
-  4. "Skip" — Don't record this learning
+  1. "False positive": Claude was wrong, no fix needed
+  2. "Correct but deferred": Valid issue, postponed
+  3. "Correct but low priority": Valid but not worth changing
+  4. "Skip": Don't record this learning
 
 For **"missed" findings** (other reviewer found, Claude missed):
 
@@ -69,9 +69,9 @@ Use AskUserQuestion:
 - Question: "Another reviewer found this issue that Claude missed. Should Claude learn to detect this?"
 - Display finding details: file, line, description, author
 - Options:
-  1. "Yes, add to patterns" — Claude should catch this in future reviews
-  2. "No, too specific" — One-off case, not worth generalizing
-  3. "Skip" — Don't record this learning
+  1. "Yes, add to patterns": Claude should catch this in future reviews
+  2. "No, too specific": One-off case, not worth generalizing
+  3. "Skip": Don't record this learning
 
 **Step 3: Record learnings**
 
@@ -219,10 +219,10 @@ Identified from PRs: <pr list>
 
 Use AskUserQuestion:
 - Options:
-  1. "Apply" — Add content to the context file
-  2. "Edit first" — Modify content before applying
-  3. "Skip" — Skip this proposal
-  4. "Stop" — Exit without processing remaining proposals
+  1. "Apply": Add content to the context file
+  2. "Edit first": Modify content before applying
+  3. "Skip": Skip this proposal
+  4. "Stop": Exit without processing remaining proposals
 
 **If "Apply":** Check if the target file exists (create with a header if not), append the proposed content, and confirm: "Added to `<target_file>`".
 
@@ -237,8 +237,8 @@ Use AskUserQuestion:
 Use AskUserQuestion:
 - Question: "Clear the learnings that were applied?"
 - Options:
-  1. "Yes, clear applied" — Remove learnings used in applied proposals from index.jsonl
-  2. "No, keep all" — Keep all learnings for future reference
+  1. "Yes, clear applied": Remove learnings used in applied proposals from index.jsonl
+  2. "No, keep all": Keep all learnings for future reference
 
 **Step 5: Display apply summary**
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -826,19 +826,19 @@ If any precondition fails, skip applying fixes but still produce the Fix Summary
 
 For each finding that survived synthesis, validation, Copilot meta-review, and voice pass, classify it into one of three buckets. The finding has `severity` (blocking/suggestion/nit/question), `file`, `line`, `description`, `proposed_fix`, and `confidence`.
 
-- **`fix_high_confidence`** — apply without commentary in the summary. All of:
+- **`fix_high_confidence`**: apply without commentary in the summary. All of:
   - One of: `severity` is `blocking` or `suggestion` and `confidence >= 80%`; OR `severity` is `nit` and `proposed_fix` is a single-line or single-identifier change.
   - `proposed_fix` is concrete (a diff, replacement code, or precise textual change), self-contained in one file, and unambiguous.
   - The change does not alter a public API, exported type, function signature, or stable identifier that other callers depend on.
   - The change does not require touching files outside the diff's modified files.
 
-- **`fix_with_judgment`** — apply, then record the choice in the summary. Any of:
+- **`fix_with_judgment`**: apply, then record the choice in the summary. Any of:
   - `confidence` is 60–79%.
   - `proposed_fix` exists but needs adaptation (style, naming, placement) before it fits the surrounding code.
   - There are 2+ reasonable approaches and you chose one. Pick the one a principal engineer would defend: clearest read, fewest moving parts, lowest blast radius. Avoid clever or speculative refactors.
   - The fix touches a small amount of related code outside the immediate line (e.g., adding a helper, removing a now-unused import) where doing so leaves the codebase cleaner than the minimal patch.
 
-- **`skip`** — do not apply. Any of:
+- **`skip`**: do not apply. Any of:
   - `severity` is `question` (the author needs to decide) or the finding is `nit` without a trivial in-place fix.
   - `confidence < 60%`.
   - No concrete `proposed_fix` is available.
@@ -885,12 +885,12 @@ After the opening line, render the two subsections below. Omit each subsection e
 
 ### Judgment Calls
 
-- **`<file>:<line>`** (`<severity>`) — <one-sentence description of what changed>.
+- **`<file>:<line>`** (`<severity>`): <one-sentence description of what changed>.
   <One or two sentences naming the chosen approach and the alternatives considered, in plain English.>
 
 ### Skipped
 
-- **`<file>:<line>`** (`<severity>`) — <one-sentence description>.
+- **`<file>:<line>`** (`<severity>`): <one-sentence description>.
   Skipped: <reason in plain English>.
 ```
 
@@ -965,6 +965,17 @@ diff_tokens: <diff_tokens from session data>
 The `token_usage` block records per-step token consumption (agents, context explorer, validators, and other steps) and the aggregate total. For chunked reviews, sum tokens by agent type across chunks (e.g., all `chunk-*-code-reviewer-security` entries become a single `code-reviewer-security` total). Always include the `total` field as the sum of all steps in `$token_usage`.
 
 This metadata is used by the learning system to determine when the review was created. The `review_commit` field records the PR's HEAD SHA at review time, enabling drift detection when creating draft reviews later. The `diff_tokens` field is an estimated token count of the diff (~4 chars per token).
+
+**Narrative voice.** The Inline Comment Voice rules earlier in this handler govern the comment bodies; the narrative you compose here (Overview, findings prose, per-agent sections, the metadata `reasoning` field) needs the same register. Write it the way you'd write a Slack summary to a colleague who is about to review the code: plain verbs, short sentences, no ceremony. Three tells to avoid outright:
+
+- Em dashes (`—`, U+2014). Restructure the sentence instead: a period and two sentences, a colon, parentheses, or a comma where it genuinely fits. Hyphens (`-`) and en dashes (`–`) are fine.
+- Bold inside a prose sentence. Bold is for line-start labels, headings, and table cells. If a clause feels like it needs bold for emphasis, the sentence is buried; lead with it instead.
+- Inflation and AI vocabulary: "critical", "robust", "comprehensive", "leverage", "utilize", "ensure", "It's not just X, it's Y". Say what the code does.
+
+An Overview paragraph in the right register reads like:
+
+> Adds a soft-hide for stale suggestion names. The new boolean ships in an additive migration, the GET returns hidden names separately, and hide/restore is admin-gated. The hidden row and any flags using it are preserved, so hiding is reversible.
+
 Save the complete review to `$review_file` and inform the user with a clickable file link:
 
 ```


### PR DESCRIPTION
## What changed and why

The first cut of this branch added a script that detected em dashes and a review step that rewrote them out. That treats the symptom. The goal is reviews that read like a person wrote them, and em dashes are just the most visible tell from a wider AI register (bold mid-sentence, inflation words, pseudo-labels). A whole pipeline stage to police one character is wasteful and leaves the rest of the register untouched.

So this fixes the voice where the text is generated, not after the fact. The detector and its test are gone.

## Generation-time fixes

`handlers/review.md`: the Compose step gets a Narrative voice block. It tells the model to write the Overview and findings prose in the same register as the inline comments (a Slack summary to a colleague), names the three tells to avoid, and shows an example Overview paragraph to mirror.

`agents/code-reviewer-voice.md`: a final-scan rule closes the fail-open hole that let em dashes through before. A body still carrying an em dash, a bold pseudo-label, or AI vocabulary is never "already clean". The agent restructures the sentence and sets `unchanged: false` instead of passing the source text through untouched.

## Prompt-surface sweep

The prompts shouldn't model the register they tell the model to avoid, so the em dashes are restructured out of:

- `agents/code-reviewer-security.md`: the agent's own instructions (it was the only reviewer agent still using them; the other eight were already clean).
- `handlers/find.md` and `handlers/learn.md`: AskUserQuestion option labels and the field tables.
- `SKILL.md`: routing prose.
- `handlers/review.md`: the fix-summary output templates and fix-bucket labels, which propagate straight into generated text.
- `context/languages/python.md`: one reference line.

## Test plan

- `bin/test` passes (unit and integration).
- `bin/lint` and `bin/fmt` are clean.
- The four em dashes left in the prompts are intentional: each names or demonstrates the literal character the rules tell the model to avoid.