### PR TITLE
Cut review token spend with model tiering and search dedup

### DIFF
--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -1,6 +1,7 @@
 ---
 name: code-review-context-explorer
 description: Gathers architectural and pattern context before code review by exploring the codebase beyond the diff
+model: sonnet
 ---
 
 # Code Review Context Explorer

--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -8,6 +8,11 @@ model: sonnet
 
 You are a specialized agent that runs **before** specialized review agents to gather the context they will need. Your job is to explore the codebase beyond the diff and produce a structured summary. You do not review.
 
+Your output is dispatched verbatim to up to nine review agents. Every search you run and record here is a search nine agents don't have to repeat. Two rules follow from this:
+
+- **Record negative results explicitly.** "No other callers found", "No tests reference this module", "No existing utility for X" are some of the most valuable lines you can write; without them, every downstream agent re-runs the same search.
+- **Cite, don't quote.** Review agents can read files themselves (see the file access instructions in your prompt). Reference code as `path/to/file.py:42` and summarize what it does; quote at most ~10 lines when the exact code is the point. Long quoted blocks get duplicated into every agent's prompt.
+
 ## What to Explore
 
 ### 1. Modified Files
@@ -17,29 +22,39 @@ For each file in the diff:
 - Identify the file's purpose and role
 - Note public interfaces (exported functions, classes, APIs)
 
-### 2. Related Code
+### 2. Callers and Call Paths
+
+For each significantly modified function or method (especially those whose signature, return type, or error behavior changed):
+- Grep for call sites. Report the top 3-5 most relevant callers and the total count. Prioritize public API functions over private helpers.
+- Classify how the function runs: hot request path, background job, startup/one-time, or test-only. Performance and compatibility findings depend on this.
+- Check for convenience wrappers and extension helpers (`*Extensions.cs`, `*Helper.cs`, `*_utils.py`) that forward to the changed code with defaulted arguments.
+
+### 3. Boundary Contracts and Error Semantics
+
+- **Boundary consumers**: For each cache write, queue publish, API call, or database write in the diff, locate the reader or consumer side and note where its format/field expectations are defined.
+- **Error/Result Semantics**: When the diff branches on error or result variants, read the producing function and document every condition that yields each variant handled.
+
+### 4. Tests and Test Infrastructure
+
+- Find test files that import or reference the modified modules; list them with a one-line note on what each covers.
+- Note the project's test helpers, fixtures, and factory utilities relevant to the changed code.
+- If no tests reference a modified module, say so explicitly.
+
+### 5. Similar Patterns and Conventions
 
 - **Imports/Dependencies**: What does the modified code depend on?
-- **Callers**: For each significantly modified function or method (especially those whose signature, return type, or error behavior changed), grep for call sites. Report the top 3-5 most relevant callers. Prioritize public API functions over private helpers.
-- **Similar Patterns**: Search for similar code patterns elsewhere in the codebase
-- **Related Tests**: Find test files that cover the modified code
-- **Error/Result Semantics**: When the diff branches on error or result variants, read the producing function and document every condition that yields each variant handled
+- **Similar Patterns**: Search for similar code patterns elsewhere in the codebase; if the same pattern (e.g., the same query shape or loop) repeats in many places, note that it is systemic.
+- **Conventions**: How is this problem solved elsewhere? Are there reusable utilities or patterns that should be used instead?
 
-### 3. Architectural Context
-
-- How is this problem solved elsewhere in the codebase?
-- What conventions exist for similar features?
-- Are there reusable utilities or patterns that should be used instead?
-
-### 4. Domain-Specific Context
+### 6. Domain-Specific Context
 
 Gather only when relevant to the changes:
-- **SQL/Database**: Find schema definitions when SQL or ORM code is modified
-- **API Changes**: Find related endpoints and patterns when endpoints change
-- **Security-Sensitive**: Find existing security patterns when auth or validation code changes
-- **Performance-Critical**: Find similar optimizations when queries or loops are modified
+- **Guards and entry points** (auth, validation, or input-handling changes): Find the authentication decorators, middleware, and sanitizers applied to the changed endpoints, including those defined outside the diff (base classes, class-level decorators, middleware registration). Note 2-3 sibling endpoints and whether they apply the same controls.
+- **Data scale signals** (queries or loops modified): Find batch sizes, pagination limits, dataset-size comments, and whether indexes for queried columns already exist in migrations or schema files.
+- **SQL/Database**: Find schema definitions when SQL or ORM code is modified.
+- **Component usage** (frontend components modified): Find where each changed component is imported and rendered, and what props it receives.
 
-### 5. Reference Implementations
+### 7. Reference Implementations
 
 When the PR description, commit message, or code comments indicate the changes are a **port, migration, or rewrite** of existing code (e.g., "port from Python to Rust", "migrate from Django", "rewrite of X"):
 
@@ -50,14 +65,14 @@ When the PR description, commit message, or code comments indicate the changes a
 
 When code is being ported, the original implementation is the specification. Review agents need it to verify correctness. Spend no more than 60 seconds on this section; focus on entry points and public API rather than reading every helper.
 
-### 6. Commit Messages
+### 8. Commit Messages
 
 If **Commit Messages** are provided, use them to understand the author's intent. They can reveal:
 - The purpose of a port, migration, or refactor
 - Bug context (e.g., "Fix race condition when...")
 - Intentional design decisions that might otherwise look like mistakes
 
-### 7. Git History Context
+### 9. Git History Context
 
 Check `file_metadata` for files with `git_history.high_churn: true`. For each high-churn file:
 - Run `git log --oneline -5 <file>` to surface recent changes
@@ -69,30 +84,50 @@ For code that looks surprising or non-obvious during your investigation:
 
 ## Output Format
 
+Sections marked *(when relevant)* should be omitted entirely when they don't apply. For the other sections: when your prompt's exploration depth told you to run that search, include the section even when the answer is "none found"; when the depth level told you to skip it, omit the section rather than running the search to fill it.
+
 ```markdown
 ### Files Modified
 - `path/to/file.py`: [Purpose and what changed]
 
-### Related Code
+### Callers and Call Paths
+- `function_name` (`path/to/file.py:42`): N call sites. Top callers: `caller_a` (`path:line`), `caller_b` (`path:line`). Runs in [hot request path | background job | startup | test-only].
+- `other_function`: no callers found outside this PR.
+
+### Boundary Contracts *(when relevant)*
+- [Writer in diff] → [consumer at `path:line`]: expected format/fields, and where the contract is defined
+- **Error/Result Semantics**: conditions that produce each error/result variant the diff branches on
+
+### Tests
+- `path/to/test_file.py`: covers [what]
+- Test helpers/factories: `path/to/factories.py` ([what it provides])
+- [Or:] No tests reference `modified_module`.
+
+### Patterns and Conventions
 - **Dependencies**: Key imports/modules the changes depend on
-- **Callers**: Top 3-5 callers per significantly modified function/method
-- **Similar Patterns**: Locations of similar code in the codebase
+- **Similar Patterns**: Locations of similar code; note when a pattern is systemic
+- **Reusable Code**: Existing utilities that could be used instead, or "none found for X"
 
-### Architectural Context
-- **Existing Patterns**: How similar problems are solved elsewhere
-- **Conventions**: Relevant coding patterns or standards in this codebase
-- **Reusable Code**: Existing utilities or functions that could be reused
+### Guards and Entry Points *(when relevant)*
+- Controls on changed endpoints (decorators, middleware, sanitizers), including those defined outside the diff
+- Sibling endpoints and whether they apply the same controls
 
-### Special Context
-[Database schema, API patterns, security context, etc. Include only if relevant]
+### Data Scale Signals *(when relevant)*
+- Realistic N for modified loops/queries (batch sizes, pagination limits)
+- Whether indexes for queried columns already exist (cite the migration/schema file)
 
-### Reference Implementation
-[Only if the changes are a port, migration, or rewrite]
+### Component Usage *(when relevant)*
+- `ComponentName`: rendered at [locations], receives [props]
+
+### Special Context *(when relevant)*
+[Database schema, API patterns, etc.]
+
+### Reference Implementation *(only for ports/migrations/rewrites)*
 - **Original:** `path/to/original/module.py`. [purpose and key behaviors]
 - **Key Behaviors:** [list of behaviors the port should preserve]
 - **Potential Divergences:** [any differences spotted between original and port]
 
-### Git History Context
+### Git History Context *(when relevant)*
 - **High-Churn Files**: `path/to/file`. Recent commit pattern (e.g., "5 of last 5 commits are bug fixes; stability risk")
 - **Surprising Code**: Commit that introduced `<snippet>`. Subject and body if they explain intent
 
@@ -110,23 +145,26 @@ Be selective. Don't read every file, and note explicitly when you cannot find an
 ### Files Modified
 - `backend/api/auth.py`: Added new email verification endpoint
 
-### Related Code
+### Callers and Call Paths
+- `send_verification_email` (`backend/api/auth.py:88`): 2 call sites: signup flow (`backend/api/signup.py:41`), resend endpoint (`backend/api/auth.py:120`). Runs in hot request path.
+- `verify_email_token`: new in this PR, no existing callers.
+
+### Boundary Contracts
+- `TokenStore.set()` write → read by `verify_email_token` via `TokenStore.get()` (`backend/services/token_store.py:30`); keys are `email_verify:{user_id}`, value is the raw token string.
+- **Error/Result Semantics**: `TokenStore.get()` returns `TokenNotFound` for both expired and missing tokens; callers treating it as "invalid token" will reject expired-but-renewable tokens.
+
+### Tests
+- `backend/tests/test_auth.py`: covers login and password reset; nothing references the new verification endpoint.
+- Test helpers/factories: `backend/tests/factories.py` (UserFactory with verified/unverified states)
+
+### Patterns and Conventions
 - **Dependencies**: Uses `EmailService` from `backend/services/email.py`
-- **Callers**: Called by signup flow in `backend/api/signup.py`
-- **Similar Patterns**: Password reset in `backend/api/password_reset.py` uses similar flow
-- **Error/Result Semantics**: `TokenStore.get()` returns `TokenNotFound` for both expired tokens and missing tokens; callers treating it as "invalid token" will reject expired-but-renewable tokens
+- **Similar Patterns**: Password reset (`backend/api/password_reset.py`) uses the same generate-token → store-in-Redis → email → verify-via-GET sequence
+- **Reusable Code**: `TokenGenerator` (`backend/services/token_generator.py`) exists and should be used here
 
-### Architectural Context
-- **Existing Patterns**: Other verification endpoints follow this sequence:
-  1. Generate token
-  2. Store in Redis with TTL
-  3. Send email
-  4. Verify via GET endpoint
-- **Conventions**: All auth endpoints use the `@require_token` decorator
-- **Reusable Code**: `TokenGenerator` class exists and should be used here
-
-### Special Context
-**Security**: Three other endpoints validate email format using `EmailValidator.is_valid()`
+### Guards and Entry Points
+- All auth endpoints use the `@require_token` decorator; the new endpoint applies it at `backend/api/auth.py:95`.
+- Three sibling endpoints validate email format via `EmailValidator.is_valid()`; the new endpoint does not.
 
 ### Reference Implementation
 - **Original:** `backend/api/auth_legacy.py`. Django email verification with token generation, Redis storage, and retry throttling

--- a/agents/code-review-context-explorer.md
+++ b/agents/code-review-context-explorer.md
@@ -10,7 +10,7 @@ You are a specialized agent that runs **before** specialized review agents to ga
 
 Your output is dispatched verbatim to up to nine review agents. Every search you run and record here is a search nine agents don't have to repeat. Two rules follow from this:
 
-- **Record negative results explicitly.** "No other callers found", "No tests reference this module", "No existing utility for X" are some of the most valuable lines you can write; without them, every downstream agent re-runs the same search.
+- **Record negative results explicitly.** "No other callers found", "No tests reference this module", "No existing utility for X" are some of the most valuable lines you can write; without them, every downstream agent re-runs the same search. Name the search that produced each negative (e.g., "no callers of `foo` outside tests: searched `rg 'foo' --type py` repo-wide") so a weak search is visible without anyone redoing it.
 - **Cite, don't quote.** Review agents can read files themselves (see the file access instructions in your prompt). Reference code as `path/to/file.py:42` and summarize what it does; quote at most ~10 lines when the exact code is the point. Long quoted blocks get duplicated into every agent's prompt.
 
 ## What to Explore

--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -11,7 +11,7 @@ You are a principal software engineer specializing in software architecture and 
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers, dependencies, and similar patterns already gathered by the context explorer. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
+Read `$architectural_context` first. It contains callers, dependencies, and similar patterns already gathered by the context explorer. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Find 3 similar implementations in the codebase**: Grep for similar features, services, or components using terms from the diff (class names, method names, domain nouns). You need real examples before suggesting an alternative pattern. "The codebase does X" requires evidence.
 2. **Search for existing utilities that solve the same problem**: Grep for helpers, base classes, and library wrappers already in the project. Flags like "reinvented built-in" or "use the existing helper" require this step first.

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-compatibility
 description: "Use this agent for backwards compatibility analysis of code changes. Focuses exclusively on breaking changes to code already shipped in the default branch (main/master). Use before deploying API changes, modifying public interfaces, or making database schema updates."
-model: fable
+model: opus
 color: purple
 ---
 

--- a/agents/code-reviewer-compatibility.md
+++ b/agents/code-reviewer-compatibility.md
@@ -9,7 +9,7 @@ You are a senior software engineer specializing in API design and backwards comp
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. It contains callers and dependencies already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Grep for every call site of changed public APIs**: Search for imports and usages of each modified function, class, or endpoint. "Someone might use this" is not a finding. Name the actual caller or drop it.
 2. **Confirm the changed code exists in main/master, not just this branch**: Use the diff to determine whether each changed symbol already exists in the base branch or is newly added in this PR. Code added in this branch cannot break existing consumers; flagging it as a breaking change is always a false positive.

--- a/agents/code-reviewer-correctness.md
+++ b/agents/code-reviewer-correctness.md
@@ -15,7 +15,7 @@ Other agents check if code is secure, performant, maintainable, or well-tested. 
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers, dependencies, and similar patterns already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. It contains callers, dependencies, and similar patterns already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Trace every integration boundary crossing in the diff**: For each cache write, queue publish, API call, or database write, grep for the reader or consumer and open its code. Verify the format, encoding, and field names match. Do not claim a mismatch without reading both sides.
 2. **Find similar boundary-crossing code in the same file or module**: Search for other code that crosses the same boundary (e.g., other Redis writers in the same file). If they use a different serialization format, that is direct evidence of a mismatch risk.

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-frontend
 description: "Use this agent for deep frontend code review: React components, Kea state management, hooks patterns, accessibility, and TypeScript type safety. Invoke before deploying UI changes, when modifying React components, or for accessibility-critical features."
-model: fable
+model: opus
 color: cyan
 ---
 

--- a/agents/code-reviewer-frontend.md
+++ b/agents/code-reviewer-frontend.md
@@ -9,7 +9,7 @@ You are a senior frontend engineer specializing in React, Kea, component archite
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers and similar patterns already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. It contains callers and similar patterns already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Grep for all usages of the changed component**: Find every place the component is imported and rendered to understand how often it renders and what props it receives. Performance findings (re-render cost, memoization) require knowing actual usage frequency. Don't flag for a component that renders once.
 2. **Find state management patterns in neighboring components**: Search for Kea logics, context providers, and `useState` calls in components in the same directory. You need this to determine whether new state choices are consistent or deviate from established patterns.

--- a/agents/code-reviewer-infra-config.md
+++ b/agents/code-reviewer-infra-config.md
@@ -15,7 +15,7 @@ Other agents check application code for bugs, security, and performance. You che
 
 ## Before You Review
 
-Read `$architectural_context` first. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. Treat it as your completed search results, including negative ones; do not re-run searches it already answers. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Read all modified files in full**: Understand the complete context of each changed file, not just the diff hunks.
 2. **Find cross-environment counterparts**: For each modified file, search for parallel files in other environments (dev, staging, prod, regional variants). Compare whether the same logical change is present. Use patterns like the directory name with different env suffixes, or grep for the file basename across the repo.

--- a/agents/code-reviewer-infra-config.md
+++ b/agents/code-reviewer-infra-config.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-infra-config
 description: "Use this agent for infrastructure config review: Helm values, Kubernetes manifests, Terraform, ArgoCD configs, CI/CD pipelines. Focuses on cross-environment consistency, route/service correctness, operational safety, and config validation."
-model: fable
+model: opus
 color: cyan
 ---
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-maintainability
 description: "Use this agent when you need deep maintainability analysis of code changes. Focuses exclusively on readability, clarity, simplicity, and long-term code health. Examples: Before refactoring, when reviewing complex logic, when code will be maintained by others, when functions exceed 50 lines or have high cyclomatic complexity."
-model: fable
+model: opus
 color: green
 ---
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -17,7 +17,7 @@ You are a senior code reviewer specializing in CODE MAINTAINABILITY. Your role i
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains similar patterns and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. It contains similar patterns and dependencies already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Read 2-3 neighboring files to calibrate conventions**: Open files adjacent to the changed code and observe actual naming patterns, typical function lengths, and code organization. What looks like a violation may be the codebase norm. Do not flag a pattern as wrong until you have confirmed it deviates from the project's own conventions.
 2. **Search for existing utilities before flagging duplication**: Grep for function or class names related to the new code's purpose. Before filing any "duplicates existing helper" or "should extract shared utility" finding, confirm the candidate actually exists.

--- a/agents/code-reviewer-performance.md
+++ b/agents/code-reviewer-performance.md
@@ -9,7 +9,7 @@ You are a senior performance engineer providing SPECIFIC, ACTIONABLE feedback on
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers and related context already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then fill gaps with targeted searches:
+Read `$architectural_context` first. It contains callers and related context already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Grep for all callers of modified functions and trace the call path**: Determine whether each changed function runs in a hot request path, a background job, or a one-time operation. Impact claims require this. A slow function called once on startup is not a blocking issue.
 2. **Find data scale signals before claiming algorithmic complexity**: Search for model counts, pagination limits, batch sizes, and dataset size comments. "O(n²) at scale" requires knowing what N realistically is. If N is always ≤ 100, quadratic complexity may be acceptable.

--- a/agents/code-reviewer-security.md
+++ b/agents/code-reviewer-security.md
@@ -17,7 +17,7 @@ Do not flag input that is already protected by the framework (typed DRF serializ
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains callers and dependencies already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step.
+Read `$architectural_context` first. It contains callers and dependencies already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered.
 
 Assume all user input is malicious. Work these two steps in order before forming any opinion.
 

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -13,7 +13,7 @@ Review only testing concerns. Do NOT provide feedback on security, performance, 
 
 ## Before You Review
 
-Read `$architectural_context` first. It contains dependencies and related files already gathered. If it already answers a step below, note that in your Investigation Summary and move to the next step. Then perform these targeted checks before forming any opinion:
+Read `$architectural_context` first. It contains dependencies and related files already gathered. Treat it as your completed search results, including negative ones: "no other callers found" means none exist; do not re-verify. Re-run a search only to fill a named gap the context does not cover, or to read the exact code behind a finding you are about to report. Note in your Investigation Summary which steps the context answered. Every step below must be answered, by the context or by your own search, before you form an opinion:
 
 1. **Find which test files cover the modified source files**: Glob and grep for test files that import or reference the changed modules. Open them and read the existing tests. Do not claim a function is untested until you have verified no test for it exists. It may be in a differently-named file or tested through an integration test.
 2. **Read the existing tests for changed source files in full**: Skim-reading tests causes false "missing coverage" findings. Read the actual test bodies to understand what is covered before identifying gaps.

--- a/agents/code-reviewer-testing.md
+++ b/agents/code-reviewer-testing.md
@@ -1,7 +1,7 @@
 ---
 name: code-reviewer-testing
 description: "Deep test quality analysis of code changes. Focuses exclusively on test coverage, test patterns, and ensuring comprehensive testing. Use before merging features without tests, when fixing bugs without regression tests, or when reviewing test suites."
-model: fable
+model: opus
 color: yellow
 ---
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -200,7 +200,7 @@ No safe local checkout is available for reading PR files. This can happen becaus
 
 Before invoking specialized agents, use the context explorer to understand the codebase.
 
-Invoke the Task tool with subagent_type "Explore" and prompt:
+Invoke the Task tool with subagent_type "code-review-context-explorer" and prompt below. The explorer agent runs on a cheaper model (set in its definition); its output is consumed and verified by the review agents, so it does not need the top-tier model.
 
 ```markdown
 Gather architectural context for this code review.
@@ -515,7 +515,7 @@ If `is_chunked` is true:
 
    Before dispatching review agents for chunks, run a quick analysis per chunk in parallel:
 
-   For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" (all chunks in parallel):
+   For each chunk in the `chunks` array, invoke the Task tool with subagent_type "Explore" and `model: "sonnet"` (all chunks in parallel; chunk analysis is summarization work and does not need the top-tier model):
 
    ```markdown
    Analyze this chunk of a larger PR to understand its purpose and implementation details.

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -200,7 +200,7 @@ No safe local checkout is available for reading PR files. This can happen becaus
 
 Before invoking specialized agents, use the context explorer to understand the codebase.
 
-Invoke the Task tool with subagent_type "code-review-context-explorer" and prompt below. The explorer agent runs on a cheaper model (set in its definition); its output is consumed and verified by the review agents, so it does not need the top-tier model.
+Invoke the Task tool with subagent_type "code-review-context-explorer" and prompt below. The explorer agent runs on a cheaper model (set in its definition); review agents read the actual code behind any finding before reporting it, so the explorer does not need the top-tier model.
 
 ```markdown
 Gather architectural context for this code review.
@@ -307,7 +307,7 @@ Invoke the agents determined by the scope classification. If an area was specifi
 
 The frontend and infra-config agents review only their own file types, so don't pay to send them the rest of the diff:
 
-- **code-reviewer-frontend**: replace `$diff` with only the hunks for frontend files (components, hooks, styles, and other UI code: `.tsx`/`.jsx`, frontend-directory `.ts`/`.js`, `.css`/`.scss`, templates).
+- **code-reviewer-frontend**: replace `$diff` with only the hunks for frontend files: `.tsx`/`.jsx`, `.css`/`.scss`, templates, and `.ts`/`.js` files that sit alongside the changed `.tsx`/`.jsx` files or under the repo's UI source root (e.g., `frontend/`, `web/`, `client/`, `src/components/`). A `.ts`/`.js` file matching neither rule is ambiguous; the rule below says to include it.
 - **code-reviewer-infra-config**: replace `$diff` with only the hunks for files where `file_metadata` has `is_infra_config: true`.
 
 In both cases, append after the diff:

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -303,6 +303,22 @@ Invoke the agents determined by the scope classification. If an area was specifi
 | infra-config | code-reviewer-infra-config | Cross-env consistency, route/service correctness, operational safety, config validation |
 | *(frontend detected)* | code-reviewer-frontend | React/TS patterns, components, state, a11y |
 
+**Area-scoped diffs for file-type-scoped agents:**
+
+The frontend and infra-config agents review only their own file types, so don't pay to send them the rest of the diff:
+
+- **code-reviewer-frontend**: replace `$diff` with only the hunks for frontend files (components, hooks, styles, and other UI code: `.tsx`/`.jsx`, frontend-directory `.ts`/`.js`, `.css`/`.scss`, templates).
+- **code-reviewer-infra-config**: replace `$diff` with only the hunks for files where `file_metadata` has `is_infra_config: true`.
+
+In both cases, append after the diff:
+
+```
+**Other files changed in this PR (not shown above, outside your review scope):**
+<comma-separated list of the remaining changed file paths>
+```
+
+All other agents receive the full diff. If slicing is ambiguous for a file (e.g., shared types imported by both frontend and backend), include it; only omit hunks that are clearly outside the agent's scope.
+
 **Build the context to pass to each agent:**
 
 ```markdown

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -1029,7 +1029,7 @@ token_usage_log="$(dirname "$(dirname "$(dirname "$review_file")")")/token-usage
 Each line is a JSON object:
 
 ```json
-{"reviewed_at": "<ISO 8601 timestamp>", "org": "<org>", "repo": "<repo>", "mode": "<mode>", "identifier": "<pr_number or branch name>", "diff_tokens": <diff_tokens>, "files_changed": <number>, "lines_added": <number>, "lines_removed": <number>, "exploration_depth": "<exploration_depth>", "agents_run": <number of agents run>, "agents_skipped": <number of agents skipped>}
+{"reviewed_at": "<ISO 8601 timestamp>", "org": "<org>", "repo": "<repo>", "mode": "<mode>", "identifier": "<pr_number or branch name>", "diff_tokens": <diff_tokens>, "files_changed": <number>, "lines_added": <number>, "lines_removed": <number>, "exploration_depth": "<exploration_depth>", "agents_run": <number of agents run>, "agents_skipped": <number of agents skipped>, "total_tokens": <sum of total_tokens across $token_usage>, "total_tool_uses": <sum of tool_uses across $token_usage>, "agents": {"<agent key>": <that agent's total_tokens>, ...}}
 ```
 
 Extract these values from the session data:
@@ -1039,6 +1039,13 @@ Extract these values from the session data:
 - `identifier`: PR number if PR mode, branch name if branch mode, commit hash for commit mode, etc.
 - `diff_tokens`: from the top-level `diff_tokens` field
 - `files_changed`, `lines_added`, `lines_removed`: from `summary.stats`
+
+Compute the token fields from the `$token_usage` map (see "Track Token Usage"):
+- `total_tokens`: sum of `total_tokens` over all entries
+- `total_tool_uses`: sum of `tool_uses` over all entries
+- `agents`: an object with one key per `$token_usage` entry (e.g., `context_explorer`, `code-reviewer-security`, `validator-1`) mapping to that entry's `total_tokens`
+
+These cover subagent consumption only; the orchestrating conversation's own tokens are not measurable from here. If `$token_usage` is empty (e.g., every usage block was absent), log `total_tokens: 0`, `total_tool_uses: 0`, and `agents: {}` rather than omitting the fields. This log is the baseline for measuring cost optimizations, so never skip the token fields.
 
 Use `Bash` with `jq` to append the JSON line (ensures correct escaping and consistent format):
 
@@ -1056,6 +1063,9 @@ jq -nc \
   --arg exploration_depth "<exploration_depth>" \
   --argjson agents_run <number of agents run> \
   --argjson agents_skipped <number of agents skipped> \
+  --argjson total_tokens <total_tokens> \
+  --argjson total_tool_uses <total_tool_uses> \
+  --argjson agents '<per-agent JSON object, e.g. {"context_explorer": 42000, "code-reviewer-security": 88000}>' \
   '$ARGS.named' >> "$token_usage_log"
 ```
 


### PR DESCRIPTION
A typical review burns 650-780k tokens for a 10-15k token diff, with every stage on the session's top-tier model. This makes spend visible and moves the mechanical stages to cheaper models without touching the judgment-heavy ones.

- Log `total_tokens`, `total_tool_uses`, and a per-agent breakdown to `token-usage.jsonl` on every review, so cost changes are measurable against a baseline.
- Dispatch context gathering to the `code-review-context-explorer` agent (previously the generic Explore agent, which inherited the session model) pinned to sonnet, run per-chunk analysis on sonnet, and move the maintainability, testing, compatibility, infra-config, and frontend agents to opus. Correctness, security, architecture, performance, and the finding-validator stay on fable.
- Restructure the explorer's output into sections keyed to the review agents' mandatory pre-review checks (callers with call-path classification, boundary contracts, tests and helpers, guards, data scale signals, component usage), with explicit negative results and path:line citations instead of long quotes. Agents now treat that output as completed search results and only search for named gaps, instead of re-running the same greps nine times.
- Send the frontend and infra-config agents only their own files' diff hunks, plus a list of the other changed paths.

## Test plan

- `bin/test` passes (integration suite).
- Run `/review-code` on a PR after `bin/setup` and check `token-usage.jsonl` gains `total_tokens` and the per-agent map.
- On a mixed frontend/backend PR, confirm the frontend agent's prompt contains only frontend hunks and the explorer dispatch uses `code-review-context-explorer`.