### PR TITLE
Resolve addressed threads on --append PR reviews

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -45,7 +45,7 @@ Single-agent arguments, each on local changes only:
 - `--draft` or `-d` - Create a pending GitHub review with inline comments (PR mode only). Automatically detects and adjusts for comment drift when the PR receives new commits between review generation and draft posting.
 - `--self` - Allow creating draft review on your own PR (for testing)
 - `--overwrite` - Replace existing review file without prompting
-- `--append` - Append to existing review file without prompting
+- `--append` - Append to existing review file without prompting. In PR mode, also resolves review threads from your previous review whose findings the author has since addressed (the code changed and the new review no longer flags them).
 - `--fix` - After the review, apply fixes for findings the agent can resolve cleanly. Edits the working tree directly. Items not fixed (and the choice made on any judgment-call fixes) are listed in a Fix Summary section in the review. Not compatible with `learn` or `find`.
 - `--parent <ref>` - Override the base branch used for branch / current-branch reviews. By default, branches with a recorded stack parent (Graphite or `branch.<name>.parent` in git config) review against that parent; use `--parent` to force a different base, e.g. `--parent main`.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -1328,6 +1328,57 @@ If failed, show the error and suggest using the review file manually.
   3. Suggest: "You can copy comments from the review file and post them manually on GitHub."
   4. **STOP HERE.** Do NOT attempt to post comments using `gh pr review` or any other method as a fallback. This will submit the review instead of keeping it pending.
 
+### Resolve Addressed Threads (--append, PR Mode Only)
+
+When this is an **append** review (`append` is true in the session JSON) **and** `mode` is `pr`, resolve the review threads from your previous review whose findings the author has since addressed. This keeps the PR's unresolved-thread list honest: stale threads you already re-checked shouldn't keep nagging the author.
+
+Skip this step entirely if `append` is not true, or if `mode` is not `pr`. Threads only exist on pull requests. This step runs whenever `append` is true and `mode` is `pr`, independent of `--draft`: a `--draft` posting that was skipped or failed earlier does not skip thread resolution.
+
+**Determine your reviewer identity.** Use `reviewer_username` from the session JSON. If it is empty, fall back to:
+
+```bash
+gh api user --jq '.login'
+```
+
+Call the result `$reviewer`. If you cannot determine a login, skip this step (without an author scope you cannot safely tell your threads from a teammate's).
+
+**List your unresolved threads.** Scope strictly to threads whose first comment is yours:
+
+```bash
+~/.claude/skills/review-code/scripts/resolve-review-threads.sh <pr_number> --author "$reviewer" --json
+```
+
+The output `threads` array holds objects with `commentId`, `path`, `line`, `isOutdated`, `author`, and `body` (the full text of your original comment, used for the re-flag comparison below). If the array is empty, there is nothing to resolve; skip the rest of this step.
+
+**Decide which threads to resolve.** Resolve a thread **only when you are confident the finding is addressed**, which requires BOTH signals:
+
+1. **The code at that location changed.** Either the thread's `isOutdated` is true, or the current review diff touches `path` at or near `line`. Requiring this is what stops you from resolving a still-open issue that a flaky re-run merely failed to surface.
+2. **Your fresh findings do not re-flag the same issue.** No finding in this review covers the same `path` within ~5 lines of `line` describing the same concern as the thread's `body`. Read the whole `body` (the listing carries up to ~1500 characters), not just its opening: a partial fix often changes the line while leaving the issue the comment described.
+
+A thread that fails either signal stays open. When in doubt, leave it open: resolving is irreversible and visible to everyone on the PR.
+
+Build `$resolve_ids` as the list of `commentId` values that pass both signals.
+
+**Resolve the confident set.** If `$resolve_ids` is non-empty, pass each as a `--comment-id`, keeping the `--author` scope as a safety guard so a stray id can never resolve a teammate's thread:
+
+```bash
+~/.claude/skills/review-code/scripts/resolve-review-threads.sh <pr_number> --author "$reviewer" \
+  --comment-id <id1> --comment-id <id2> --json
+```
+
+**Report.** Tell the user what changed and why, listing each resolved thread with its reason and each thread you deliberately left open:
+
+```
+Resolved 2 threads from the previous review:
+- src/api.py:42 — code changed and no longer flagged
+- src/db.py:88 — thread outdated, fix confirmed
+
+Left open 1 thread:
+- src/auth.py:12 — re-flagged in this review
+```
+
+If `$resolve_ids` was empty, say so briefly (e.g. "No previous-review threads were confidently addressed; left all open.").
+
 ### Cleanup Session
 
 After the review is complete, clean up the session (replace `<SESSION_ID>` with the actual session ID):

--- a/skills/review-code/scripts/resolve-review-threads.sh
+++ b/skills/review-code/scripts/resolve-review-threads.sh
@@ -140,17 +140,23 @@ fetch_all_threads() {
             cursor_args+=(-f cursor="$cursor")
         fi
 
-        local result
+        local result gh_err
+        gh_err=$(mktemp)
         result=$(gh api graphql \
             -f query="$query" \
             -F owner="$owner" \
             -F repo="$repo_name" \
             -F number="$pr_number" \
             "${cursor_args[@]}" \
-            2> /dev/null) || {
-            log_error "GraphQL query failed: ${result}"
+            2> "$gh_err") || {
+            log_error "GraphQL query failed: $(
+                cat "$gh_err"
+                echo "${result}"
+            )"
+            rm -f "$gh_err"
             exit 1
         }
+        rm -f "$gh_err"
 
         local parsed
         parsed=$(echo "$result" | jq '{
@@ -251,166 +257,167 @@ display_threads() {
     done
 }
 
-# ── Argument parsing ─────────────────────────────────────────────────────────
+# ── Argument parsing + main ──────────────────────────────────────────────────
 
 usage() {
     sed -n '4,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
-FILTER_MODE="list"
-DRY_RUN=false
-JSON_OUTPUT=false
-PR_ARG=""
-AUTHOR_FILTER=""
-COMMENT_IDS=()
+main() {
+    FILTER_MODE="list"
+    DRY_RUN=false
+    JSON_OUTPUT=false
+    PR_ARG=""
+    AUTHOR_FILTER=""
+    COMMENT_IDS=()
 
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        --outdated)
-            if [[ "$FILTER_MODE" != "list" ]]; then
-                log_error "Cannot combine --outdated with --all or --comment-id"
-                exit 1
-            fi
-            FILTER_MODE="outdated"
-            shift
-            ;;
-        --all)
-            if [[ "$FILTER_MODE" != "list" ]]; then
-                log_error "Cannot combine --all with --outdated or --comment-id"
-                exit 1
-            fi
-            FILTER_MODE="all"
-            shift
-            ;;
-        --comment-id)
-            if [[ "$FILTER_MODE" != "list" && "$FILTER_MODE" != "comment-ids" ]]; then
-                log_error "Cannot combine --comment-id with --outdated or --all"
-                exit 1
-            fi
-            if [[ $# -lt 2 ]]; then
-                log_error "--comment-id requires an argument"
-                exit 1
-            fi
-            FILTER_MODE="comment-ids"
-            if [[ ! "$2" =~ ^[0-9]+$ ]]; then
-                log_error "--comment-id requires a numeric REST API comment ID, got: $2"
-                exit 1
-            fi
-            COMMENT_IDS+=("$2")
-            shift 2
-            ;;
-        --author)
-            if [[ $# -lt 2 ]]; then
-                log_error "--author requires an argument"
-                exit 1
-            fi
-            AUTHOR_FILTER="$2"
-            shift 2
-            ;;
-        --dry-run)
-            DRY_RUN=true
-            shift
-            ;;
-        --json)
-            JSON_OUTPUT=true
-            shift
-            ;;
-        -h | --help)
-            usage
-            exit 0
-            ;;
-        -*)
-            log_error "Unknown option: $1"
-            usage >&2
-            exit 1
-            ;;
-        *)
-            if [[ -n "$PR_ARG" ]]; then
-                log_error "Unexpected argument: $1"
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --outdated)
+                if [[ "$FILTER_MODE" != "list" ]]; then
+                    log_error "Cannot combine --outdated with --all or --comment-id"
+                    exit 1
+                fi
+                FILTER_MODE="outdated"
+                shift
+                ;;
+            --all)
+                if [[ "$FILTER_MODE" != "list" ]]; then
+                    log_error "Cannot combine --all with --outdated or --comment-id"
+                    exit 1
+                fi
+                FILTER_MODE="all"
+                shift
+                ;;
+            --comment-id)
+                if [[ "$FILTER_MODE" != "list" && "$FILTER_MODE" != "comment-ids" ]]; then
+                    log_error "Cannot combine --comment-id with --outdated or --all"
+                    exit 1
+                fi
+                if [[ $# -lt 2 ]]; then
+                    log_error "--comment-id requires an argument"
+                    exit 1
+                fi
+                FILTER_MODE="comment-ids"
+                if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+                    log_error "--comment-id requires a numeric REST API comment ID, got: $2"
+                    exit 1
+                fi
+                COMMENT_IDS+=("$2")
+                shift 2
+                ;;
+            --author)
+                if [[ $# -lt 2 ]]; then
+                    log_error "--author requires an argument"
+                    exit 1
+                fi
+                AUTHOR_FILTER="$2"
+                shift 2
+                ;;
+            --dry-run)
+                DRY_RUN=true
+                shift
+                ;;
+            --json)
+                JSON_OUTPUT=true
+                shift
+                ;;
+            -h | --help)
+                usage
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
                 usage >&2
                 exit 1
-            fi
-            PR_ARG="$1"
-            shift
-            ;;
-    esac
-done
+                ;;
+            *)
+                if [[ -n "$PR_ARG" ]]; then
+                    log_error "Unexpected argument: $1"
+                    usage >&2
+                    exit 1
+                fi
+                PR_ARG="$1"
+                shift
+                ;;
+        esac
+    done
 
-# ── Main logic ───────────────────────────────────────────────────────────────
+    # ── Main logic ───────────────────────────────────────────────────────────────
 
-resolve_pr_target "$PR_ARG"
+    resolve_pr_target "$PR_ARG"
 
-log_info "Fetching review threads for ${REPO}#${PR_NUMBER}…"
+    log_info "Fetching review threads for ${REPO}#${PR_NUMBER}…"
 
-all_threads=$(fetch_all_threads "$OWNER" "$REPO_NAME" "$PR_NUMBER")
+    all_threads=$(fetch_all_threads "$OWNER" "$REPO_NAME" "$PR_NUMBER")
 
-# Filter to unresolved, and (if requested) to a specific author.
-unresolved=$(echo "$all_threads" | jq '[.[] | select(.isResolved == false)]')
-if [[ -n "$AUTHOR_FILTER" ]]; then
-    unresolved=$(echo "$unresolved" | jq --arg a "$AUTHOR_FILTER" \
-        '[.[] | select((.author // "" | ascii_downcase) == ($a | ascii_downcase))]')
-fi
-unresolved_count=$(echo "$unresolved" | jq 'length')
-
-if [[ "$unresolved_count" -eq 0 ]]; then
-    if [[ "$JSON_OUTPUT" == "true" ]]; then
-        jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" \
-            '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: 0, affectedFiles: []}'
-    else
-        echo "No unresolved threads on ${REPO}#${PR_NUMBER}." >&2
+    # Filter to unresolved, and (if requested) to a specific author.
+    unresolved=$(echo "$all_threads" | jq '[.[] | select(.isResolved == false)]')
+    if [[ -n "$AUTHOR_FILTER" ]]; then
+        unresolved=$(echo "$unresolved" | jq --arg a "$AUTHOR_FILTER" \
+            '[.[] | select((.author // "" | ascii_downcase) == ($a | ascii_downcase))]')
     fi
-    exit 0
-fi
+    unresolved_count=$(echo "$unresolved" | jq 'length')
 
-# Apply filter
-filtered="[]"
-label=""
-case "$FILTER_MODE" in
-    list)
+    if [[ "$unresolved_count" -eq 0 ]]; then
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            echo "$unresolved" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" '{
+            jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" \
+                '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: 0, affectedFiles: []}'
+        else
+            echo "No unresolved threads on ${REPO}#${PR_NUMBER}." >&2
+        fi
+        exit 0
+    fi
+
+    # Apply filter
+    filtered="[]"
+    label=""
+    case "$FILTER_MODE" in
+        list)
+            if [[ "$JSON_OUTPUT" == "true" ]]; then
+                echo "$unresolved" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" '{
         repo: $repo,
         pr: $pr,
         threads: .,
         totalUnresolved: length,
         affectedFiles: ([.[].path] | unique)
       }'
+            else
+                display_threads "$unresolved" "unresolved"
+            fi
+            exit 0
+            ;;
+        outdated)
+            filtered=$(echo "$unresolved" | jq '[.[] | select(.isOutdated == true)]')
+            label="outdated"
+            ;;
+        all)
+            filtered="$unresolved"
+            label="unresolved"
+            ;;
+        comment-ids)
+            id_array=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
+            filtered=$(echo "$unresolved" | jq --argjson ids "$id_array" '[.[] | select(.commentId as $c | $ids | index($c) != null)]')
+            label="matching"
+            ;;
+    esac
+
+    filtered_count=$(echo "$filtered" | jq 'length')
+
+    if [[ "$filtered_count" -eq 0 ]]; then
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" \
+                '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: $total, affectedFiles: []}'
         else
-            display_threads "$unresolved" "unresolved"
+            echo "No ${label} threads to resolve (${unresolved_count} unresolved total)." >&2
         fi
         exit 0
-        ;;
-    outdated)
-        filtered=$(echo "$unresolved" | jq '[.[] | select(.isOutdated == true)]')
-        label="outdated"
-        ;;
-    all)
-        filtered="$unresolved"
-        label="unresolved"
-        ;;
-    comment-ids)
-        id_array=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
-        filtered=$(echo "$unresolved" | jq --argjson ids "$id_array" '[.[] | select(.commentId as $c | $ids | index($c) != null)]')
-        label="matching"
-        ;;
-esac
-
-filtered_count=$(echo "$filtered" | jq 'length')
-
-if [[ "$filtered_count" -eq 0 ]]; then
-    if [[ "$JSON_OUTPUT" == "true" ]]; then
-        jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" \
-            '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: $total, affectedFiles: []}'
-    else
-        echo "No ${label} threads to resolve (${unresolved_count} unresolved total)." >&2
     fi
-    exit 0
-fi
 
-# Dry run
-if [[ "$DRY_RUN" == "true" ]]; then
-    if [[ "$JSON_OUTPUT" == "true" ]]; then
-        echo "$filtered" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" '{
+    # Dry run
+    if [[ "$DRY_RUN" == "true" ]]; then
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            echo "$filtered" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" '{
       repo: $repo,
       pr: $pr,
       threads: [.[] | . + {resolved: false}],
@@ -419,45 +426,45 @@ if [[ "$DRY_RUN" == "true" ]]; then
       affectedFiles: ([.[].path] | unique),
       dryRun: true
     }'
-    else
-        echo "Dry run — would resolve:" >&2
-        display_threads "$filtered" "${label}"
+        else
+            echo "Dry run — would resolve:" >&2
+            display_threads "$filtered" "${label}"
+        fi
+        exit 0
     fi
-    exit 0
-fi
 
-# Resolve threads
-log_info "Resolving ${filtered_count} ${label} thread(s)…"
+    # Resolve threads
+    log_info "Resolving ${filtered_count} ${label} thread(s)…"
 
-resolved_count=0
-failed_count=0
-resolved_files=()
+    resolved_count=0
+    failed_count=0
+    resolved_files=()
 
-while IFS=$'\t' read -r thread_id thread_path thread_line; do
-    if resolve_thread "$thread_id"; then
-        log_success "Resolved: ${thread_path}:${thread_line}"
-        resolved_count=$((resolved_count + 1))
-        resolved_files+=("$thread_path")
+    while IFS=$'\t' read -r thread_id thread_path thread_line; do
+        if resolve_thread "$thread_id"; then
+            log_success "Resolved: ${thread_path}:${thread_line}"
+            resolved_count=$((resolved_count + 1))
+            resolved_files+=("$thread_path")
+        else
+            log_warn "Failed to resolve: ${thread_path}:${thread_line}"
+            failed_count=$((failed_count + 1))
+        fi
+    done < <(echo "$filtered" | jq -r '.[] | [.id, .path, (.line // "-" | tostring)] | @tsv')
+
+    if [[ ${#resolved_files[@]} -gt 0 ]]; then
+        file_count=$(printf '%s\n' "${resolved_files[@]}" | sort -u | grep -c . || true)
     else
-        log_warn "Failed to resolve: ${thread_path}:${thread_line}"
-        failed_count=$((failed_count + 1))
+        file_count=0
     fi
-done < <(echo "$filtered" | jq -r '.[] | [.id, .path, (.line // "-" | tostring)] | @tsv')
 
-if [[ ${#resolved_files[@]} -gt 0 ]]; then
-    file_count=$(printf '%s\n' "${resolved_files[@]}" | sort -u | grep -c . || true)
-else
-    file_count=0
-fi
-
-# Summary
-if [[ "$JSON_OUTPUT" == "true" ]]; then
-    echo "$filtered" | jq \
-        --arg repo "$REPO" \
-        --argjson pr "$PR_NUMBER" \
-        --argjson resolved "$resolved_count" \
-        --argjson failed "$failed_count" \
-        --argjson total "$unresolved_count" '{
+    # Summary
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo "$filtered" | jq \
+            --arg repo "$REPO" \
+            --argjson pr "$PR_NUMBER" \
+            --argjson resolved "$resolved_count" \
+            --argjson failed "$failed_count" \
+            --argjson total "$unresolved_count" '{
       repo: $repo,
       pr: $pr,
       threads: .,
@@ -466,10 +473,15 @@ if [[ "$JSON_OUTPUT" == "true" ]]; then
       totalUnresolved: $total,
       affectedFiles: ([.[].path] | unique)
     }'
-else
-    if [[ "$failed_count" -gt 0 ]]; then
-        log_warn "Resolved ${resolved_count}/${filtered_count} thread(s) across ${file_count} file(s) (${failed_count} failed)"
     else
-        log_success "Resolved ${resolved_count} thread(s) across ${file_count} file(s)"
+        if [[ "$failed_count" -gt 0 ]]; then
+            log_warn "Resolved ${resolved_count}/${filtered_count} thread(s) across ${file_count} file(s) (${failed_count} failed)"
+        else
+            log_success "Resolved ${resolved_count} thread(s) across ${file_count} file(s)"
+        fi
     fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
 fi

--- a/skills/review-code/scripts/resolve-review-threads.sh
+++ b/skills/review-code/scripts/resolve-review-threads.sh
@@ -1,0 +1,475 @@
+#!/usr/bin/env bash
+# resolve-review-threads.sh - List and resolve GitHub PR review threads
+#
+# Self-contained vendoring of the gh-resolve-threads utility so the
+# review-code skill can resolve review threads without external dependencies.
+# Used by the --append flow to resolve threads from a previous review once the
+# underlying finding has been addressed.
+#
+# Usage: resolve-review-threads.sh [PR] [OPTIONS]
+#
+# PR can be:
+#   (none)              Infer from the current branch
+#   NUMBER              PR number in the current repo
+#   GITHUB_PR_URL       Full PR URL
+#
+# Options:
+#   --outdated           Resolve only outdated threads
+#   --all                Resolve all unresolved threads
+#   --comment-id ID      Resolve thread whose first comment has this ID (repeatable)
+#   --author LOGIN       Restrict to threads whose first comment is by LOGIN
+#                        (applies to list and resolve; safety scope for "our" threads)
+#   --dry-run            Show what would be resolved
+#   --json               Output as JSON
+#   -h, --help           Show this help message
+#
+# With no filter flag (--outdated/--all/--comment-id), lists unresolved threads
+# without resolving them.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+# Log to stderr so stdout stays clean for JSON consumers.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+# ── PR target resolution ─────────────────────────────────────────────────────
+
+# Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, and PR_NUMBER.
+parse_pr_url() {
+    local url="$1"
+    if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        OWNER="${BASH_REMATCH[1]}"
+        REPO_NAME="${BASH_REMATCH[2]}"
+        REPO="${OWNER}/${REPO_NAME}"
+        PR_NUMBER="${BASH_REMATCH[3]}"
+        return 0
+    fi
+    return 1
+}
+
+get_current_repo() {
+    gh repo view --json nameWithOwner -q '.nameWithOwner' 2> /dev/null || {
+        log_error "Could not determine repository. Run from inside a repo or pass a full PR URL."
+        exit 1
+    }
+}
+
+# Resolve a PR argument (URL, number, or empty) into OWNER/REPO_NAME/REPO/PR_NUMBER.
+resolve_pr_target() {
+    local pr_arg="${1:-}"
+    if [[ -z "$pr_arg" ]]; then
+        local pr_url
+        pr_url=$(gh pr view --json url -q '.url' 2> /dev/null) || {
+            log_error "No PR found for the current branch. Specify a PR number or URL."
+            exit 1
+        }
+        if ! parse_pr_url "$pr_url"; then
+            log_error "Could not parse PR URL from current branch: ${pr_url}"
+            exit 1
+        fi
+    elif parse_pr_url "$pr_arg"; then
+        :
+    elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="$pr_arg"
+        REPO=$(get_current_repo)
+        OWNER="${REPO%%/*}"
+        REPO_NAME="${REPO##*/}"
+    else
+        log_error "Invalid PR argument: ${pr_arg}"
+        log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
+        exit 1
+    fi
+}
+
+# ── Thread fetching ──────────────────────────────────────────────────────────
+
+# Fetch all review threads for a PR, handling pagination.
+# Outputs a JSON array of flattened thread objects.
+fetch_all_threads() {
+    local owner="$1" repo_name="$2" pr_number="$3"
+
+    local query='
+    query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $number) {
+          reviewThreads(first: 100, after: $cursor) {
+            nodes {
+              id
+              isResolved
+              isOutdated
+              path
+              line
+              comments(first: 1) {
+                nodes {
+                  databaseId
+                  body
+                  author { login }
+                }
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+      }
+    }
+  '
+
+    local all_nodes="[]"
+    local cursor="null"
+
+    while true; do
+        local -a cursor_args=()
+        if [[ "$cursor" != "null" ]]; then
+            cursor_args+=(-f cursor="$cursor")
+        fi
+
+        local result
+        result=$(gh api graphql \
+            -f query="$query" \
+            -F owner="$owner" \
+            -F repo="$repo_name" \
+            -F number="$pr_number" \
+            "${cursor_args[@]}" \
+            2> /dev/null) || {
+            log_error "GraphQL query failed: ${result}"
+            exit 1
+        }
+
+        local parsed
+        parsed=$(echo "$result" | jq '{
+      error: (.errors[0].message // null),
+      pr_null: (.data.repository.pullRequest == null),
+      nodes: .data.repository.pullRequest.reviewThreads.nodes,
+      hasNextPage: .data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage,
+      endCursor: .data.repository.pullRequest.reviewThreads.pageInfo.endCursor
+    }')
+
+        local gql_error
+        gql_error=$(echo "$parsed" | jq -r '.error // empty')
+        if [[ -n "$gql_error" ]]; then
+            log_error "GraphQL error: ${gql_error}"
+            exit 1
+        fi
+
+        if [[ "$(echo "$parsed" | jq '.pr_null')" == "true" ]]; then
+            log_error "PR #${pr_number} not found in ${owner}/${repo_name}"
+            exit 1
+        fi
+
+        local nodes has_next end_cursor
+        nodes=$(echo "$parsed" | jq '.nodes')
+        has_next=$(echo "$parsed" | jq -r '.hasNextPage')
+        end_cursor=$(echo "$parsed" | jq -r '.endCursor')
+
+        # Flatten each thread's first comment for easier downstream use
+        all_nodes=$(echo "$all_nodes" "$nodes" | jq -s '.[0] + [.[1][] | {
+      id,
+      isResolved,
+      isOutdated,
+      path,
+      line,
+      commentId: (.comments.nodes[0].databaseId // null),
+      author: (.comments.nodes[0].author.login // null),
+      body: ((.comments.nodes[0].body // "") | .[0:1500]),
+      bodyPreview: ((.comments.nodes[0].body // "") | .[0:80])
+    }]')
+
+        if [[ "$has_next" != "true" ]]; then
+            break
+        fi
+        cursor="$end_cursor"
+    done
+
+    echo "$all_nodes"
+}
+
+# Resolve a single review thread by its GraphQL node ID.
+resolve_thread() {
+    local thread_id="$1"
+
+    local mutation='
+    mutation($threadId: ID!) {
+      resolveReviewThread(input: {threadId: $threadId}) {
+        thread { id isResolved }
+      }
+    }
+  '
+
+    gh api graphql \
+        -f query="$mutation" \
+        -f threadId="$thread_id" \
+        --silent 2> /dev/null || return 1
+}
+
+# Display threads as a table (to stderr; keeps stdout clean).
+display_threads() {
+    local threads="$1" label="$2"
+
+    local count
+    count=$(echo "$threads" | jq 'length')
+
+    if [[ "$count" -eq 0 ]]; then
+        echo "No ${label} threads." >&2
+        return
+    fi
+
+    local file_count
+    file_count=$(echo "$threads" | jq '[.[].path] | unique | length')
+
+    {
+        echo "${count} ${label} thread(s) across ${file_count} file(s):"
+        echo ""
+        printf "  %-36s %6s  %-8s  %-16s  %s\n" "PATH" "LINE" "OUTDATED" "AUTHOR" "COMMENT"
+        printf "  %s\n" "$(printf '%.0s─' {1..100})"
+    } >&2
+
+    echo "$threads" | jq -r '.[] | [
+    .path,
+    (.line // "-" | tostring),
+    (if .isOutdated then "yes" else "no" end),
+    (.author // "-"),
+    (.bodyPreview | gsub("\n"; " ") | .[0:40])
+  ] | @tsv' | while IFS=$'\t' read -r path line outdated author body; do
+        printf "  %-36s %6s  %-8s  %-16s  %s\n" "$path" "$line" "$outdated" "$author" "$body" >&2
+    done
+}
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+
+usage() {
+    sed -n '4,28p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+FILTER_MODE="list"
+DRY_RUN=false
+JSON_OUTPUT=false
+PR_ARG=""
+AUTHOR_FILTER=""
+COMMENT_IDS=()
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --outdated)
+            if [[ "$FILTER_MODE" != "list" ]]; then
+                log_error "Cannot combine --outdated with --all or --comment-id"
+                exit 1
+            fi
+            FILTER_MODE="outdated"
+            shift
+            ;;
+        --all)
+            if [[ "$FILTER_MODE" != "list" ]]; then
+                log_error "Cannot combine --all with --outdated or --comment-id"
+                exit 1
+            fi
+            FILTER_MODE="all"
+            shift
+            ;;
+        --comment-id)
+            if [[ "$FILTER_MODE" != "list" && "$FILTER_MODE" != "comment-ids" ]]; then
+                log_error "Cannot combine --comment-id with --outdated or --all"
+                exit 1
+            fi
+            if [[ $# -lt 2 ]]; then
+                log_error "--comment-id requires an argument"
+                exit 1
+            fi
+            FILTER_MODE="comment-ids"
+            if [[ ! "$2" =~ ^[0-9]+$ ]]; then
+                log_error "--comment-id requires a numeric REST API comment ID, got: $2"
+                exit 1
+            fi
+            COMMENT_IDS+=("$2")
+            shift 2
+            ;;
+        --author)
+            if [[ $# -lt 2 ]]; then
+                log_error "--author requires an argument"
+                exit 1
+            fi
+            AUTHOR_FILTER="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --json)
+            JSON_OUTPUT=true
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        -*)
+            log_error "Unknown option: $1"
+            usage >&2
+            exit 1
+            ;;
+        *)
+            if [[ -n "$PR_ARG" ]]; then
+                log_error "Unexpected argument: $1"
+                usage >&2
+                exit 1
+            fi
+            PR_ARG="$1"
+            shift
+            ;;
+    esac
+done
+
+# ── Main logic ───────────────────────────────────────────────────────────────
+
+resolve_pr_target "$PR_ARG"
+
+log_info "Fetching review threads for ${REPO}#${PR_NUMBER}…"
+
+all_threads=$(fetch_all_threads "$OWNER" "$REPO_NAME" "$PR_NUMBER")
+
+# Filter to unresolved, and (if requested) to a specific author.
+unresolved=$(echo "$all_threads" | jq '[.[] | select(.isResolved == false)]')
+if [[ -n "$AUTHOR_FILTER" ]]; then
+    unresolved=$(echo "$unresolved" | jq --arg a "$AUTHOR_FILTER" \
+        '[.[] | select((.author // "" | ascii_downcase) == ($a | ascii_downcase))]')
+fi
+unresolved_count=$(echo "$unresolved" | jq 'length')
+
+if [[ "$unresolved_count" -eq 0 ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" \
+            '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: 0, affectedFiles: []}'
+    else
+        echo "No unresolved threads on ${REPO}#${PR_NUMBER}." >&2
+    fi
+    exit 0
+fi
+
+# Apply filter
+filtered="[]"
+label=""
+case "$FILTER_MODE" in
+    list)
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            echo "$unresolved" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" '{
+        repo: $repo,
+        pr: $pr,
+        threads: .,
+        totalUnresolved: length,
+        affectedFiles: ([.[].path] | unique)
+      }'
+        else
+            display_threads "$unresolved" "unresolved"
+        fi
+        exit 0
+        ;;
+    outdated)
+        filtered=$(echo "$unresolved" | jq '[.[] | select(.isOutdated == true)]')
+        label="outdated"
+        ;;
+    all)
+        filtered="$unresolved"
+        label="unresolved"
+        ;;
+    comment-ids)
+        id_array=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
+        filtered=$(echo "$unresolved" | jq --argjson ids "$id_array" '[.[] | select(.commentId as $c | $ids | index($c) != null)]')
+        label="matching"
+        ;;
+esac
+
+filtered_count=$(echo "$filtered" | jq 'length')
+
+if [[ "$filtered_count" -eq 0 ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        jq -n --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" \
+            '{repo: $repo, pr: $pr, threads: [], resolvedCount: 0, totalUnresolved: $total, affectedFiles: []}'
+    else
+        echo "No ${label} threads to resolve (${unresolved_count} unresolved total)." >&2
+    fi
+    exit 0
+fi
+
+# Dry run
+if [[ "$DRY_RUN" == "true" ]]; then
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        echo "$filtered" | jq --arg repo "$REPO" --argjson pr "$PR_NUMBER" --argjson total "$unresolved_count" '{
+      repo: $repo,
+      pr: $pr,
+      threads: [.[] | . + {resolved: false}],
+      resolvedCount: 0,
+      totalUnresolved: $total,
+      affectedFiles: ([.[].path] | unique),
+      dryRun: true
+    }'
+    else
+        echo "Dry run — would resolve:" >&2
+        display_threads "$filtered" "${label}"
+    fi
+    exit 0
+fi
+
+# Resolve threads
+log_info "Resolving ${filtered_count} ${label} thread(s)…"
+
+resolved_count=0
+failed_count=0
+resolved_files=()
+
+while IFS=$'\t' read -r thread_id thread_path thread_line; do
+    if resolve_thread "$thread_id"; then
+        log_success "Resolved: ${thread_path}:${thread_line}"
+        resolved_count=$((resolved_count + 1))
+        resolved_files+=("$thread_path")
+    else
+        log_warn "Failed to resolve: ${thread_path}:${thread_line}"
+        failed_count=$((failed_count + 1))
+    fi
+done < <(echo "$filtered" | jq -r '.[] | [.id, .path, (.line // "-" | tostring)] | @tsv')
+
+if [[ ${#resolved_files[@]} -gt 0 ]]; then
+    file_count=$(printf '%s\n' "${resolved_files[@]}" | sort -u | grep -c . || true)
+else
+    file_count=0
+fi
+
+# Summary
+if [[ "$JSON_OUTPUT" == "true" ]]; then
+    echo "$filtered" | jq \
+        --arg repo "$REPO" \
+        --argjson pr "$PR_NUMBER" \
+        --argjson resolved "$resolved_count" \
+        --argjson failed "$failed_count" \
+        --argjson total "$unresolved_count" '{
+      repo: $repo,
+      pr: $pr,
+      threads: .,
+      resolvedCount: $resolved,
+      failedCount: $failed,
+      totalUnresolved: $total,
+      affectedFiles: ([.[].path] | unique)
+    }'
+else
+    if [[ "$failed_count" -gt 0 ]]; then
+        log_warn "Resolved ${resolved_count}/${filtered_count} thread(s) across ${file_count} file(s) (${failed_count} failed)"
+    else
+        log_success "Resolved ${resolved_count} thread(s) across ${file_count} file(s)"
+    fi
+fi

--- a/tests/unit/test-resolve-review-threads.bats
+++ b/tests/unit/test-resolve-review-threads.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# Tests for resolve-review-threads.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/resolve-review-threads.sh"
+
+    MOCK_DIR=$(mktemp -d)
+    export PATH="$MOCK_DIR:$PATH"
+}
+
+teardown() {
+    rm -rf "$MOCK_DIR"
+}
+
+# Mock gh: resolves repo, returns a canned single-page reviewThreads response,
+# and records resolveReviewThread mutations to $MOCK_DIR/resolved.log.
+# Threads:
+#   111  a.py:42  unresolved  outdated   author haacked
+#   222  b.py:10  unresolved  current    author teammate
+#   333  c.py:5   resolved    current    author haacked
+create_mock_gh() {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/usr/bin/env bash
+args="$*"
+if [[ "$args" == *"repo view"* ]]; then
+    echo "owner/repo"
+    exit 0
+fi
+if [[ "$args" == *"resolveReviewThread"* || "$args" == *"--silent"* ]]; then
+    # Record the threadId being resolved
+    for ((i=1;i<=$#;i++)); do
+        if [[ "${!i}" == "threadId="* ]]; then
+            echo "${!i#threadId=}" >> "${MOCK_RESOLVED_LOG}"
+        fi
+    done
+    # Real `gh ... --silent` prints nothing on stdout; mirror that so the
+    # script's JSON summary is the only thing on stdout.
+    exit 0
+fi
+if [[ "$args" == *"graphql"* ]]; then
+    cat <<'JSON'
+{"data":{"repository":{"pullRequest":{"reviewThreads":{
+  "nodes":[
+    {"id":"NODE111","isResolved":false,"isOutdated":true,"path":"a.py","line":42,"comments":{"nodes":[{"databaseId":111,"body":"N+1 query here","author":{"login":"haacked"}}]}},
+    {"id":"NODE222","isResolved":false,"isOutdated":false,"path":"b.py","line":10,"comments":{"nodes":[{"databaseId":222,"body":"human comment","author":{"login":"teammate"}}]}},
+    {"id":"NODE333","isResolved":true,"isOutdated":false,"path":"c.py","line":5,"comments":{"nodes":[{"databaseId":333,"body":"old","author":{"login":"haacked"}}]}}
+  ],
+  "pageInfo":{"hasNextPage":false,"endCursor":null}
+}}}}}
+JSON
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$MOCK_DIR/gh"
+    MOCK_RESOLVED_LOG="$MOCK_DIR/resolved.log"
+    : > "$MOCK_RESOLVED_LOG"
+    export MOCK_RESOLVED_LOG
+}
+
+# =============================================================================
+# Script structure
+# =============================================================================
+
+@test "resolve-review-threads: has correct shebang" {
+    run bash -c "head -1 '$SCRIPT' | grep -q '^#!/usr/bin/env bash'"
+    [ "$status" -eq 0 ]
+}
+
+@test "resolve-review-threads: uses set -euo pipefail" {
+    run bash -c "head -40 '$SCRIPT' | grep -q 'set -euo pipefail'"
+    [ "$status" -eq 0 ]
+}
+
+@test "resolve-review-threads: query requests comment author login" {
+    run bash -c "grep -q 'author { login }' '$SCRIPT'"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Argument validation
+# =============================================================================
+
+@test "resolve-review-threads: --outdated and --all are mutually exclusive" {
+    run "$SCRIPT" 123 --outdated --all
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Cannot combine"* ]]
+}
+
+@test "resolve-review-threads: --comment-id rejects non-numeric id" {
+    run "$SCRIPT" 123 --comment-id abc
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"numeric"* ]]
+}
+
+@test "resolve-review-threads: --author requires an argument" {
+    run "$SCRIPT" 123 --author
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--author requires"* ]]
+}
+
+@test "resolve-review-threads: --help exits zero and prints usage" {
+    run "$SCRIPT" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+}
+
+# =============================================================================
+# Filtering behavior (mocked gh)
+# =============================================================================
+
+@test "resolve-review-threads: --json list excludes resolved threads" {
+    create_mock_gh
+    run bash -c "'$SCRIPT' 123 --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    # Only the two unresolved threads (111, 222); the resolved 333 is excluded
+    count=$(echo "$output" | jq '.threads | length')
+    [ "$count" -eq 2 ]
+    echo "$output" | jq -e '[.threads[].commentId] | index(333) == null'
+}
+
+@test "resolve-review-threads: --author scopes list to that author" {
+    create_mock_gh
+    run bash -c "'$SCRIPT' 123 --author haacked --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    count=$(echo "$output" | jq '.threads | length')
+    [ "$count" -eq 1 ]
+    [ "$(echo "$output" | jq -r '.threads[0].commentId')" -eq 111 ]
+    # Full comment body is surfaced for the semantic re-flag comparison
+    echo "$output" | jq -e '.threads[0] | has("body")'
+}
+
+@test "resolve-review-threads: author match is case-insensitive" {
+    create_mock_gh
+    run bash -c "'$SCRIPT' 123 --author HAACKED --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.threads | length')" -eq 1 ]
+}
+
+@test "resolve-review-threads: --comment-id resolves only the matching thread" {
+    create_mock_gh
+    run bash -c "'$SCRIPT' 123 --author haacked --comment-id 111 --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.resolvedCount')" -eq 1 ]
+    # The resolved node id was recorded by the mock
+    grep -q "NODE111" "$MOCK_DIR/resolved.log"
+    ! grep -q "NODE222" "$MOCK_DIR/resolved.log"
+}
+
+@test "resolve-review-threads: --comment-id for a teammate thread resolves nothing under our author scope" {
+    create_mock_gh
+    # 222 belongs to teammate; with --author haacked it is out of scope
+    run bash -c "'$SCRIPT' 123 --author haacked --comment-id 222 --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.resolvedCount')" -eq 0 ]
+    [ ! -s "$MOCK_DIR/resolved.log" ]
+}
+
+@test "resolve-review-threads: --dry-run does not resolve" {
+    create_mock_gh
+    run bash -c "'$SCRIPT' 123 --author haacked --comment-id 111 --dry-run --json 2>/dev/null"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.dryRun')" = "true" ]
+    [ ! -s "$MOCK_DIR/resolved.log" ]
+}


### PR DESCRIPTION
On `--append` in PR mode, the skill now auto-resolves GitHub review threads from your previous review whose findings the author has since addressed.

The resolution gate requires both signals before resolving: the code at the thread's location changed (the thread is outdated or the diff touches that path/line), and the fresh review no longer flags the same issue. If either signal is missing, the thread stays open. The skill then reports which threads were resolved and why, and which were left open.

To keep the action scoped to your own threads, a new `--author` filter on `resolve-review-threads.sh` restricts listing and resolving to threads whose first comment is yours. This prevents a stray comment ID from ever resolving a teammate's thread.

The script is a self-contained vendoring of `~/.dotfiles/bin/gh-resolve-threads` (so no external dependency), with three additions: `author` capture in the GraphQL query, `body` (up to 1500 chars) in the JSON output for the re-flag comparison, and the `--author` flag.

## Changes

- `scripts/resolve-review-threads.sh`: vendored `gh-resolve-threads`, adding `author`/`body` fields and `--author` flag
- `handlers/review.md`: new "Resolve Addressed Threads" step in the `--append` flow, placed after fresh findings are known and explicitly independent of `--draft`
- `SKILL.md`: updated `--append` description

## Test plan

13 new bats tests in `tests/unit/test-resolve-review-threads.bats` cover arg validation, author scoping (including case-insensitivity), unresolved/comment-id filtering, the teammate-thread safety guard, dry-run, and the `body` field. Full suite (1049 tests) passes.