### PR TITLE
Ensure review sessions clean up on cancellation and stale sweeps

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -35,6 +35,12 @@ If user selects "Merge and continue":
 3. Write merged content to PR review file
 4. Delete branch review file: `rm "$branch_review_path"`
 
+If user selects "Cancel": clean up the session, then stop (a worktree may have been provisioned for this session; this releases it instead of leaving it behind).
+
+```bash
+~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"
+```
+
 **If `needs_rename` is true** (branch review exists but should migrate to PR format):
 
 Use AskUserQuestion:
@@ -49,6 +55,12 @@ If user selects "Migrate and continue":
 2. Move file: `mv "$file_path" "$new_path"`
 3. Update `review_file` variable to new path
 
+If user selects "Cancel": clean up the session, then stop.
+
+```bash
+~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"
+```
+
 **If `file_info.file_exists` is true** (a review file exists but neither of the above conditions apply):
 
 First, check the session JSON for `overwrite` and `append` flags:
@@ -59,6 +71,12 @@ First, check the session JSON for `overwrite` and `append` flags:
     1. "Overwrite": Replace the existing review
     2. "Append": Add new findings to the existing review
     3. "Cancel": Stop without reviewing
+
+If user selects "Cancel": clean up the session, then stop.
+
+```bash
+~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"
+```
 
 ### Extract Session Data
 
@@ -1326,7 +1344,8 @@ If failed, show the error and suggest using the review file manually.
   1. Display the error message to the user
   2. Tell them: "Draft review creation failed. The review has been saved to the markdown file."
   3. Suggest: "You can copy comments from the review file and post them manually on GitHub."
-  4. **STOP HERE.** Do NOT attempt to post comments using `gh pr review` or any other method as a fallback. This will submit the review instead of keeping it pending.
+  4. Clean up the session: `~/.claude/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"`
+  5. **STOP HERE.** Do NOT attempt to post comments using `gh pr review` or any other method as a fallback. This will submit the review instead of keeping it pending.
 
 ### Resolve Addressed Threads (--append, PR Mode Only)
 

--- a/skills/review-code/scripts/review-status-handler.sh
+++ b/skills/review-code/scripts/review-status-handler.sh
@@ -46,6 +46,9 @@ ORCHESTRATOR=$(find_orchestrator)
 # Main logic
 case "${ACTION}" in
     "init")
+        # Sweep sessions (and worktrees) from a crashed/abandoned prior review.
+        # 24h threshold avoids reaping one still paused on a prompt elsewhere.
+        session_cleanup_old "review-code" 1440 2> /dev/null || true
         # Initialize session - run orchestrator and cache result
         # Pass arguments separately to preserve word splitting
         review_data=$("${ORCHESTRATOR}" "$@")

--- a/skills/review-code/scripts/session-manager.sh
+++ b/skills/review-code/scripts/session-manager.sh
@@ -220,13 +220,15 @@ session_cleanup() {
     rm -f "${command_dir}/${session_id}.meta.json"
 }
 
-# Cleanup old sessions (older than 1 hour)
+# Cleanup old sessions (older than $2, default 1 hour)
 # Args: $1 = command name (optional, if not provided cleans all commands)
+#       $2 = staleness threshold in minutes (optional, default 60)
 # Routes each stale session through session_cleanup so per-session teardown
 # (e.g. worktree removal) runs. Meta files have no per-session teardown so
 # they're swept separately with find -delete.
 session_cleanup_old() {
     local command_name="${1:-}"
+    local max_age_minutes="${2:-60}"
 
     local search_dir
     if [[ -z "${command_name}" ]]; then
@@ -241,9 +243,9 @@ session_cleanup_old() {
     while IFS= read -r -d '' stale_file; do
         session_id=$(basename "${stale_file}" .json)
         session_cleanup "${session_id}" 2> /dev/null || true
-    done < <(find "${search_dir}" -name "*.json" -not -name "*.meta.json" -type f -mmin +60 -print0 2> /dev/null)
+    done < <(find "${search_dir}" -name "*.json" -not -name "*.meta.json" -type f -mmin "+${max_age_minutes}" -print0 2> /dev/null)
 
-    find "${search_dir}" -name "*.meta.json" -type f -mmin +60 -delete 2> /dev/null || true
+    find "${search_dir}" -name "*.meta.json" -type f -mmin "+${max_age_minutes}" -delete 2> /dev/null || true
 }
 
 # List active sessions for a command


### PR DESCRIPTION
The review-code skill already tears down the git worktree it provisions for cross-repo PR reviews, but only when a review reaches its final "Cleanup Session" step. Four early-exit paths skipped that step and leaked the worktree instead: the three Cancel branches when an existing review file needs merging, migrating, or overwriting, and the stop path after a --draft API failure. Those paths now call session cleanup before stopping.

As a backstop for reviews that crash or get abandoned before reaching any cleanup step, /review-code init now sweeps sessions older than 24 hours and reaps their worktrees too. The threshold is generous so it doesn't reap a session that's just paused on a prompt in another window. session_cleanup_old takes the staleness threshold as an optional argument now instead of a hardcoded 60 minutes, so this call and any other caller can tune it independently.

## Test plan

Ran bin/test: 1321 unit tests and 12 integration tests pass.