### PR TITLE
Rename PR review worktree root to .worktrees

### DIFF
--- a/skills/review-code/scripts/helpers/worktree-layout.sh
+++ b/skills/review-code/scripts/helpers/worktree-layout.sh
@@ -7,7 +7,7 @@
 
 # Root directory that holds all review worktrees.
 worktree_root() {
-    echo "${REVIEW_CODE_WORKTREE_DIR:-${HOME}/.claude/skills/review-code/worktrees}"
+    echo "${REVIEW_CODE_WORKTREE_DIR:-${HOME}/.claude/skills/review-code/.worktrees}"
 }
 
 # Path leaf relative to worktree_root, e.g. "acme/widget/pr-7". Lowercases org

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -5,7 +5,7 @@
 #   pr-worktree.sh provision <org> <repo> <pr_number> <local_clone>
 #     Fetches refs/pull/<N>/head into refs/review-code/pr/<N> inside the user's
 #     clone, then creates (or reuses) a detached worktree at
-#     ${REVIEW_CODE_WORKTREE_DIR:-$HOME/.claude/skills/review-code/worktrees}/<org>/<repo>/pr-<N>.
+#     ${REVIEW_CODE_WORKTREE_DIR:-$HOME/.claude/skills/review-code/.worktrees}/<org>/<repo>/pr-<N>.
 #
 #     stdout: JSON {"worktree_path": "<abs>", "ref": "refs/review-code/pr/<N>"}
 #     stderr: progress / diagnostics

--- a/tests/unit/test-worktree-layout.bats
+++ b/tests/unit/test-worktree-layout.bats
@@ -11,11 +11,11 @@ setup() {
     source "$HELPER"
 }
 
-@test "worktree_root: falls back to ~/.claude/skills/review-code/worktrees by default" {
+@test "worktree_root: falls back to ~/.claude/skills/review-code/.worktrees by default" {
     unset REVIEW_CODE_WORKTREE_DIR
     run worktree_root
     [ "$status" -eq 0 ]
-    [ "$output" = "$HOME/.claude/skills/review-code/worktrees" ]
+    [ "$output" = "$HOME/.claude/skills/review-code/.worktrees" ]
 }
 
 @test "worktree_root: honors REVIEW_CODE_WORKTREE_DIR" {


### PR DESCRIPTION
- Moves the default PR review worktree root from `~/.claude/skills/review-code/worktrees` to `~/.claude/skills/review-code/.worktrees`. Tools that glob the skill directory, like `rg`, `fd`, and editor file trees, skip dot-prefixed directories by default, so checked-out PR content from other repos no longer gets mistaken for skill source.
- Existing worktrees provisioned under the old path aren't migrated. `bin/setup`'s orphan check only scans the new `.worktrees` root now, so leftover worktrees at the old location need manual cleanup with `git worktree remove`.

## Test plan

- Run `bin/test tests/unit/test-worktree-layout.bats` and confirm the updated default path assertion passes.
- Run `bin/setup` and confirm it installs cleanly.