### PR TITLE
Unlock worktrees before removal in teardown

### DIFF
--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -12,9 +12,10 @@
 #     exit 1 on fetch or worktree failure (caller falls back to diff-only)
 #
 #   pr-worktree.sh teardown <org> <repo> <pr_number> <local_clone>
-#     Removes the worktree via `git worktree remove --force`. Keeps the ref
-#     (trivially small; speeds up re-reviews of the same PR).
-#     No error if the worktree is already gone.
+#     Unlocks (in case an external tool locked it) and removes the worktree
+#     via `git worktree remove --force`. Keeps the ref (trivially small;
+#     speeds up re-reviews of the same PR). No error if the worktree is
+#     already gone.
 
 set -euo pipefail
 
@@ -190,6 +191,14 @@ teardown() {
     fi
 
     log "Removing worktree ${path}…"
+    # Some environments (e.g. Supacode's worktree manager) lock any git
+    # worktree they discover on disk, including ones we provision for
+    # ourselves. `git worktree remove` refuses a locked worktree unless
+    # --force is given twice; unlocking first lets a single --force work
+    # regardless of who (or what) placed the lock. `unlock` errors (and is
+    # swallowed) when the worktree isn't locked at all, which is the common
+    # case.
+    git -C "${local_clone}" worktree unlock "${path}" > /dev/null 2>&1 || true
     git -C "${local_clone}" worktree remove --force "${path}" > /dev/null 2>&1 || true
     # Best-effort cleanup of empty ancestor directories.
     local repo_dir="${path%/*}"

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -240,6 +240,26 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "pr-worktree teardown: removes a worktree locked by an external tool" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+
+    # Simulate an external tool (e.g. Supacode) locking the worktree it
+    # discovered on disk, independent of review-code's own provisioning.
+    git -C "$CLONE_DIR" worktree lock "$wt_path" --reason "locked by external tool"
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" == *"locked"* ]]
+
+    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    [ ! -d "$wt_path" ]
+
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" != *"$wt_path"* ]]
+}
+
 # =============================================================================
 # path layout
 # =============================================================================


### PR DESCRIPTION
- `teardown()` now calls `git worktree unlock` before `git worktree remove --force`, so removal succeeds even when an external tool (e.g. Supacode's daemon) has locked the worktree
- Without the unlock, `git worktree remove` silently failed on a locked worktree since it needs `--force` twice, and orphaned worktrees under `.worktrees/<org>/<repo>/` permanently, because `session_cleanup` deletes the session file right after invoking teardown regardless of success

Test plan:
- Added a bats test that locks a worktree externally mid-test, then asserts teardown still removes it
- `bin/test` passes (1329 tests)