### PR TITLE
Skip teardown for review worktrees with uncommitted changes

### DIFF
--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -15,7 +15,8 @@
 #     Unlocks (in case an external tool locked it) and removes the worktree
 #     via `git worktree remove --force`. Keeps the ref (trivially small;
 #     speeds up re-reviews of the same PR). No error if the worktree is
-#     already gone.
+#     already gone. Leaves the worktree untouched if it has uncommitted or
+#     untracked changes, so in-progress edits are never destroyed.
 
 set -euo pipefail
 
@@ -187,6 +188,16 @@ teardown() {
     path=$(canonicalize "${path}")
 
     if ! worktree_is_registered "${local_clone}" "${path}"; then
+        return 0
+    fi
+
+    # An external lock (see below) used to be the only thing standing between
+    # a stray `--force` and an in-progress edit, since a single --force can't
+    # touch a locked worktree. Now that we unlock deliberately, check for
+    # uncommitted/untracked changes ourselves before removing anything -
+    # mirroring the dirty-worktree guard in git-bclean-local.
+    if [[ -n "$(git -C "${path}" status --porcelain 2> /dev/null)" ]]; then
+        log "Leaving worktree ${path} in place (has uncommitted changes)."
         return 0
     fi
 

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -196,7 +196,12 @@ teardown() {
     # touch a locked worktree. Now that we unlock deliberately, check for
     # uncommitted/untracked changes ourselves before removing anything -
     # mirroring the dirty-worktree guard in git-bclean-local.
-    if [[ -n "$(git -C "${path}" status --porcelain 2> /dev/null)" ]]; then
+    local status_output
+    if ! status_output=$(git -C "${path}" status --porcelain --untracked-files=normal 2>&1); then
+        log "Leaving worktree ${path} in place (couldn't check for uncommitted changes)."
+        return 0
+    fi
+    if [[ -n "${status_output}" ]]; then
         log "Leaving worktree ${path} in place (has uncommitted changes)."
         return 0
     fi

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -260,6 +260,39 @@ EOF
     [[ "$output" != *"$wt_path"* ]]
 }
 
+@test "pr-worktree teardown: leaves a worktree with uncommitted changes in place" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+
+    # Simulate in-progress edits, e.g. a reviewer applying a suggested fix.
+    echo "uncommitted edit" >> "$wt_path/file.txt"
+
+    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$wt_path" ]
+
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" == *"$wt_path"* ]]
+}
+
+@test "pr-worktree teardown: leaves a worktree with untracked files in place" {
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    local wt_path
+    wt_path=$(echo "$output" | jq -r '.worktree_path')
+
+    echo "scratch notes" > "$wt_path/untracked.txt"
+
+    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+    [ -d "$wt_path" ]
+
+    run git -C "$CLONE_DIR" worktree list --porcelain
+    [[ "$output" == *"$wt_path"* ]]
+}
+
 # =============================================================================
 # path layout
 # =============================================================================


### PR DESCRIPTION
- #119 made `teardown()` unlock a worktree before force-removing it, so removal succeeds even when Supacode's daemon has locked it.
- That lock had been the only thing stopping a stray `--force` from wiping out uncommitted changes: git already refuses to remove a dirty worktree with a single `--force`, but a locked worktree needs `--force` twice regardless of its dirty state. Once teardown unlocks first, a worktree with in-progress edits gets silently destroyed the next time it's torn down, including via the 24h stale-session sweep that runs on any unrelated `/review-code` invocation.
- `teardown()` now checks `git status --porcelain` before unlocking and removing, the same guard `git-bclean-local` already uses, and leaves the worktree in place if it's dirty.

## Test plan

Added two bats tests covering uncommitted changes and untracked files; both are left in place. `bin/test` passes (1324 unit tests, 12 integration tests).