### PR TITLE
Fix missing worktree cleanup hook and add locking

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -126,8 +126,7 @@ copy_scripts_dir() {
     local src
     for src in "${src_subdir}/"*.sh; do
         [[ -e "${src}" ]] || continue
-        local filename
-        filename=$(basename "${src}")
+        local filename="${src##*/}"
         cp "${src}" "${dst_subdir}/${filename}"
         chmod +x "${dst_subdir}/${filename}"
     done

--- a/bin/setup
+++ b/bin/setup
@@ -117,12 +117,29 @@ verify_repo_structure() {
     fi
 }
 
+# Copy every *.sh in $1 to $2, marking each executable. No-op if $1 doesn't
+# exist or is empty.
+copy_scripts_dir() {
+    local src_subdir="$1"
+    local dst_subdir="$2"
+    [[ -d "${src_subdir}" ]] || return 0
+    local src
+    for src in "${src_subdir}/"*.sh; do
+        [[ -e "${src}" ]] || continue
+        local filename
+        filename=$(basename "${src}")
+        cp "${src}" "${dst_subdir}/${filename}"
+        chmod +x "${dst_subdir}/${filename}"
+    done
+}
+
 install_skill() {
     local src_dir="${SCRIPT_DIR}/skills/review-code"
     local dst_dir="${SKILL_DIR}"
 
     # Create skill directory structure
     mkdir -p "${dst_dir}/scripts/helpers"
+    mkdir -p "${dst_dir}/scripts/session-hooks"
     mkdir -p "${dst_dir}/reviews"
     mkdir -p "${dst_dir}/learnings"
 
@@ -155,17 +172,11 @@ install_skill() {
     done
 
     # Copy helper scripts
-    if [[ -d "${src_dir}/scripts/helpers" ]]; then
-        for src in "${src_dir}/scripts/helpers/"*.sh; do
-            [[ -e "${src}" ]] || continue
-            local filename
-            filename=$(basename "${src}")
-            local dst="${dst_dir}/scripts/helpers/${filename}"
+    copy_scripts_dir "${src_dir}/scripts/helpers" "${dst_dir}/scripts/helpers"
 
-            cp "${src}" "${dst}"
-            chmod +x "${dst}"
-        done
-    fi
+    # Copy session hooks (per-command teardown invoked by session-manager.sh;
+    # e.g. review-code-cleanup.sh removes a provisioned PR worktree)
+    copy_scripts_dir "${src_dir}/scripts/session-hooks" "${dst_dir}/scripts/session-hooks"
 
     # Copy handlers
     if [[ -d "${src_dir}/handlers" ]]; then

--- a/skills/review-code/scripts/helpers/worktree-layout.sh
+++ b/skills/review-code/scripts/helpers/worktree-layout.sh
@@ -31,3 +31,14 @@ worktree_path_for() {
 worktree_layout_depth() {
     echo 3
 }
+
+# Lock directory (mkdir-based) guarding provision/teardown for a given
+# org/repo pair. Both operations run `git fetch` and `git worktree add/remove`
+# against the same local clone, which is not safe to do concurrently - two
+# overlapping reviews of the same repo could race on git's internal
+# refs/worktree metadata.
+worktree_lock_for() {
+    local org="$1"
+    local repo="$2"
+    echo "$(worktree_root)/${org,,}/${repo,,}.lock"
+}

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -17,6 +17,12 @@
 #     speeds up re-reviews of the same PR). No error if the worktree is
 #     already gone. Leaves the worktree untouched if it has uncommitted or
 #     untracked changes, so in-progress edits are never destroyed.
+#
+# Both commands serialize on a per-org/repo mkdir-based lock before touching
+# the local clone, since concurrent `git fetch`/`git worktree add|remove`
+# against the same clone is not safe (see worktree_lock_for). Lock wait tops
+# out at REVIEW_CODE_LOCK_TIMEOUT seconds (default 30); the caller falls back
+# to diff-only on timeout.
 
 set -euo pipefail
 
@@ -33,6 +39,33 @@ export GIT_TERMINAL_PROMPT=0
 # All progress output goes to stderr; stdout is reserved for the provision JSON.
 log() {
     echo "$*" >&2
+}
+
+LOCK_DIR=""
+
+cleanup_lock() {
+    if [[ -n "${LOCK_DIR}" ]]; then
+        rmdir "${LOCK_DIR}" 2> /dev/null || true
+    fi
+}
+trap cleanup_lock EXIT INT TERM
+
+# Serializes provision/teardown per org/repo (see worktree_lock_for). mkdir is
+# the lock primitive: atomic create, no extra dependency, and portable (macOS
+# has no `flock`). Self-clears via the EXIT trap even if the caller is killed.
+acquire_lock() {
+    local lockfile="$1"
+    local waited=0
+    mkdir -p "$(dirname "${lockfile}")"
+    while ! mkdir "${lockfile}" 2> /dev/null; do
+        sleep 1
+        waited=$((waited + 1))
+        if ((waited >= ${REVIEW_CODE_LOCK_TIMEOUT:-30})); then
+            error "Timed out waiting for worktree lock: ${lockfile}"
+            return 1
+        fi
+    done
+    LOCK_DIR="${lockfile}"
 }
 
 # Resolve symlinks in <path>. Needed because `git worktree list` returns
@@ -119,6 +152,8 @@ provision() {
     local pr_number="$3"
     local local_clone="$4"
 
+    acquire_lock "$(worktree_lock_for "${org}" "${repo}")" || return 1
+
     local ref
     ref=$(ref_for "${pr_number}")
     local path
@@ -182,6 +217,8 @@ teardown() {
     # pointer (which may be gone), but the clone still has a stale
     # registration that needs `git worktree remove --force` to drop.
     local local_clone="$4"
+
+    acquire_lock "$(worktree_lock_for "${org}" "${repo}")" || return 1
 
     local path
     path=$(worktree_path_for "${org}" "${repo}" "${pr_number}")

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -21,8 +21,9 @@
 # Both commands serialize on a per-org/repo mkdir-based lock before touching
 # the local clone, since concurrent `git fetch`/`git worktree add|remove`
 # against the same clone is not safe (see worktree_lock_for). Lock wait tops
-# out at REVIEW_CODE_LOCK_TIMEOUT seconds (default 30); the caller falls back
-# to diff-only on timeout.
+# out at REVIEW_CODE_LOCK_TIMEOUT seconds (default 30). On timeout, provision's
+# caller falls back to diff-only; teardown's caller swallows the failure and
+# leaves the worktree in place for a later run to remove.
 
 set -euo pipefail
 
@@ -52,7 +53,10 @@ trap cleanup_lock EXIT INT TERM
 
 # Serializes provision/teardown per org/repo (see worktree_lock_for). mkdir is
 # the lock primitive: atomic create, no extra dependency, and portable (macOS
-# has no `flock`). Self-clears via the EXIT trap even if the caller is killed.
+# has no `flock`). The EXIT/INT/TERM trap clears it on normal exit and on
+# Ctrl-C/terminate, but a SIGKILL or OOM-kill leaves the directory behind;
+# there is no stale-lock recovery yet, so a killed holder wedges every future
+# provision/teardown for that org/repo until someone manually rmdirs it.
 acquire_lock() {
     local lockfile="$1"
     local waited=0

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -216,6 +216,47 @@ EOF
     grep -q "post-crash" "$wt_path/file.txt"
 }
 
+@test "pr-worktree provision: serializes concurrent invocations for the same org/repo" {
+    # Manually hold the lock provision() would acquire, to verify it actually
+    # waits rather than racing a second `git fetch`/`worktree add` against the
+    # same clone concurrently.
+    local lock_path="$WORKTREE_ROOT/myorg/myrepo.lock"
+    mkdir -p "$(dirname "$lock_path")"
+    mkdir "$lock_path"
+
+    "$SCRIPT" provision myorg myrepo 42 "$CLONE_DIR" \
+        > "$TEST_DIR/bg-output.json" 2> "$TEST_DIR/bg-output.log" &
+    local bg_pid=$!
+
+    sleep 2
+    # Still blocked on the lock: no worktree yet.
+    [ ! -d "$WORKTREE_ROOT/myorg/myrepo/pr-42" ]
+    kill -0 "$bg_pid"
+
+    rmdir "$lock_path"
+    wait "$bg_pid"
+    [ "$?" -eq 0 ]
+    [ -d "$WORKTREE_ROOT/myorg/myrepo/pr-42" ]
+    # provision released its own lock via the EXIT trap.
+    [ ! -d "$lock_path" ]
+}
+
+@test "pr-worktree provision: gives up and returns 1 after the lock timeout" {
+    # Hold the lock and never release it, forcing provision() down the
+    # timeout path. REVIEW_CODE_LOCK_TIMEOUT keeps this test fast.
+    local lock_path="$WORKTREE_ROOT/myorg/myrepo.lock"
+    mkdir -p "$(dirname "$lock_path")"
+    mkdir "$lock_path"
+
+    REVIEW_CODE_LOCK_TIMEOUT=2 run "$SCRIPT" provision myorg myrepo 42 "$CLONE_DIR"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Timed out waiting for worktree lock"* ]]
+    [ ! -d "$WORKTREE_ROOT/myorg/myrepo/pr-42" ]
+    # The still-held lock is the caller's, not provision's; it must remain.
+    [ -d "$lock_path" ]
+}
+
 # =============================================================================
 # teardown
 # =============================================================================

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -257,6 +257,26 @@ EOF
     [ -d "$lock_path" ]
 }
 
+@test "pr-worktree teardown: gives up and returns 1 after the lock timeout" {
+    # Provision first so there's a real worktree teardown would otherwise
+    # remove, then confirm a contended lock blocks teardown too and leaves
+    # that worktree untouched.
+    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
+    [ "$status" -eq 0 ]
+
+    local lock_path="$WORKTREE_ROOT/myorg/myrepo.lock"
+    mkdir "$lock_path"
+
+    REVIEW_CODE_LOCK_TIMEOUT=2 run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
+
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Timed out waiting for worktree lock"* ]]
+    # The worktree survived because teardown never got the lock.
+    [ -d "$WORKTREE_ROOT/myorg/myrepo/pr-42" ]
+    # The still-held lock is the caller's, not teardown's; it must remain.
+    [ -d "$lock_path" ]
+}
+
 # =============================================================================
 # teardown
 # =============================================================================

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -208,7 +208,7 @@ setup() {
 }
 
 @test "setup: install_skill copies session hooks" {
-    run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'session-hooks'"
+    run bash -c "awk '/^install_skill\(\)/{f=1} f{print} /^}/{if(f)exit}' '$PROJECT_ROOT/bin/setup' | grep -q 'session-hooks'"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -188,7 +188,7 @@ setup() {
 }
 
 @test "setup: install_skill copies uninstall script" {
-    run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'uninstall.sh'"
+    run bash -c "awk '/^install_skill\(\)/{f=1} f{print} /^}/{if(f)exit}' '$PROJECT_ROOT/bin/setup' | grep -q 'uninstall.sh'"
     [ "$status" -eq 0 ]
 }
 
@@ -205,6 +205,44 @@ setup() {
 @test "setup: install_skill creates learnings directory" {
     run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'learnings'"
     [ "$status" -eq 0 ]
+}
+
+@test "setup: install_skill copies session hooks" {
+    run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'session-hooks'"
+    [ "$status" -eq 0 ]
+}
+
+@test "setup: install_skill actually deploys session-hooks files to disk" {
+    # Regression test for a bug where scripts/session-hooks/ was added to the
+    # repo (review-code-cleanup.sh) but install_skill only ever copied
+    # scripts/*.sh and scripts/helpers/*.sh, silently never deploying it.
+    TEST_TEMP_DIR=$(mktemp -d)
+    src_dir="${TEST_TEMP_DIR}/src/skills/review-code"
+    dst_dir="${TEST_TEMP_DIR}/dst/skills/review-code"
+    mkdir -p "${src_dir}/scripts/session-hooks"
+    echo '#!/usr/bin/env bash' > "${src_dir}/scripts/session-hooks/review-code-cleanup.sh"
+    mkdir -p "${src_dir}/scripts/helpers"
+    touch "${src_dir}/SKILL.md"
+
+    run bash -c "
+        set -euo pipefail
+        info() { :; }
+        debug() { :; }
+        warn() { :; }
+        error() { :; }
+        SCRIPT_DIR='${TEST_TEMP_DIR}/src'
+        CLAUDE_DIR='${TEST_TEMP_DIR}/dst'
+        SKILL_DIR='${dst_dir}'
+        source <(sed -n '/^copy_scripts_dir()/,/^}/p' '$PROJECT_ROOT/bin/setup')
+        source <(sed -n '/^install_skill()/,/^}/p' '$PROJECT_ROOT/bin/setup')
+        install_skill
+    "
+
+    [ "$status" -eq 0 ]
+    [ -f "${dst_dir}/scripts/session-hooks/review-code-cleanup.sh" ]
+    [ -x "${dst_dir}/scripts/session-hooks/review-code-cleanup.sh" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
 }
 
 # =============================================================================

--- a/tests/unit/test-worktree-layout.bats
+++ b/tests/unit/test-worktree-layout.bats
@@ -42,3 +42,19 @@ setup() {
     run worktree_layout_depth
     [ "$output" = "3" ]
 }
+
+@test "worktree_lock_for: lowercases org and repo and appends .lock" {
+    REVIEW_CODE_WORKTREE_DIR=/tmp/wt run worktree_lock_for "Acme" "Widget"
+    [ "$output" = "/tmp/wt/acme/widget.lock" ]
+}
+
+@test "worktree_lock_for: is a sibling of the repo's worktree directory, not nested in it" {
+    REVIEW_CODE_WORKTREE_DIR=/tmp/wt
+    export REVIEW_CODE_WORKTREE_DIR
+    local wt_path lock_path
+    wt_path=$(worktree_path_for "acme" "widget" 7)
+    lock_path=$(worktree_lock_for "acme" "widget")
+    # Both live directly under .../acme/, so removing a PR worktree can never
+    # remove the lock, and vice versa.
+    [ "$(dirname "$(dirname "$wt_path")")" = "$(dirname "$lock_path")" ]
+}


### PR DESCRIPTION
install_skill() in bin/setup copies scripts/*.sh and scripts/helpers/*.sh individually, but never copies scripts/session-hooks/. That means review-code-cleanup.sh (added in #117) has been committed and merged for a while, but no install has ever actually deployed it. Every /review-code session has been silently missing its own worktree teardown hook since #117 landed, leaking a git worktree on disk for every review that provisions one.

pr-worktree.sh's provision() and teardown() both run git fetch and git worktree add/remove against the caller's shared local clone, with nothing stopping two overlapping reviews of the same repo from racing on git's internal refs/worktree metadata. Added the same mkdir-based lock repo-cache.sh already uses for this class of problem, keyed by org/repo.

**Test plan**
- `bin/test` passes (full suite)
- `shellcheck -x -o all -e SC1091,SC2250` is clean on `bin/setup`, the only changed file `bin/lint` actually covers
- New test confirms `install_skill` deploys `scripts/session-hooks/*.sh` to disk, not just that the string appears in the function source
- New test confirms `provision()` blocks while another invocation holds the org/repo lock, then proceeds once released