### PR TITLE
Fix regex bug that duplicated context sections on every setup run

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -45,20 +45,25 @@ CLAUDE_DIR="${HOME}/.claude"
 SKILL_DIR="${CLAUDE_DIR}/skills/review-code"
 
 # Functions
+#
+# All four write to stderr, not stdout: several call sites (e.g.
+# process_context_file) run inside `$(...)` command substitution and use
+# stdout as their actual return value, so a helper that printed to stdout
+# would silently corrupt that value with log text.
 info() {
-    echo -e "${GREEN}✓${NC} $1"
+    echo -e "${GREEN}✓${NC} $1" >&2
 }
 
 warn() {
-    echo -e "${YELLOW}⚠${NC} $1"
+    echo -e "${YELLOW}⚠${NC} $1" >&2
 }
 
 error() {
-    echo -e "${RED}✗${NC} $1"
+    echo -e "${RED}✗${NC} $1" >&2
 }
 
 debug() {
-    echo -e "${BLUE}→${NC} $1"
+    echo -e "${BLUE}→${NC} $1" >&2
 }
 
 check_prerequisites() {
@@ -305,7 +310,11 @@ get_section_headers() {
 has_section() {
     local file="$1"
     local section="$2"
-    grep -qE "^## ${section}$" "${file}" 2> /dev/null
+    # Fixed-string, whole-line match: section titles routinely contain regex
+    # metacharacters (e.g. "Derive Awareness (Critical)"), which -E would
+    # otherwise interpret as grouping/anchoring instead of literal text and
+    # never match, causing the section to be re-appended on every merge.
+    grep -qFx "## ${section}" "${file}" 2> /dev/null
 }
 
 # Extract a section from a markdown file (header + content until next header or EOF)
@@ -324,6 +333,35 @@ extract_section() {
         }
         printing { print }
     ' "${file}"
+}
+
+# Remove duplicate H2 sections from a file in place, keeping the first
+# occurrence of each. Self-heals installations corrupted by the historical
+# has_section bug: its broken regex meant duplicate-detection always failed
+# for section titles containing regex metacharacters (e.g. "Derive
+# Awareness (Critical)"), so those sections got re-appended on every setup
+# run. Fixing has_section alone stops new duplication but can't undo
+# duplicates a prior run already wrote to disk, hence this separate pass.
+# Returns 0 if the file was changed, 1 if it had no duplicate sections.
+dedupe_sections_in_place() {
+    local file="$1"
+    local original
+    original=$(cat "${file}")
+
+    local deduped
+    deduped=$(awk '
+        /^## / {
+            if ($0 in seen) { skip = 1 } else { seen[$0] = 1; skip = 0 }
+        }
+        !skip { print }
+    ' "${file}")
+
+    if [[ "${deduped}" == "${original}" ]]; then
+        return 1
+    fi
+
+    printf '%s\n' "${deduped}" > "${file}"
+    return 0
 }
 
 # Smart merge: copy new sections from src to dst, preserving existing dst content
@@ -370,13 +408,24 @@ process_context_file() {
         return
     fi
 
+    local was_deduped=false
+    # shellcheck disable=SC2310 # a 1 return (no duplicates found) is expected, not an error
+    if dedupe_sections_in_place "${dst}"; then
+        was_deduped=true
+        debug "Removed duplicate section(s): ${display_name}"
+    fi
+
     local src_sum dst_sum
     src_sum=$(get_file_checksum "${src}")
     dst_sum=$(get_file_checksum "${dst}")
 
     if [[ "${src_sum}" == "${dst_sum}" ]]; then
         # Files identical - no action needed
-        echo "updated"
+        if [[ "${was_deduped}" == true ]]; then
+            echo "deduped"
+        else
+            echo "updated"
+        fi
         return
     fi
 
@@ -387,6 +436,8 @@ process_context_file() {
     if [[ "${sections_added}" -gt 0 ]]; then
         debug "Merged ${sections_added} new section(s): ${display_name}"
         echo "merged"
+    elif [[ "${was_deduped}" == true ]]; then
+        echo "deduped"
     else
         # No new sections to add, preserve user's version
         echo "preserved"
@@ -406,6 +457,7 @@ install_context() {
     local preserved=0
     local new=0
     local merged=0
+    local deduped=0
 
     # Copy language context files with smart merge
     for src in "${context_src}/languages/"*.md; do
@@ -420,6 +472,7 @@ install_context() {
             updated) updated=$((updated + 1)) ;;
             merged) merged=$((merged + 1)) ;;
             preserved) preserved=$((preserved + 1)) ;;
+            deduped) deduped=$((deduped + 1)) ;;
             *) ;;
         esac
     done
@@ -437,6 +490,7 @@ install_context() {
             updated) updated=$((updated + 1)) ;;
             merged) merged=$((merged + 1)) ;;
             preserved) preserved=$((preserved + 1)) ;;
+            deduped) deduped=$((deduped + 1)) ;;
             *) ;;
         esac
     done
@@ -462,6 +516,7 @@ install_context() {
                     updated) updated=$((updated + 1)) ;;
                     merged) merged=$((merged + 1)) ;;
                     preserved) preserved=$((preserved + 1)) ;;
+                    deduped) deduped=$((deduped + 1)) ;;
                     *) ;;
                 esac
             done
@@ -481,6 +536,7 @@ install_context() {
                         updated) updated=$((updated + 1)) ;;
                         merged) merged=$((merged + 1)) ;;
                         preserved) preserved=$((preserved + 1)) ;;
+                        deduped) deduped=$((deduped + 1)) ;;
                         *) ;;
                     esac
                 done
@@ -497,6 +553,9 @@ install_context() {
     fi
     if [[ ${preserved} -gt 0 ]]; then
         summary="${summary}, ${preserved} preserved"
+    fi
+    if [[ ${deduped} -gt 0 ]]; then
+        summary="${summary}, ${deduped} deduplicated"
     fi
     info "Context files: ${summary}"
 }

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -328,7 +328,7 @@ get_section_headers() {
 has_section() {
     local file="$1"
     local section="$2"
-    grep -qE "^## ${section}$" "${file}" 2> /dev/null
+    grep -qFx "## ${section}" "${file}" 2> /dev/null
 }
 
 extract_section() {
@@ -344,6 +344,27 @@ extract_section() {
         }
         printing { print }
     ' "${file}"
+}
+
+dedupe_sections_in_place() {
+    local file="$1"
+    local original
+    original=$(cat "${file}")
+
+    local deduped
+    deduped=$(awk '
+        /^## / {
+            if ($0 in seen) { skip = 1 } else { seen[$0] = 1; skip = 0 }
+        }
+        !skip { print }
+    ' "${file}")
+
+    if [[ "${deduped}" == "${original}" ]]; then
+        return 1
+    fi
+
+    printf '%s\n' "${deduped}" > "${file}"
+    return 0
 }
 
 merge_markdown_sections() {
@@ -367,6 +388,70 @@ merge_markdown_sections() {
     done <<< "${section_headers}"
 
     echo "${new_sections_added}"
+}
+
+# Minimal stand-ins for bin/setup's logging helpers. The real ones write to
+# stderr specifically so they can't corrupt a caller's `$(...)` capture; this
+# copy must match that or the process_context_file tests below would pass
+# for the wrong reason.
+debug() {
+    echo "-> $1" >&2
+}
+
+get_file_checksum() {
+    local file="$1"
+    if [[ -f "${file}" ]]; then
+        if command -v md5 &> /dev/null; then
+            md5 -q "${file}"
+        else
+            md5sum "${file}" | cut -d' ' -f1
+        fi
+    else
+        echo ""
+    fi
+}
+
+process_context_file() {
+    local src="$1"
+    local dst="$2"
+    local display_name="$3"
+
+    if [[ ! -f "${dst}" ]]; then
+        cp "${src}" "${dst}"
+        echo "new"
+        return
+    fi
+
+    local was_deduped=false
+    if dedupe_sections_in_place "${dst}"; then
+        was_deduped=true
+        debug "Removed duplicate section(s): ${display_name}"
+    fi
+
+    local src_sum dst_sum
+    src_sum=$(get_file_checksum "${src}")
+    dst_sum=$(get_file_checksum "${dst}")
+
+    if [[ "${src_sum}" == "${dst_sum}" ]]; then
+        if [[ "${was_deduped}" == true ]]; then
+            echo "deduped"
+        else
+            echo "updated"
+        fi
+        return
+    fi
+
+    local sections_added
+    sections_added=$(merge_markdown_sections "${src}" "${dst}")
+
+    if [[ "${sections_added}" -gt 0 ]]; then
+        debug "Merged ${sections_added} new section(s): ${display_name}"
+        echo "merged"
+    elif [[ "${was_deduped}" == true ]]; then
+        echo "deduped"
+    else
+        echo "preserved"
+    fi
 }
 FUNCTIONS
 }
@@ -441,6 +526,26 @@ EOF
 
     run has_section "$TEST_TEMP_DIR/test.md" "Missing Section"
     [ "$status" -ne 0 ]
+
+    teardown_smart_merge
+}
+
+@test "has_section: returns 0 for a title containing regex metacharacters" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    # Regression test: titles like "Derive Awareness (Critical)" or
+    # "Accessibility Requirements (WCAG 2.1 AA)" contain unescaped ERE
+    # metacharacters. A grep -E match on these previously always failed,
+    # so has_section reported the section missing even when present,
+    # causing merge_markdown_sections to re-append it on every run.
+    cat > "$TEST_TEMP_DIR/test.md" << 'EOF'
+## Derive Awareness (Critical)
+Content
+EOF
+
+    run has_section "$TEST_TEMP_DIR/test.md" "Derive Awareness (Critical)"
+    [ "$status" -eq 0 ]
 
     teardown_smart_merge
 }
@@ -593,6 +698,31 @@ EOF
     teardown_smart_merge
 }
 
+@test "merge_markdown_sections: does not duplicate a section whose title has regex metacharacters across repeated runs" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    # Regression test for the bin/setup rerun bug: sections like
+    # "Derive Awareness (Critical)" were re-appended on every run because
+    # has_section's grep -E never matched the literal parentheses.
+    cat > "$TEST_TEMP_DIR/src.md" << 'EOF'
+## Derive Awareness (Critical)
+Detection signals here.
+EOF
+
+    cp "$TEST_TEMP_DIR/src.md" "$TEST_TEMP_DIR/dst.md"
+
+    # Simulate `bin/setup` being run repeatedly (its stated, supported usage).
+    for _ in 1 2 3; do
+        merge_markdown_sections "$TEST_TEMP_DIR/src.md" "$TEST_TEMP_DIR/dst.md" > /dev/null
+    done
+
+    occurrences=$(grep -c "## Derive Awareness (Critical)" "$TEST_TEMP_DIR/dst.md")
+    [ "$occurrences" -eq 1 ]
+
+    teardown_smart_merge
+}
+
 @test "merge_markdown_sections: handles empty source file" {
     setup_smart_merge
     source "$TEST_TEMP_DIR/smart_merge.sh"
@@ -613,9 +743,159 @@ EOF
     teardown_smart_merge
 }
 
+@test "setup: has dedupe_sections_in_place function" {
+    run bash -c "grep -q '^dedupe_sections_in_place()' '$PROJECT_ROOT/bin/setup'"
+    [ "$status" -eq 0 ]
+}
+
+@test "setup: process_context_file uses dedupe_sections_in_place" {
+    run bash -c "grep -A20 '^process_context_file()' '$PROJECT_ROOT/bin/setup' | grep -q 'dedupe_sections_in_place'"
+    [ "$status" -eq 0 ]
+}
+
+@test "dedupe_sections_in_place: removes duplicate sections, keeps first occurrence" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    cat > "$TEST_TEMP_DIR/dup.md" << 'EOF'
+# Title
+
+## Derive Awareness (Critical)
+First copy, this is the one that should survive.
+
+## Other Section
+Other content.
+
+## Derive Awareness (Critical)
+Second copy, a duplicate that should be removed.
+EOF
+
+    run dedupe_sections_in_place "$TEST_TEMP_DIR/dup.md"
+    [ "$status" -eq 0 ]
+
+    occurrences=$(grep -c "## Derive Awareness (Critical)" "$TEST_TEMP_DIR/dup.md")
+    [ "$occurrences" -eq 1 ]
+    grep -q "First copy, this is the one that should survive." "$TEST_TEMP_DIR/dup.md"
+    ! grep -q "Second copy, a duplicate that should be removed." "$TEST_TEMP_DIR/dup.md"
+    # Untouched section and the pre-H2 title survive.
+    grep -q "^# Title$" "$TEST_TEMP_DIR/dup.md"
+    grep -q "## Other Section" "$TEST_TEMP_DIR/dup.md"
+
+    teardown_smart_merge
+}
+
+@test "dedupe_sections_in_place: returns non-zero and leaves file unchanged when there are no duplicates" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    cat > "$TEST_TEMP_DIR/clean.md" << 'EOF'
+## Section One
+Content one.
+
+## Section Two
+Content two.
+EOF
+    cp "$TEST_TEMP_DIR/clean.md" "$TEST_TEMP_DIR/clean.md.orig"
+
+    run dedupe_sections_in_place "$TEST_TEMP_DIR/clean.md"
+    [ "$status" -ne 0 ]
+
+    diff "$TEST_TEMP_DIR/clean.md" "$TEST_TEMP_DIR/clean.md.orig"
+
+    teardown_smart_merge
+}
+
+@test "dedupe_sections_in_place: collapses many repeated duplicates (simulates a corrupted installation)" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    {
+        echo "# Rust Review Guidelines"
+        for _ in $(seq 1 238); do
+            echo ""
+            echo "## Derive Awareness (Critical)"
+            echo "Detection signals here."
+        done
+    } > "$TEST_TEMP_DIR/bloated.md"
+
+    run dedupe_sections_in_place "$TEST_TEMP_DIR/bloated.md"
+    [ "$status" -eq 0 ]
+
+    occurrences=$(grep -c "## Derive Awareness (Critical)" "$TEST_TEMP_DIR/bloated.md")
+    [ "$occurrences" -eq 1 ]
+
+    teardown_smart_merge
+}
+
 @test "setup: has process_context_file function" {
     run bash -c "grep -q '^process_context_file()' '$PROJECT_ROOT/bin/setup'"
     [ "$status" -eq 0 ]
+}
+
+@test "setup: logging helpers write to stderr, not stdout" {
+    # Regression test: process_context_file's return value is the stdout of
+    # a \$(...) call, and it calls debug() internally. If any of info/warn/
+    # error/debug wrote to stdout, that log text would corrupt the captured
+    # status (see the two tests below for the concrete failure mode this
+    # caused: "deduped"/"merged" silently vanishing from the setup summary).
+    for fn in info warn error debug; do
+        run bash -c "grep -A2 \"^${fn}()\" '$PROJECT_ROOT/bin/setup' | grep -q '>&2'"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "process_context_file: returns a single-word status even when a section was deduplicated" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    cat > "$TEST_TEMP_DIR/src.md" << 'EOF'
+## Derive Awareness (Critical)
+Content.
+EOF
+
+    # A destination that already has every section from src, just duplicated,
+    # so dedupe changes it but merge finds nothing new to add.
+    cat > "$TEST_TEMP_DIR/dst.md" << 'EOF'
+## Derive Awareness (Critical)
+Content.
+
+## Derive Awareness (Critical)
+Content.
+EOF
+
+    result=$(process_context_file "$TEST_TEMP_DIR/src.md" "$TEST_TEMP_DIR/dst.md" "test.md")
+
+    # Must be exactly "deduped", not that plus a stray debug line, and not
+    # silently swallowed into `*) ;;` by a case statement that can't match
+    # a multi-line value.
+    [ "$result" = "deduped" ]
+
+    teardown_smart_merge
+}
+
+@test "process_context_file: returns a single-word status when new sections are merged" {
+    setup_smart_merge
+    source "$TEST_TEMP_DIR/smart_merge.sh"
+
+    cat > "$TEST_TEMP_DIR/src.md" << 'EOF'
+## Existing Section
+Source content.
+
+## New Section
+New content.
+EOF
+
+    cat > "$TEST_TEMP_DIR/dst.md" << 'EOF'
+## Existing Section
+User content, kept as-is.
+EOF
+
+    result=$(process_context_file "$TEST_TEMP_DIR/src.md" "$TEST_TEMP_DIR/dst.md" "test.md")
+
+    [ "$result" = "merged" ]
+    grep -q "## New Section" "$TEST_TEMP_DIR/dst.md"
+
+    teardown_smart_merge
 }
 
 @test "setup: install_context uses process_context_file" {


### PR DESCRIPTION
`has_section` matched section titles with `grep -E`, so a title containing regex metacharacters like `Derive Awareness (Critical)` never matched its own literal text in the destination file. `merge_markdown_sections` read that as "section missing" and re-appended it on every `bin/setup` run, so some installed context files grew past 500KB with hundreds of duplicate copies of the same section. Switched to `grep -qFx` for a literal, whole-line match.

Added `dedupe_sections_in_place` so `bin/setup` collapses duplicates a prior run already wrote to disk, self-healing a corrupted install instead of requiring manual cleanup.

Fixed `info`/`warn`/`error`/`debug` to write to stderr instead of stdout. `process_context_file` captures its own return value through `$(...)`, and a `debug()` call mixed into that capture was silently corrupting the merge/dedupe status, falling through the caller's `case` statement and going uncounted. This affected the existing "merged" status too, not just the new "deduped" one.

## Test plan

- `bin/test` passes: 1341 unit tests, 12 integration tests
- `bin/lint` and `bin/fmt` are clean
- Verified against a real corrupted installation: `rust.md` (518KB, 238 duplicate copies of "Derive Awareness (Critical)") and `react.md` (903KB, 238 duplicate copies of "Accessibility Requirements (WCAG 2.1 AA)") both collapsed to their correct size after running `bin/setup`, and stayed stable across repeated runs
- Added regression tests for `has_section` with regex-metacharacter titles, idempotent repeated merges, `dedupe_sections_in_place` directly (including a 238-copy stress case), and `process_context_file` returning a clean status for both "deduped" and "merged" outcomes