### PR TITLE
Add name field to SKILL.md frontmatter

### DIFF
--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -1,4 +1,5 @@
 ---
+name: review-code
 description: Run specialized code review agents on code changes or pull requests
 argument-hint: [find|learn|pr|commit|branch|range|area]
 allowed-tools: Bash(~/.claude/skills/review-code/scripts/*:*), Read(~/.claude/**), Write(~/.claude/skills/review-code/learnings/*), Edit(~/.claude/skills/review-code/learnings/*)


### PR DESCRIPTION
## Why

The `/review-code` skill shows up with no description in PostHog Desktop's skill picker. Desktop's frontmatter parser treats `name` as required — when it's absent, parsing returns `null` and the skill falls back to its directory name with an empty description. `review-code` was the only installed skill without a `name` field, so its description was never read even though it's present.

Claude Code itself uses the directory name, which is why the description shows correctly in the CLI. The [Agent Skills spec](https://code.claude.com/docs/en/skills) also lists `name` as a required frontmatter field, so adding it is correct regardless of the desktop bug.

## What

Adds `name: review-code` to the frontmatter of `skills/review-code/SKILL.md`.

Verified with `bin/setup` (installed copy updated), `bin/fmt`, and `bin/test` (all 12 integration tests pass).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*