### PR TITLE
Fix eval harness on macOS and current claude CLI

### DIFF
--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -256,16 +256,13 @@ run_crafted_benchmark() {
     # Detached HEAD: restore by commit SHA instead of branch name
     [[ -n "${original_ref}" ]] || original_ref=$(git -C "${TARGET_REPO}" rev-parse HEAD)
 
-    # Restore the original checkout and delete the temp branch when this function
-    # returns. The handler clears the trap because RETURN traps persist after the
-    # function that set them returns, and would otherwise re-fire on later
-    # function returns where these locals no longer exist.
+    # Restore the original checkout and delete the temp branch. Called explicitly
+    # at every exit path; a RETURN trap is unreliable here (bash fires it after
+    # the function's locals are out of scope, aborting under set -u).
     cleanup_crafted_benchmark() {
-        trap - RETURN
         git -C "${TARGET_REPO}" checkout "${original_ref}" --quiet 2> /dev/null || true
         git -C "${TARGET_REPO}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
     }
-    trap cleanup_crafted_benchmark RETURN
 
     echo "  Applying patch to ${tmp_branch}…"
 
@@ -282,6 +279,7 @@ run_crafted_benchmark() {
         echo "  Applying base patch…"
         if ! git -C "${TARGET_REPO}" apply "${base_patch}"; then
             echo "  Error: failed to apply base patch for ${id}" >&2
+            cleanup_crafted_benchmark
             return 1
         fi
         git -C "${TARGET_REPO}" add -A
@@ -292,6 +290,7 @@ run_crafted_benchmark() {
         echo "  Warning: patch does not apply cleanly, attempting forced apply" >&2
         if ! git -C "${TARGET_REPO}" apply "${patch}" --allow-empty 2> /dev/null; then
             echo "  Error: failed to apply patch for ${id}" >&2
+            cleanup_crafted_benchmark
             return 1
         fi
     else
@@ -315,6 +314,12 @@ run_crafted_benchmark() {
     [[ -n "${org}" ]] || org="unknown"
     [[ -n "${repo}" ]] || repo="unknown"
 
+    # A review file left over from a previous run would make the skill prompt
+    # to overwrite, which stalls a non-interactive claude -p run. Eval branch
+    # review files are eval-owned, so removing them is safe.
+    rm -f "${SKILL_REVIEWS_DIR}/${org}/${repo}/${tmp_branch}.md" \
+        "${SKILL_REVIEWS_DIR}/${org}/${repo}/branch-${tmp_branch}.md"
+
     # Run the review via claude -p from inside the target repo, so the skill's
     # git commands operate on the checkout that has the benchmark branch.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
@@ -331,25 +336,30 @@ run_crafted_benchmark() {
         echo "  Warning: claude exited with code ${claude_exit}" >&2
     fi
 
-    # Locate the review file and copy it to results
-    local review_file="${SKILL_REVIEWS_DIR}/${org}/${repo}/branch-${tmp_branch}.md"
-    if [[ -f "${review_file}" ]]; then
+    # Locate the review file and copy it to results. Branch reviews are saved
+    # as <branch>.md; older skill versions used branch-<branch>.md.
+    local review_file=""
+    local candidate
+    for candidate in \
+        "${SKILL_REVIEWS_DIR}/${org}/${repo}/${tmp_branch}.md" \
+        "${SKILL_REVIEWS_DIR}/${org}/${repo}/branch-${tmp_branch}.md"; do
+        if [[ -f "${candidate}" ]]; then
+            review_file="${candidate}"
+            break
+        fi
+    done
+    if [[ -z "${review_file}" ]]; then
+        review_file=$(find "${SKILL_REVIEWS_DIR}" -name "*${tmp_branch}*" -type f 2> /dev/null | head -1)
+    fi
+
+    if [[ -n "${review_file}" ]]; then
         cp "${review_file}" "${result_dir}/review.md"
         echo "  Review saved to ${result_dir}/review.md"
     else
-        echo "  Warning: review file not found at ${review_file}" >&2
-        echo "  Checking for any review matching this branch…" >&2
-        local found
-        found=$(find "${SKILL_REVIEWS_DIR}" -name "*${tmp_branch}*" -type f 2> /dev/null | head -1)
-        if [[ -n "${found}" ]]; then
-            cp "${found}" "${result_dir}/review.md"
-            echo "  Found review at ${found}"
-        else
-            echo "  No review output found" >&2
-        fi
+        echo "  Warning: no review output found for ${tmp_branch}" >&2
     fi
 
-    # Cleanup happens automatically via the RETURN trap
+    cleanup_crafted_benchmark
     echo "  Done with ${id}"
 }
 

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -16,18 +16,33 @@
 # Crafted benchmarks: applies patch to a temporary branch, reviews via `claude -p`
 # Real-world PR benchmarks: reviews via PR URL directly (no patch needed)
 # Results are saved to evals/results/.
+#
+# Environment:
+#   EVAL_TARGET_REPO   Git checkout that crafted benchmark patches are applied in
+#                      (default: this repo). Set it to a separate clone or worktree
+#                      to keep benchmark branches out of the checkout you work in.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 EVALS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${EVALS_DIR}/.." && pwd)"
+TARGET_REPO="${EVAL_TARGET_REPO:-${REPO_ROOT}}"
 REGISTRY="${EVALS_DIR}/benchmarks/registry.json"
 RESULTS_DIR="${EVALS_DIR}/results"
 SKILL_REVIEWS_DIR="${HOME}/.claude/skills/review-code/reviews"
 BASELINE_PROMPT="${EVALS_DIR}/prompts/baseline.md"
 
 source "${SCRIPT_DIR}/helpers/eval-helpers.sh"
+
+# Build the claude -p prompt that runs the review-code skill.
+# `claude -p` does not register personal skills as slash commands (verified on
+# claude 2.1.219: both `/review-code` and the Skill tool report unknown), so
+# instruct the model to load the installed skill file and follow it directly.
+# Args: $1 = the /review-code arguments (e.g. "my-branch --force")
+skill_prompt() {
+    echo "Read ${HOME}/.claude/skills/review-code/SKILL.md and follow its instructions exactly, as if the user ran: /review-code $1"
+}
 
 # Generate a unique run ID from timestamp + short git SHA
 generate_run_id() {
@@ -185,7 +200,7 @@ run_pr_benchmark() {
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
     echo "  Budget: \$${budget}"
     local claude_exit=0
-    env -u CLAUDECODE "${frozen_env[@]}" claude -p "/review-code ${pr_url} --force" \
+    env -u CLAUDECODE "${frozen_env[@]}" claude -p "$(skill_prompt "${pr_url} --force")" \
         --dangerously-skip-permissions \
         --max-budget-usd "${budget}" \
         > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
@@ -230,71 +245,87 @@ run_crafted_benchmark() {
     fi
 
     # Fail fast if working tree is dirty — patching on a dirty tree risks losing work
-    if [[ -n "$(git -C "${REPO_ROOT}" status --porcelain 2> /dev/null)" ]]; then
+    if [[ -n "$(git -C "${TARGET_REPO}" status --porcelain 2> /dev/null)" ]]; then
         echo "Error: working tree is dirty; commit or stash changes before running crafted benchmarks" >&2
         return 1
     fi
 
     local tmp_branch="eval-tmp-${id}"
-    local original_branch
-    original_branch=$(git -C "${REPO_ROOT}" branch --show-current 2> /dev/null || echo "HEAD")
+    local original_ref
+    original_ref=$(git -C "${TARGET_REPO}" branch --show-current 2> /dev/null)
+    # Detached HEAD: restore by commit SHA instead of branch name
+    [[ -n "${original_ref}" ]] || original_ref=$(git -C "${TARGET_REPO}" rev-parse HEAD)
 
-    # Ensure we restore the original branch and clean up the temp branch on any exit
+    # Restore the original checkout and delete the temp branch when this function
+    # returns. The handler clears the trap because RETURN traps persist after the
+    # function that set them returns, and would otherwise re-fire on later
+    # function returns where these locals no longer exist.
     cleanup_crafted_benchmark() {
-        git -C "${REPO_ROOT}" checkout "${original_branch}" --quiet 2> /dev/null || true
-        git -C "${REPO_ROOT}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
+        trap - RETURN
+        git -C "${TARGET_REPO}" checkout "${original_ref}" --quiet 2> /dev/null || true
+        git -C "${TARGET_REPO}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
     }
     trap cleanup_crafted_benchmark RETURN
 
     echo "  Applying patch to ${tmp_branch}…"
 
     # Create a temporary branch from HEAD, apply the patch, and commit
-    git -C "${REPO_ROOT}" checkout -b "${tmp_branch}" --quiet 2> /dev/null || {
+    git -C "${TARGET_REPO}" checkout -b "${tmp_branch}" --quiet 2> /dev/null || {
         # Branch may already exist from a previous failed run; clean it up
-        git -C "${REPO_ROOT}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
-        git -C "${REPO_ROOT}" checkout -b "${tmp_branch}" --quiet
+        git -C "${TARGET_REPO}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
+        git -C "${TARGET_REPO}" checkout -b "${tmp_branch}" --quiet
     }
 
     # Apply base.patch first if it exists (creates files needed by diff.patch)
     local base_patch="${bench_dir}/base.patch"
     if [[ -f "${base_patch}" ]]; then
         echo "  Applying base patch…"
-        if ! git -C "${REPO_ROOT}" apply "${base_patch}"; then
+        if ! git -C "${TARGET_REPO}" apply "${base_patch}"; then
             echo "  Error: failed to apply base patch for ${id}" >&2
             return 1
         fi
-        git -C "${REPO_ROOT}" add -A
-        git -C "${REPO_ROOT}" commit -m "eval: base state for ${id}" --quiet --no-gpg-sign
+        git -C "${TARGET_REPO}" add -A
+        git -C "${TARGET_REPO}" commit -m "eval: base state for ${id}" --quiet --no-gpg-sign
     fi
 
-    if ! git -C "${REPO_ROOT}" apply --check "${patch}" 2> /dev/null; then
+    if ! git -C "${TARGET_REPO}" apply --check "${patch}" 2> /dev/null; then
         echo "  Warning: patch does not apply cleanly, attempting forced apply" >&2
-        if ! git -C "${REPO_ROOT}" apply "${patch}" --allow-empty 2> /dev/null; then
+        if ! git -C "${TARGET_REPO}" apply "${patch}" --allow-empty 2> /dev/null; then
             echo "  Error: failed to apply patch for ${id}" >&2
             return 1
         fi
     else
-        git -C "${REPO_ROOT}" apply "${patch}"
+        git -C "${TARGET_REPO}" apply "${patch}"
     fi
 
-    git -C "${REPO_ROOT}" add -A
-    git -C "${REPO_ROOT}" commit -m "eval: apply benchmark ${id}" --quiet --no-gpg-sign
+    git -C "${TARGET_REPO}" add -A
+    git -C "${TARGET_REPO}" commit -m "eval: apply benchmark ${id}" --quiet --no-gpg-sign
 
     echo "  Running review on ${tmp_branch}…"
 
-    # Determine the org/repo for locating the review output
-    local org repo
-    org=$(git -C "${REPO_ROOT}" remote get-url origin 2> /dev/null | sed -E 's#.*[:/]([^/]+)/([^/]+?)(\.git)?$#\1#' || echo "unknown")
-    repo=$(git -C "${REPO_ROOT}" remote get-url origin 2> /dev/null | sed -E 's#.*[:/]([^/]+)/([^/]+?)(\.git)?$#\2#' || echo "unknown")
+    # Determine the org/repo for locating the review output. Plain string
+    # slicing instead of sed: BSD sed rejects the lazy quantifier a trailing
+    # optional .git group would need.
+    local origin_url org repo
+    origin_url=$(git -C "${TARGET_REPO}" remote get-url origin 2> /dev/null || echo "")
+    origin_url="${origin_url%.git}"
+    repo="${origin_url##*/}"
+    org="${origin_url%/*}"
+    org="${org##*[:/]}"
+    [[ -n "${org}" ]] || org="unknown"
+    [[ -n "${repo}" ]] || repo="unknown"
 
-    # Run the review via claude -p.
+    # Run the review via claude -p from inside the target repo, so the skill's
+    # git commands operate on the checkout that has the benchmark branch.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
     echo "  Budget: \$${budget}"
     local claude_exit=0
-    env -u CLAUDECODE claude -p "/review-code ${tmp_branch} --force" \
-        --dangerously-skip-permissions \
-        --max-budget-usd "${budget}" \
-        > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
+    (
+        cd "${TARGET_REPO}" \
+            && env -u CLAUDECODE claude -p "$(skill_prompt "${tmp_branch} --force")" \
+                --dangerously-skip-permissions \
+                --max-budget-usd "${budget}"
+    ) > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
 
     if [[ ${claude_exit} -ne 0 ]]; then
         echo "  Warning: claude exited with code ${claude_exit}" >&2

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -21,6 +21,8 @@
 #   EVAL_TARGET_REPO   Git checkout that crafted benchmark patches are applied in
 #                      (default: this repo). Set it to a separate clone or worktree
 #                      to keep benchmark branches out of the checkout you work in.
+#   EVAL_BUDGET_USD    Per-benchmark budget cap, overriding each benchmark's
+#                      metadata (default: metadata budget_usd, else 5).
 
 set -euo pipefail
 
@@ -142,9 +144,10 @@ run_benchmark() {
     local result_dir="${RESULTS_DIR}/${run_id}/${id}"
     mkdir -p "${result_dir}"
 
-    # Per-benchmark budget from metadata, defaulting to $5
+    # Per-benchmark budget: env override, else metadata, else $5
     local budget
     budget=$(jq -r '.budget_usd // 5' "${bench_dir}/metadata.json" 2> /dev/null)
+    budget="${EVAL_BUDGET_USD:-${budget}}"
 
     if [[ "${approach}" == "baseline" ]]; then
         run_baseline_benchmark "${id}" "${bench_dir}" "${result_dir}" "${budget}"

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -41,9 +41,14 @@ source "${SCRIPT_DIR}/helpers/eval-helpers.sh"
 # `claude -p` does not register personal skills as slash commands (verified on
 # claude 2.1.219: both `/review-code` and the Skill tool report unknown), so
 # instruct the model to load the installed skill file and follow it directly.
+# Print mode cannot answer AskUserQuestion prompts, so pin the answer the
+# skill's current-branch disambiguation would ask for: review the branch
+# against its base, never a substitute range (a range changes the review
+# file's name and the harness then can't find the output).
 # Args: $1 = the /review-code arguments (e.g. "my-branch --force")
 skill_prompt() {
-    echo "Read ${HOME}/.claude/skills/review-code/SKILL.md and follow its instructions exactly, as if the user ran: /review-code $1"
+    echo "Read ${HOME}/.claude/skills/review-code/SKILL.md and follow its instructions exactly, as if the user ran: /review-code $1
+This session cannot answer interactive prompts. If the skill asks what to review (uncommitted vs branch changes), review the branch changes vs the base branch, re-initializing the session with the branch argument if needed."
 }
 
 # Generate a unique run ID from timestamp + short git SHA
@@ -327,6 +332,7 @@ run_crafted_benchmark() {
     # git commands operate on the checkout that has the benchmark branch.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
     echo "  Budget: \$${budget}"
+    touch "${result_dir}/.start"
     local claude_exit=0
     (
         cd "${TARGET_REPO}" \
@@ -340,7 +346,10 @@ run_crafted_benchmark() {
     fi
 
     # Locate the review file and copy it to results. Branch reviews are saved
-    # as <branch>.md; older skill versions used branch-<branch>.md.
+    # as <branch>.md; older skill versions used branch-<branch>.md. As a last
+    # resort take the newest review in the repo's directory written since this
+    # benchmark started (the skill may have reviewed an equivalent range and
+    # saved under a range-based name).
     local review_file=""
     local candidate
     for candidate in \
@@ -353,6 +362,11 @@ run_crafted_benchmark() {
     done
     if [[ -z "${review_file}" ]]; then
         review_file=$(find "${SKILL_REVIEWS_DIR}" -name "*${tmp_branch}*" -type f 2> /dev/null | head -1)
+    fi
+    if [[ -z "${review_file}" ]]; then
+        review_file=$(find "${SKILL_REVIEWS_DIR}/${org}/${repo}" -name '*.md' -type f \
+            -newer "${result_dir}/.start" 2> /dev/null | head -1)
+        [[ -z "${review_file}" ]] || echo "  Note: matched review by timestamp: ${review_file}" >&2
     fi
 
     if [[ -n "${review_file}" ]]; then

--- a/evals/scripts/score-eval.sh
+++ b/evals/scripts/score-eval.sh
@@ -205,24 +205,29 @@ Rate each dimension from 1 (poor) to 5 (excellent):
 - **signal_to_noise**: What is the ratio of valuable, real findings to filler, noise, or false positives? High signal = mostly real issues.
 - **overall_quality**: Overall quality of the review as a professional code review.
 
-Also provide brief notes explaining your scoring rationale.
+Respond with only a JSON object, no code fence and no other text:
+{"actionability": N, "specificity": N, "signal_to_noise": N, "overall_quality": N, "notes": "brief rationale"}
 PROMPT
     )
 
     local judge_result
-    judge_result=$(claude -p "${prompt}" \
+    judge_result=$(env -u CLAUDECODE claude -p "${prompt}" \
         --output-format json \
         --max-budget-usd 0.50 \
-        2> /dev/null || echo '{"actionability":0,"specificity":0,"signal_to_noise":0,"overall_quality":0,"notes":"LLM judge failed"}')
+        2> /dev/null || echo '{"result":""}')
 
-    # Extract just the fields we need (claude output may have wrapper)
-    echo "${judge_result}" | jq '{
-        actionability: (.actionability // 0),
-        specificity: (.specificity // 0),
-        signal_to_noise: (.signal_to_noise // 0),
-        overall_quality: (.overall_quality // 0),
-        notes: (.notes // "")
-    }'
+    # --output-format json wraps the model's text in an envelope; the scores
+    # are in the .result string (possibly fenced despite instructions).
+    echo "${judge_result}" | jq -r '.result // ""' \
+        | sed 's/^```json$//; s/^```$//' \
+        | jq '{
+            actionability: (.actionability // 0),
+            specificity: (.specificity // 0),
+            signal_to_noise: (.signal_to_noise // 0),
+            overall_quality: (.overall_quality // 0),
+            notes: (.notes // "")
+        }' 2> /dev/null \
+        || echo '{"actionability":0,"specificity":0,"signal_to_noise":0,"overall_quality":0,"notes":"LLM judge failed"}'
 }
 
 # Compute composite score from pattern matching and LLM judge results

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -103,12 +103,13 @@ main() {
         fi
 
         # Detect file:line reference patterns
-        # Pattern 1: #### `path/to/file.py:123`
-        if [[ "${line}" =~ ^\#{3,4}[[:space:]]+\`([^:]+):([0-9]+)\` ]]; then
+        # Pattern 1: #### `path/to/file.py:123`, with optional "N. " numbering
+        # as written by branch-mode review documents: ### 1. `path/to/file.py:123`
+        if [[ "${line}" =~ ^\#{3,4}[[:space:]]+([0-9]+\.[[:space:]]+)?\`([^:]+):([0-9]+)\` ]]; then
             flush_pending_finding
 
-            finding_file="${BASH_REMATCH[1]}"
-            finding_line="${BASH_REMATCH[2]}"
+            finding_file="${BASH_REMATCH[2]}"
+            finding_line="${BASH_REMATCH[3]}"
             finding_description=""
             current_confidence=""
             in_finding=true


### PR DESCRIPTION
The eval harness (`evals/scripts/run-eval.sh`, `score-eval.sh`) had rotted against the current environment; every crafted benchmark run failed before producing a scoreable result. This fixes the full path from run to score:

**run-eval.sh**
- BSD sed rejects the lazy quantifier in the org/repo extraction regex; replaced with plain string slicing.
- The `RETURN` trap for benchmark cleanup fired again after the function's locals left scope, aborting the run under `set -u`. Cleanup is now called explicitly at every exit path.
- Detached-HEAD checkouts are restored by SHA instead of an empty branch name.
- `claude -p` no longer registers personal skills as slash commands (verified on 2.1.219: both `/review-code` and the Skill tool report unknown), so the prompt now tells the model to read the installed SKILL.md and follow it. It also pins the answer to the current-branch disambiguation, which print mode can't answer interactively.
- New `EVAL_TARGET_REPO` env var runs crafted benchmarks against a separate checkout, keeping eval branches out of the working repo, and `EVAL_BUDGET_USD` overrides the per-benchmark budget (the $5 default kills runs mid-review at current pricing).
- Leftover eval review files are removed before each run so the skill's overwrite prompt can't stall a non-interactive session, and the review file is located by its current name (`<branch>.md`), the legacy name, then newest-since-start as a fallback.

**score-eval.sh / parse-review-findings.sh**
- The findings parser dropped every finding in branch-mode reviews: they number their headers (`### 1. \`path:line\``) and the parser only matched unnumbered ones, so recall always scored zero. The header pattern now accepts optional numbering.
- The LLM judge always returned zeros: the prompt never asked for JSON and the `--output-format json` envelope was never unwrapped. The judge now gets an explicit response schema and the scores are extracted from the envelope's `.result`.

With these fixes a full crafted-category run completes end-to-end and produces non-degenerate scores.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*