### PR TITLE
Run evals without a budget cap by default

### DIFF
--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -22,7 +22,9 @@
 #                      (default: this repo). Set it to a separate clone or worktree
 #                      to keep benchmark branches out of the checkout you work in.
 #   EVAL_BUDGET_USD    Per-benchmark budget cap, overriding each benchmark's
-#                      metadata (default: metadata budget_usd, else 5).
+#                      metadata (default: no cap). A benchmark killed mid-review
+#                      by a cap produces an unscoreable partial result, so caps
+#                      are opt-in.
 
 set -euo pipefail
 
@@ -106,7 +108,7 @@ run_baseline_benchmark() {
     local id="$1"
     local bench_dir="$2"
     local result_dir="$3"
-    local budget="${4:-5}"
+    local budget="${4:-}"
 
     local diff_content
     diff_content=$(read_benchmark_diff "${bench_dir}") || return 1
@@ -115,12 +117,15 @@ run_baseline_benchmark() {
     prompt=$(build_baseline_prompt "${bench_dir}" "${diff_content}")
 
     echo "  Running baseline review (bare prompt)..."
-    echo "  Budget: \$${budget}"
+    echo "  Budget: ${budget:+\$}${budget:-none}"
+
+    local budget_args=()
+    [[ -z "${budget}" ]] || budget_args=(--max-budget-usd "${budget}")
 
     local claude_exit=0
     env -u CLAUDECODE claude -p "${prompt}" \
         --dangerously-skip-permissions \
-        --max-budget-usd "${budget}" \
+        "${budget_args[@]}" \
         > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
 
     if [[ ${claude_exit} -ne 0 ]]; then
@@ -149,10 +154,10 @@ run_benchmark() {
     local result_dir="${RESULTS_DIR}/${run_id}/${id}"
     mkdir -p "${result_dir}"
 
-    # Per-benchmark budget: env override, else metadata, else $5
-    local budget
-    budget=$(jq -r '.budget_usd // 5' "${bench_dir}/metadata.json" 2> /dev/null)
-    budget="${EVAL_BUDGET_USD:-${budget}}"
+    # Budget cap: EVAL_BUDGET_USD or none. Benchmark metadata budget_usd is
+    # ignored; a cap that kills a run mid-review leaves a partial result that
+    # scores as a false regression.
+    local budget="${EVAL_BUDGET_USD:-}"
 
     if [[ "${approach}" == "baseline" ]]; then
         run_baseline_benchmark "${id}" "${bench_dir}" "${result_dir}" "${budget}"
@@ -177,7 +182,7 @@ run_pr_benchmark() {
     local bench_dir="$2"
     local result_dir="$3"
     local pr_url="$4"
-    local budget="${5:-5}"
+    local budget="${5:-}"
 
     # Extract org/repo/number from the PR URL (lowercase for file lookup)
     local org repo pr_number
@@ -206,11 +211,13 @@ run_pr_benchmark() {
 
     # Run the review via claude -p using the PR URL.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
-    echo "  Budget: \$${budget}"
+    echo "  Budget: ${budget:+\$}${budget:-none}"
+    local budget_args=()
+    [[ -z "${budget}" ]] || budget_args=(--max-budget-usd "${budget}")
     local claude_exit=0
     env -u CLAUDECODE "${frozen_env[@]}" claude -p "$(skill_prompt "${pr_url} --force")" \
         --dangerously-skip-permissions \
-        --max-budget-usd "${budget}" \
+        "${budget_args[@]}" \
         > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
 
     if [[ ${claude_exit} -ne 0 ]]; then
@@ -244,7 +251,7 @@ run_crafted_benchmark() {
     local id="$1"
     local bench_dir="$2"
     local result_dir="$3"
-    local budget="${4:-5}"
+    local budget="${4:-}"
 
     local patch="${bench_dir}/diff.patch"
     if [[ ! -f "${patch}" ]]; then
@@ -331,14 +338,16 @@ run_crafted_benchmark() {
     # Run the review via claude -p from inside the target repo, so the skill's
     # git commands operate on the checkout that has the benchmark branch.
     # Unset CLAUDECODE to allow running inside an existing Claude Code session.
-    echo "  Budget: \$${budget}"
+    echo "  Budget: ${budget:+\$}${budget:-none}"
+    local budget_args=()
+    [[ -z "${budget}" ]] || budget_args=(--max-budget-usd "${budget}")
     touch "${result_dir}/.start"
     local claude_exit=0
     (
         cd "${TARGET_REPO}" \
             && env -u CLAUDECODE claude -p "$(skill_prompt "${tmp_branch} --force")" \
                 --dangerously-skip-permissions \
-                --max-budget-usd "${budget}"
+                "${budget_args[@]}"
     ) > "${result_dir}/claude-output.txt" 2>&1 || claude_exit=$?
 
     if [[ ${claude_exit} -ne 0 ]]; then

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -89,6 +89,16 @@ main() {
     local finding_line=""
     local finding_description=""
 
+    # H3/H4 finding header with optional numbering and optional backticks
+    # around the path:line token (see Pattern 1 below). Kept in variables
+    # because a backtick inside a bracket expression defeats inline =~.
+    local finding_header_re='^#{3,4}[[:space:]]+([0-9]+\.[[:space:]]+)?`?([^:`]+):([0-9]+)`?'
+    # Numbered prose-title finding header: ### 2. The allowlist does not hold
+    local prose_header_re='^#{3,4}[[:space:]]+[0-9]+\.[[:space:]]+(.+)$'
+    # Standalone location line under a prose-titled finding: `path/file.sh:14`
+    # or `path/file.sh:73-74`
+    local standalone_loc_re='^`([^:`]+):([0-9]+)(-[0-9]+)?`[[:space:]]*$'
+
     while IFS= read -r line || [[ -n "${line}" ]]; do
         # Detect agent section headers (## Security Review, ## Performance Review, etc.)
         if [[ "${line}" =~ ^##[[:space:]]+(Security|Performance|Correctness|Maintainability|Testing|Compatibility|Architecture|Frontend)[[:space:]]+Review ]]; then
@@ -103,9 +113,10 @@ main() {
         fi
 
         # Detect file:line reference patterns
-        # Pattern 1: #### `path/to/file.py:123`, with optional "N. " numbering
-        # as written by branch-mode review documents: ### 1. `path/to/file.py:123`
-        if [[ "${line}" =~ ^\#{3,4}[[:space:]]+([0-9]+\.[[:space:]]+)?\`([^:]+):([0-9]+)\` ]]; then
+        # Pattern 1: #### `path/to/file.py:123`. Reviews vary the header shape,
+        # so accept optional "N. " numbering (### 1. `path:123`) and headers
+        # without backticks (#### path/to/file.py:123).
+        if [[ "${line}" =~ ${finding_header_re} ]]; then
             flush_pending_finding
 
             finding_file="${BASH_REMATCH[2]}"
@@ -113,6 +124,29 @@ main() {
             finding_description=""
             current_confidence=""
             in_finding=true
+            continue
+        fi
+
+        # Pattern 1b: numbered prose-title header (### 2. The allowlist does
+        # not hold). The location arrives later, either inline in the body or
+        # as a standalone `path:line` line (Pattern 1c).
+        if [[ "${line}" =~ ${prose_header_re} ]]; then
+            flush_pending_finding
+
+            finding_file=""
+            finding_line=""
+            finding_description="${BASH_REMATCH[1]}"
+            current_confidence=""
+            in_finding=true
+            continue
+        fi
+
+        # Pattern 1c: standalone location line for the current finding. For a
+        # range, keep the starting line.
+        if [[ "${in_finding}" == true ]] && [[ -z "${finding_file}" ]] \
+            && [[ "${line}" =~ ${standalone_loc_re} ]]; then
+            finding_file="${BASH_REMATCH[1]}"
+            finding_line="${BASH_REMATCH[2]}"
             continue
         fi
 


### PR DESCRIPTION
Both PostHog PR benchmark runs so far hit their `--max-budget-usd` cap mid-review; one died before writing any review at all, which scores as a false regression. An unexpectedly expensive run is a known cost; a silently truncated one corrupts the measurement.

Evals now run uncapped by default. `EVAL_BUDGET_USD` remains as an opt-in cap, and the per-benchmark `budget_usd` metadata is ignored.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*