### PR TITLE
Add readability score to eval reports

### DIFF
--- a/evals/scripts/report.sh
+++ b/evals/scripts/report.sh
@@ -38,9 +38,9 @@ color_score() {
 # Args: stdin = JSONL lines to display
 show_table() {
     # Print header
-    printf "${BOLD}%-22s %-10s %-20s %-10s %-8s %-8s %-8s %-10s${NC}\n" \
-        "Run" "Approach" "Benchmark" "SHA" "Recall" "Precis." "LLM" "Composite"
-    printf "%-22s %-10s %-20s %-10s %-8s %-8s %-8s %-10s\n" \
+    printf "${BOLD}%-22s %-10s %-20s %-10s %-8s %-8s %-8s %-8s %-10s${NC}\n" \
+        "Run" "Approach" "Benchmark" "SHA" "Recall" "Precis." "LLM" "Read." "Composite"
+    printf "%-22s %-10s %-20s %-10s %-8s %-8s %-8s %-8s %-10s\n" \
         "$(printf '─%.0s' {1..22})" \
         "$(printf '─%.0s' {1..10})" \
         "$(printf '─%.0s' {1..20})" \
@@ -48,10 +48,11 @@ show_table() {
         "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..8})" \
+        "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..10})"
 
     while IFS= read -r line; do
-        local run_id approach benchmark sha recall precision llm composite
+        local run_id approach benchmark sha recall precision llm readability composite
         run_id=$(echo "${line}" | jq -r '.run_id')
         approach=$(echo "${line}" | jq -r '.approach // "skill"')
         benchmark=$(echo "${line}" | jq -r '.benchmark_id')
@@ -59,14 +60,15 @@ show_table() {
         recall=$(echo "${line}" | jq -r '.pattern_matching.recall.weighted')
         precision=$(echo "${line}" | jq -r '.pattern_matching.precision.ratio')
         llm=$(echo "${line}" | jq -r '.llm_judge.overall_quality')
+        readability=$(echo "${line}" | jq -r '.readability.mean // "-"')
         composite=$(echo "${line}" | jq -r '.composite_score')
 
         # Truncate long fields
         run_id="${run_id:0:22}"
         benchmark="${benchmark:0:20}"
 
-        printf "%-22s %-10s %-20s %-10s %-8s %-8s %-8s " \
-            "${run_id}" "${approach}" "${benchmark}" "${sha}" "${recall}" "${precision}" "${llm}"
+        printf "%-22s %-10s %-20s %-10s %-8s %-8s %-8s %-8s " \
+            "${run_id}" "${approach}" "${benchmark}" "${sha}" "${recall}" "${precision}" "${llm}" "${readability}"
         color_score "${composite}"
     done
 }
@@ -88,15 +90,25 @@ show_aggregate() {
     local total_composite=0
     local total_recall=0
     local total_precision=0
+    local total_readability=0
+    local readability_count=0
 
     while IFS= read -r line; do
-        local c r p
+        local c r p rd
         c=$(echo "${line}" | jq -r '.composite_score')
         r=$(echo "${line}" | jq -r '.pattern_matching.recall.weighted')
         p=$(echo "${line}" | jq -r '.pattern_matching.precision.ratio')
         total_composite=$(echo "${total_composite} + ${c}" | bc)
         total_recall=$(echo "${total_recall} + ${r}" | bc)
         total_precision=$(echo "${total_precision} + ${p}" | bc)
+        # Readability landed later than the other scores; average only the
+        # lines that have a scored value (count > 0), so old history and
+        # --no-llm runs don't drag the average down.
+        rd=$(echo "${line}" | jq -r 'if (.readability.mean | type) == "number" and (.readability.count // 0) > 0 then .readability.mean else empty end')
+        if [[ -n "${rd}" ]]; then
+            total_readability=$(echo "${total_readability} + ${rd}" | bc)
+            readability_count=$((readability_count + 1))
+        fi
     done <<< "${lines}"
 
     local avg_composite avg_recall avg_precision
@@ -104,11 +116,17 @@ show_aggregate() {
     avg_recall=$(echo "scale=2; ${total_recall} / ${count}" | bc)
     avg_precision=$(echo "scale=2; ${total_precision} / ${count}" | bc)
 
+    local avg_readability="-"
+    if [[ ${readability_count} -gt 0 ]]; then
+        avg_readability=$(echo "scale=2; ${total_readability} / ${readability_count}" | bc)
+    fi
+
     echo ""
     echo -e "${BOLD}Aggregate (${count} scores):${NC}"
-    printf "  Avg Recall:    %s\n" "${avg_recall}"
-    printf "  Avg Precision: %s\n" "${avg_precision}"
-    printf "  Avg Composite: "
+    printf "  Avg Recall:      %s\n" "${avg_recall}"
+    printf "  Avg Precision:   %s\n" "${avg_precision}"
+    printf "  Avg Readability: %s\n" "${avg_readability}"
+    printf "  Avg Composite:   "
     color_score "${avg_composite}"
 }
 
@@ -128,11 +146,12 @@ compare_approaches() {
     # Show per-benchmark comparison
     echo -e "${BOLD}Per-Benchmark Comparison (skill vs baseline):${NC}"
     echo ""
-    printf "${BOLD}%-25s %-10s %-8s %-8s %-10s${NC}\n" \
-        "Benchmark" "Approach" "Recall" "Precis." "Composite"
-    printf "%-25s %-10s %-8s %-8s %-10s\n" \
+    printf "${BOLD}%-25s %-10s %-8s %-8s %-8s %-10s${NC}\n" \
+        "Benchmark" "Approach" "Recall" "Precis." "Read." "Composite"
+    printf "%-25s %-10s %-8s %-8s %-8s %-10s\n" \
         "$(printf '─%.0s' {1..25})" \
         "$(printf '─%.0s' {1..10})" \
+        "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..8})" \
         "$(printf '─%.0s' {1..10})"
@@ -150,20 +169,22 @@ compare_approaches() {
         baseline_line=$(echo "${baseline_data}" | jq -c "select(.benchmark_id == \"${bid}\")" | tail -1)
 
         if [[ -n "${skill_line}" ]]; then
-            local s_recall s_precision s_composite
+            local s_recall s_precision s_readability s_composite
             s_recall=$(echo "${skill_line}" | jq -r '.pattern_matching.recall.weighted')
             s_precision=$(echo "${skill_line}" | jq -r '.pattern_matching.precision.ratio')
+            s_readability=$(echo "${skill_line}" | jq -r '.readability.mean // "-"')
             s_composite=$(echo "${skill_line}" | jq -r '.composite_score')
-            printf "%-25s %-10s %-8s %-8s " "${bid:0:25}" "skill" "${s_recall}" "${s_precision}"
+            printf "%-25s %-10s %-8s %-8s %-8s " "${bid:0:25}" "skill" "${s_recall}" "${s_precision}" "${s_readability}"
             color_score "${s_composite}"
         fi
 
         if [[ -n "${baseline_line}" ]]; then
-            local b_recall b_precision b_composite
+            local b_recall b_precision b_readability b_composite
             b_recall=$(echo "${baseline_line}" | jq -r '.pattern_matching.recall.weighted')
             b_precision=$(echo "${baseline_line}" | jq -r '.pattern_matching.precision.ratio')
+            b_readability=$(echo "${baseline_line}" | jq -r '.readability.mean // "-"')
             b_composite=$(echo "${baseline_line}" | jq -r '.composite_score')
-            printf "%-25s %-10s %-8s %-8s " "" "baseline" "${b_recall}" "${b_precision}"
+            printf "%-25s %-10s %-8s %-8s %-8s " "" "baseline" "${b_recall}" "${b_precision}" "${b_readability}"
             color_score "${b_composite}"
         fi
 
@@ -175,7 +196,7 @@ compare_approaches() {
             if (($(echo "${delta} > 0" | bc -l))); then
                 sign="+"
             fi
-            printf "%-25s %-10s %-8s %-8s " "" "delta" "" ""
+            printf "%-25s %-10s %-8s %-8s %-8s " "" "delta" "" "" ""
             if (($(echo "${delta} >= 0" | bc -l))); then
                 echo -e "${GREEN}${sign}${delta}${NC}"
             else
@@ -202,9 +223,10 @@ compare_approaches() {
         fi
 
         local count=0 total_recall=0 total_precision=0 total_composite=0
+        local total_readability=0 readability_count=0
         while IFS= read -r line; do
             [[ -z "${line}" ]] && continue
-            local r p c
+            local r p c rd
             r=$(echo "${line}" | jq -r '.pattern_matching.recall.weighted')
             p=$(echo "${line}" | jq -r '.pattern_matching.precision.ratio')
             c=$(echo "${line}" | jq -r '.composite_score')
@@ -212,6 +234,11 @@ compare_approaches() {
             total_precision=$(echo "${total_precision} + ${p}" | bc)
             total_composite=$(echo "${total_composite} + ${c}" | bc)
             count=$((count + 1))
+            rd=$(echo "${line}" | jq -r 'if (.readability.mean | type) == "number" and (.readability.count // 0) > 0 then .readability.mean else empty end')
+            if [[ -n "${rd}" ]]; then
+                total_readability=$(echo "${total_readability} + ${rd}" | bc)
+                readability_count=$((readability_count + 1))
+            fi
         done <<< "${data}"
 
         if [[ ${count} -gt 0 ]]; then
@@ -220,10 +247,16 @@ compare_approaches() {
             avg_precision=$(echo "scale=2; ${total_precision} / ${count}" | bc)
             avg_composite=$(echo "scale=2; ${total_composite} / ${count}" | bc)
 
+            local avg_readability="-"
+            if [[ ${readability_count} -gt 0 ]]; then
+                avg_readability=$(echo "scale=2; ${total_readability} / ${readability_count}" | bc)
+            fi
+
             echo -e "  ${BOLD}${a}${NC} (${count} scores):"
-            printf "    Avg Recall:    %s\n" "${avg_recall}"
-            printf "    Avg Precision: %s\n" "${avg_precision}"
-            printf "    Avg Composite: "
+            printf "    Avg Recall:      %s\n" "${avg_recall}"
+            printf "    Avg Precision:   %s\n" "${avg_precision}"
+            printf "    Avg Readability: %s\n" "${avg_readability}"
+            printf "    Avg Composite:   "
             color_score "${avg_composite}"
         fi
     done

--- a/evals/scripts/score-eval.sh
+++ b/evals/scripts/score-eval.sh
@@ -4,11 +4,12 @@
 # Usage:
 #   score-eval.sh <run-id>                 Score all benchmarks in a run
 #   score-eval.sh <run-id> <benchmark-id>  Score a specific benchmark
-#   score-eval.sh <run-id> --no-llm        Skip LLM judge (pattern matching only)
+#   score-eval.sh <run-id> --no-llm        Skip LLM judges (pattern matching only)
 #
-# Compares review output to answer keys using two tiers:
+# Compares review output to answer keys using three tiers:
 # 1. Automated pattern matching (recall, precision, severity accuracy)
 # 2. LLM-as-judge scoring (actionability, specificity, signal-to-noise)
+# 3. LLM readability judge (cold-reader score per finding, no answer key)
 #
 # Outputs per-benchmark score JSON and appends to evals/history/scores.jsonl.
 
@@ -230,6 +231,62 @@ PROMPT
         || echo '{"actionability":0,"specificity":0,"signal_to_noise":0,"overall_quality":0,"notes":"LLM judge failed"}'
 }
 
+# Tier 3: LLM readability judge. Cold-reads each finding body with no answer
+# key, no diff, and no code access, and scores whether a reader can tell what
+# breaks and what to do from the body alone.
+# Args: $1 = review file path
+# Outputs: JSON readability object on stdout
+score_readability() {
+    local review_file="$1"
+
+    local review_content
+    review_content=$(cat "${review_file}")
+
+    local prompt
+    prompt=$(
+        cat << PROMPT
+You are grading the readability of code review comments, not their correctness. Assume every claim is true. You have no access to the diff or the code.
+
+## The Review
+
+${review_content}
+
+## Task
+
+Identify each finding comment body in the review: prose that opens with a severity prefix such as blocking, suggestion, question, or nit, in any formatting. For each one, reading cold:
+
+- Can you state in one sentence what breaks (or what is being asked), from the body alone?
+- Can you state in one sentence what the author should do, from the body alone?
+- Does the first sentence carry the main point?
+- How many sentences did you have to re-read to parse?
+
+Score each finding from 1 to 5: 5 = both questions answerable, point in the first sentence, zero re-reads; 4 = both answerable, minor friction; 3 = answerable with effort, or the point is buried; 2 = one answer missing, or heavy re-reading; 1 = cannot tell what breaks or what to do.
+
+Respond with only a JSON object, no code fence and no other text:
+{"findings": [{"location": "file:line or a short label", "score": N, "notes": "what was unclear, if anything"}], "mean": N.N, "count": N}
+
+If the review contains no findings, respond: {"findings": [], "mean": 0, "count": 0}
+PROMPT
+    )
+
+    local judge_result
+    judge_result=$(env -u CLAUDECODE claude -p "${prompt}" \
+        --output-format json \
+        --max-budget-usd 0.50 \
+        2> /dev/null || echo '{"result":""}')
+
+    # --output-format json wraps the model's text in an envelope; the scores
+    # are in the .result string (possibly fenced despite instructions).
+    echo "${judge_result}" | jq -r '.result // ""' \
+        | sed 's/^```json$//; s/^```$//' \
+        | jq '{
+            findings: (.findings // []),
+            mean: (.mean // 0),
+            count: (.count // 0)
+        }' 2> /dev/null \
+        || echo '{"findings":[],"mean":0,"count":0,"notes":"readability judge failed"}'
+}
+
 # Compute composite score from pattern matching and LLM judge results
 # Args: $1 = pattern matching JSON, $2 = LLM judge JSON
 # Outputs: composite score (float) on stdout
@@ -278,9 +335,12 @@ score_benchmark() {
     pattern_score=$(score_pattern_matching "${review_file}" "${answer_key}")
 
     local llm_score='{"actionability":0,"specificity":0,"signal_to_noise":0,"overall_quality":0,"notes":"skipped"}'
+    local readability_score='{"findings":[],"mean":0,"count":0,"notes":"skipped"}'
     if [[ "${skip_llm}" != "true" ]]; then
         echo "  Running LLM judge…"
         llm_score=$(score_llm_judge "${review_file}" "${answer_key}")
+        echo "  Running readability judge…"
+        readability_score=$(score_readability "${review_file}")
     fi
 
     local composite
@@ -303,6 +363,7 @@ score_benchmark() {
         --arg timestamp "${timestamp}" \
         --argjson pattern "${pattern_score}" \
         --argjson llm "${llm_score}" \
+        --argjson readability "${readability_score}" \
         --arg composite "${composite}" \
         '{
             run_id: $run_id,
@@ -312,6 +373,7 @@ score_benchmark() {
             timestamp: $timestamp,
             pattern_matching: $pattern,
             llm_judge: $llm,
+            readability: $readability,
             composite_score: ($composite | tonumber)
         }')
 


### PR DESCRIPTION
Follow-up to #129. The evals scored finding recall and judge quality but nothing graded whether a cold reader can parse the findings, so register regressions were invisible. This adds a readability tier next to recall.

## What changed

**`score-eval.sh`** gains a third tier, `score_readability()`: a judge reads the review with no answer key, no diff, and no code access, identifies each severity-prefixed finding body, and scores it 1-5 on the cold-reader rubric (can you say in one sentence what breaks and what the author should do, from the body alone; does the first sentence carry the point; how many sentences needed a re-read). It runs behind the same `--no-llm` skip and the same $0.50 budget cap as the existing judge, fails to a zeroed object, and lands as a top-level `readability` key in score.json. The judge reads the raw review file rather than `parse-review-findings.sh` output because the parser truncates descriptions to 500 characters.

**`report.sh`** shows a `Read.` column between LLM and Composite in the main table and in `--compare-approaches`, plus an `Avg Readability` line in the aggregates. Rows without a scored value (pre-existing history, `--no-llm` runs, reviews with zero findings) render `-` and stay out of the averages, keyed on `readability.count > 0`.

`compute_composite()` is untouched, so composite scores stay comparable across history. `evals/prompts/baseline.md` is untouched; it's the comparator.

## Verification

- `bin/fmt`, `bin/lint`, `bin/test` all green.
- Rendered a synthetic history covering all three row shapes (old format, scored, skipped): the table shows `-` / `4.5` / `0`, the aggregate averages only the scored rows, and `--compare-approaches` carries the column through per-benchmark rows, the delta row, and per-approach aggregates.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*