### PR TITLE
Keep installed runtime state in dot-prefixed directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,16 +50,18 @@ agents/                               # Review agent definitions
         languages/
         frameworks/
         orgs/
-    reviews/                          # Review outputs (org/repo/pr.md)
+    .reviews/                         # Review outputs (org/repo/pr.md)
         posthog/
             posthog/
                 pr-123.md
-    learnings/                        # Learning index
+    .learnings/                       # Learning index
         index.jsonl
         analyzed.json
+    .sessions/                        # Session state and pre-flight markers
+    .worktrees/                       # PR checkout worktrees (org/repo/pr-N)
 ```
 
-**Key insight:** The repo structure mirrors the installed structure. During setup, `skills/review-code/` is copied to `~/.claude/skills/review-code/`. User learnings applied to installed context are preserved through smart merge - new sections from base are added, but existing sections (which may contain learned patterns) are kept.
+**Key insight:** The repo structure mirrors the installed structure, except that runtime state (reviews, learnings, sessions, worktrees) is installed into dot-prefixed directories so skill scanners that ignore dot-directories don't count it against the skill's file budget (source `learnings/README.md` installs to `.learnings/README.md`). During setup, `skills/review-code/` is copied to `~/.claude/skills/review-code/`. User learnings applied to installed context are preserved through smart merge - new sections from base are added, but existing sections (which may contain learned patterns) are kept.
 
 ## Important: Edit Source Files Only
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Both methods will:
 - Copy agent definitions to `~/.claude/agents/`
 - Install the uninstaller at `~/.claude/bin/uninstall-review-code.sh`
 - Smart-merge context files so user learnings are preserved across updates
-- Prompt you to choose where to save code reviews (default: `~/dev/ai/reviews`)
+- Migrate runtime state (reviews, learnings, sessions) into dot-prefixed directories
 - Show permissions guide for Claude Code
 
 ## Usage
@@ -478,24 +478,18 @@ Loads repo-specific workflows and requirements. Add your own in `context/orgs/{o
 
 ### Review Output Path
 
-Reviews are saved to a configurable location. The default is `~/dev/ai/reviews/{org}/{repo}/{pr-number-or-branch}.md`.
-
-To change the path, edit `~/.claude/skills/review-code/.env`:
-
-```bash
-REVIEW_ROOT_PATH="$HOME/my-custom-path/reviews"
-```
-
-The directory structure will be created automatically:
+Reviews are saved to `~/.claude/skills/review-code/.reviews/{org}/{repo}/{pr-number-or-branch}.md`. The directory structure is created automatically:
 
 ```text
-~/my-custom-path/reviews/
+~/.claude/skills/review-code/.reviews/
 ├── org-name/
 │   ├── repo-name/
 │   │   ├── pr-123.md
 │   │   ├── pr-456.md
 │   │   └── feature-branch.md
 ```
+
+Like the other runtime-state directories (`.learnings/`, `.sessions/`, `.worktrees/`), the reviews directory is dot-prefixed so skill scanners that ignore dot-directories don't count review outputs against the skill's file budget.
 
 ## Testing
 
@@ -602,11 +596,10 @@ Your review files are preserved unless you explicitly choose to remove the conte
 - Check that org name matches directory: `context/orgs/{org-name}/`
 - Org names are case-insensitive and normalized to lowercase
 
-### Config file not being read
+### Reviews not being saved
 
-- Check file exists: `ls -la ~/.claude/skills/review-code/.env`
-- Check syntax: `cat ~/.claude/skills/review-code/.env`
-- Ensure `REVIEW_ROOT_PATH` is set correctly
+- Reviews are written to `~/.claude/skills/review-code/.reviews/{org}/{repo}/`
+- Check the directory exists and is writable: `ls -la ~/.claude/skills/review-code/.reviews`
 
 ## Documentation
 

--- a/bin/setup
+++ b/bin/setup
@@ -145,11 +145,13 @@ install_skill() {
     local src_dir="${SCRIPT_DIR}/skills/review-code"
     local dst_dir="${SKILL_DIR}"
 
-    # Create skill directory structure
+    # Create skill directory structure. Runtime-state dirs are dot-prefixed
+    # so skill scanners that ignore dot-directories don't count their
+    # contents against the skill's file budget.
     mkdir -p "${dst_dir}/scripts/helpers"
     mkdir -p "${dst_dir}/scripts/session-hooks"
-    mkdir -p "${dst_dir}/reviews"
-    mkdir -p "${dst_dir}/learnings"
+    mkdir -p "${dst_dir}/.reviews"
+    mkdir -p "${dst_dir}/.learnings"
 
     # Copy SKILL.md
     local skill_src="${src_dir}/SKILL.md"
@@ -198,8 +200,8 @@ install_skill() {
     fi
 
     # Copy learnings README if not exists
-    if [[ -f "${src_dir}/learnings/README.md" ]] && [[ ! -f "${dst_dir}/learnings/README.md" ]]; then
-        cp "${src_dir}/learnings/README.md" "${dst_dir}/learnings/README.md"
+    if [[ -f "${src_dir}/learnings/README.md" ]] && [[ ! -f "${dst_dir}/.learnings/README.md" ]]; then
+        cp "${src_dir}/learnings/README.md" "${dst_dir}/.learnings/README.md"
     fi
 
     # Copy uninstall script to main bin (not in skill folder)
@@ -601,6 +603,57 @@ cleanup_old_config() {
     done
 }
 
+# Migrate pre-dot runtime-state directories (reviews/, sessions/, learnings/)
+# to their dot-prefixed names so skill scanners that ignore dot-directories
+# skip runtime state. Idempotent: no-op when the old directories are absent.
+# When both old and new exist (a re-run, or a stale session that loaded the
+# old SKILL.md recreated an old directory), merge old into new: move
+# non-colliding files, append colliding *.jsonl files (concatenation-safe),
+# and keep the new copy for other collisions.
+migrate_state_dirs() {
+    local name old_dir new_dir
+    for name in reviews sessions learnings; do
+        old_dir="${SKILL_DIR}/${name}"
+        new_dir="${SKILL_DIR}/.${name}"
+        [[ -d "${old_dir}" ]] || continue
+
+        if [[ ! -e "${new_dir}" ]]; then
+            mv "${old_dir}" "${new_dir}"
+            info "Migrated ${name}/ → .${name}/"
+            continue
+        fi
+
+        # Merge file by file with find: sessions/ holds dot-files
+        # (.pending-clear, .pending-resume) that bare globs would miss.
+        local src dst rel
+        while IFS= read -r -d '' src; do
+            rel="${src#"${old_dir}"/}"
+            dst="${new_dir}/${rel}"
+            if [[ ! -e "${dst}" ]]; then
+                mkdir -p "$(dirname "${dst}")"
+                mv "${src}" "${dst}"
+            elif [[ "${src}" == *.jsonl ]]; then
+                cat "${src}" >> "${dst}"
+                rm "${src}"
+            else
+                rm "${src}"
+            fi
+        done < <(find "${old_dir}" -type f -print0 || true)
+        rm -rf "${old_dir}"
+        info "Merged ${name}/ into existing .${name}/"
+    done
+
+    # Fold a legacy token-usage.jsonl at the skill root into the live log
+    # inside .reviews/.
+    local stale_log="${SKILL_DIR}/token-usage.jsonl"
+    if [[ -f "${stale_log}" ]]; then
+        mkdir -p "${SKILL_DIR}/.reviews"
+        cat "${stale_log}" >> "${SKILL_DIR}/.reviews/token-usage.jsonl"
+        rm "${stale_log}"
+        info "Merged legacy token-usage.jsonl into .reviews/token-usage.jsonl"
+    fi
+}
+
 # Report PR review worktrees present under the skill's worktree root.
 # Includes both active (in-flight reviews) and orphan (crashed reviews) entries
 # — distinguishing them reliably would require cross-referencing live sessions.
@@ -728,6 +781,11 @@ main() {
     # content lives in react.md and kea.md.
     rm -f "${SKILL_DIR}/context/frameworks/react-kea.md"
 
+    # Move pre-dot runtime state to the dot-prefixed names install_skill
+    # expects. Must run before install_skill so a first migration is a plain
+    # rename rather than a merge into freshly created empty dirs.
+    migrate_state_dirs
+
     # Install components
     echo ""
     info "Installing review-code components…"
@@ -764,7 +822,7 @@ main() {
         echo "  - Agents (PostHog Desktop): ${posthog_agent_dir}/"
     done
     echo "  - Context: ${SKILL_DIR}/context/"
-    echo "  - Reviews: ${SKILL_DIR}/reviews/"
+    echo "  - Reviews: ${SKILL_DIR}/.reviews/"
     echo ""
     echo "To update: Run bin/setup again"
     echo "To uninstall: Run uninstall.sh"

--- a/docs/review-code-standalone.md
+++ b/docs/review-code-standalone.md
@@ -55,7 +55,7 @@ cd ~/.review-code
 
 Both methods will:
 
-- Prompt you to choose where to save code reviews (default: `~/dev/ai/reviews`)
+- Store review outputs at `~/.claude/skills/review-code/.reviews/`
 - Complete installation in seconds
 
 ### Usage
@@ -190,18 +190,10 @@ Loads repo-specific workflows and requirements:
 
 ### Review Output Path
 
-Reviews are saved to a configurable location. The default is `~/dev/ai/reviews/{org}/{repo}/{pr-number-or-branch}.md`.
-
-To change the path, edit `~/.claude/skills/review-code/.env`:
-
-```bash
-REVIEW_ROOT_PATH="$HOME/my-custom-path/reviews"
-```
-
-The directory structure will be created automatically:
+Reviews are saved to `~/.claude/skills/review-code/.reviews/{org}/{repo}/{pr-number-or-branch}.md`. The directory structure is created automatically:
 
 ```text
-~/my-custom-path/reviews/
+~/.claude/skills/review-code/.reviews/
 ├── org-name/
 │   ├── repo-name/
 │   │   ├── pr-123.md
@@ -271,11 +263,10 @@ Helper scripts and context files remain in `~/.dotfiles` for future use.
 - Check that org name matches directory: `~/.review-code/context/orgs/{org-name}/`
 - Org names are case-insensitive and normalized to lowercase
 
-### Config file not being read
+### Reviews not being saved
 
-- Check file exists: `ls -la ~/.claude/skills/review-code/.env`
-- Check syntax: `cat ~/.claude/skills/review-code/.env`
-- Ensure `REVIEW_ROOT_PATH` is set correctly
+- Reviews are written to `~/.claude/skills/review-code/.reviews/{org}/{repo}/`
+- Check the directory exists and is writable: `ls -la ~/.claude/skills/review-code/.reviews`
 
 ## Next Steps
 

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -34,10 +34,12 @@ REPO_ROOT="$(cd "${EVALS_DIR}/.." && pwd)"
 TARGET_REPO="${EVAL_TARGET_REPO:-${REPO_ROOT}}"
 REGISTRY="${EVALS_DIR}/benchmarks/registry.json"
 RESULTS_DIR="${EVALS_DIR}/results"
-SKILL_REVIEWS_DIR="${HOME}/.claude/skills/review-code/reviews"
 BASELINE_PROMPT="${EVALS_DIR}/prompts/baseline.md"
 
 source "${SCRIPT_DIR}/helpers/eval-helpers.sh"
+# shellcheck source=../../skills/review-code/scripts/helpers/config-helpers.sh
+source "${REPO_ROOT}/skills/review-code/scripts/helpers/config-helpers.sh"
+SKILL_REVIEWS_DIR="$(get_review_root)"
 
 # Build the claude -p prompt that runs the review-code skill.
 # `claude -p` does not register personal skills as slash commands (verified on

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -2,7 +2,7 @@
 name: review-code
 description: Run specialized code review agents on code changes or pull requests
 argument-hint: [find|learn|pr|commit|branch|range|area]
-allowed-tools: Bash(~/.claude/skills/review-code/scripts/*:*), Read(~/.claude/**), Write(~/.claude/skills/review-code/learnings/*), Edit(~/.claude/skills/review-code/learnings/*)
+allowed-tools: Bash(~/.claude/skills/review-code/scripts/*:*), Read(~/.claude/**), Write(~/.claude/skills/review-code/.learnings/*), Edit(~/.claude/skills/review-code/.learnings/*)
 hooks:
   PreToolUse:
     - matcher: Bash

--- a/skills/review-code/handlers/learn.md
+++ b/skills/review-code/handlers/learn.md
@@ -48,7 +48,7 @@ For **"missed" findings** (other reviewer found, Claude missed), show file, line
   2. "No, too specific": One-off case, not worth generalizing
   3. "Skip": Don't record this learning
 
-**3. Record learnings.** For each response other than "Skip", append a record to `~/.claude/skills/review-code/learnings/index.jsonl`:
+**3. Record learnings.** For each response other than "Skip", append a record to `~/.claude/skills/review-code/.learnings/index.jsonl`:
 
 ```json
 {
@@ -72,7 +72,7 @@ For **"missed" findings** (other reviewer found, Claude missed), show file, line
 }
 ```
 
-**4. Mark the PR as analyzed.** Read `~/.claude/skills/review-code/learnings/analyzed.json` (create `{}` if missing). Extract `org` and `repo` from `learn_data`. Merge `{"<org>/<repo>": {"<pr_number>": "<timestamp>"}}` into the existing data and write it back.
+**4. Mark the PR as analyzed.** Read `~/.claude/skills/review-code/.learnings/analyzed.json` (create `{}` if missing). Extract `org` and `repo` from `learn_data`. Merge `{"<org>/<repo>": {"<pr_number>": "<timestamp>"}}` into the existing data and write it back.
 
 **5. Wrap up.** Report the counts of learnings recorded by type, and point at `/review-code learn --apply` for updating context files once patterns accumulate.
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -708,7 +708,7 @@ In debug mode, save the stage `12-token-usage` artifacts (see `review-debug.md`)
 
 After saving the review, append a line to a central token usage log. This tracks token counts across reviews over time.
 
-Derive the log path from the review file's directory: take the parent of the `org/repo/` directory (i.e., the review root) and append `token-usage.jsonl`. For example, if `$review_file` is `~/dev/ai/reviews/posthog/posthog/pr-123.md`, the log path is `~/dev/ai/reviews/token-usage.jsonl`.
+Derive the log path from the review file's directory: take the parent of the `org/repo/` directory (i.e., the review root) and append `token-usage.jsonl`. For example, if `$review_file` is `~/.claude/skills/review-code/.reviews/posthog/posthog/pr-123.md`, the log path is `~/.claude/skills/review-code/.reviews/token-usage.jsonl`.
 
 In practice, this is the great-grandparent directory of `$review_file` (three directories up):
 

--- a/skills/review-code/scripts/clear-marker.sh
+++ b/skills/review-code/scripts/clear-marker.sh
@@ -18,7 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers/date-helpers.sh
 source "${SCRIPT_DIR}/helpers/date-helpers.sh"
 
-MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
+MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/.sessions}"
 MARKER_FILE="${MARKER_DIR}/.pending-clear"
 MARKER_TTL_SECONDS=600
 

--- a/skills/review-code/scripts/helpers/config-helpers.sh
+++ b/skills/review-code/scripts/helpers/config-helpers.sh
@@ -2,12 +2,16 @@
 # Configuration helpers
 # Provides path resolution for the review-code skill
 #
-# All paths are now relative to the skill directory:
+# All paths are relative to the skill directory:
 #   ~/.claude/skills/review-code/
 #     context/     - Language, framework, and org context files
-#     reviews/     - Review output files (org/repo/pr.md)
-#     learnings/   - Learning index
+#     .reviews/    - Review output files (org/repo/pr.md)
+#     .learnings/  - Learning index
 #     scripts/     - Helper scripts
+#
+# Runtime state (reviews, learnings, sessions, worktrees) lives in
+# dot-prefixed directories so skill scanners that ignore dot-directories
+# don't count it against the skill's file budget.
 
 # Get the skill installation directory
 # Uses HOME at call time to support testing with alternate HOME values
@@ -23,7 +27,7 @@ get_skill_dir() {
 # Returns:
 #   The review root path on stdout
 get_review_root() {
-    echo "$(get_skill_dir)/reviews"
+    echo "$(get_skill_dir)/.reviews"
 }
 
 # Get the context path (where context files are stored)
@@ -47,5 +51,5 @@ get_context_path() {
 # Returns:
 #   The learnings directory path on stdout
 get_learnings_dir() {
-    echo "$(get_skill_dir)/learnings"
+    echo "$(get_skill_dir)/.learnings"
 }

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -7,7 +7,7 @@
 #
 # Description:
 #   Analyzes a PR's final state to learn from review outcomes:
-#   1. Loads Claude's review notes from ~/dev/ai/reviews/{org}/{repo}/pr-{number}.md
+#   1. Loads Claude's review notes from ~/.claude/skills/review-code/.reviews/{org}/{repo}/pr-{number}.md
 #   2. Fetches GitHub review comments (changes requested / resolved threads)
 #   3. Gets commit history after reviews were posted
 #   4. Cross-references to determine outcomes

--- a/skills/review-code/scripts/pending-resume.sh
+++ b/skills/review-code/scripts/pending-resume.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers/date-helpers.sh
 source "${SCRIPT_DIR}/helpers/date-helpers.sh"
 
-MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/sessions}"
+MARKER_DIR="${REVIEW_CODE_MARKER_DIR:-${HOME}/.claude/skills/review-code/.sessions}"
 PENDING_RESUME_FILE="${MARKER_DIR}/.pending-resume"
 
 # 10-minute TTL matches the clear-marker so a stale resume can't auto-fire

--- a/skills/review-code/scripts/review-file-path.sh
+++ b/skills/review-code/scripts/review-file-path.sh
@@ -12,9 +12,8 @@ source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 #
 # Configuration:
-#   Reads review root path from ~/.claude/skills/review-code/.env
-#   Falls back to ~/.claude/review-code.env for backward compatibility
-#   Defaults to ~/dev/ai/reviews if no config file exists
+#   Reviews live under the fixed root from get_review_root() in
+#   helpers/config-helpers.sh (~/.claude/skills/review-code/.reviews)
 #
 # Arguments:
 #   --org ORG: GitHub organization (optional, extracts from git if not provided)
@@ -32,12 +31,12 @@ source "${SCRIPT_DIR}/helpers/config-helpers.sh"
 #     "repo": "posthog",
 #     "branch": "main",
 #     "pr_number": "123",
-#     "file_path": "{REVIEW_ROOT_PATH}/posthog/posthog/pr-123.md",
+#     "file_path": "{review_root}/posthog/posthog/pr-123.md",
 #     "file_exists": true,
 #     "needs_rename": false,
 #     "old_path": null,
 #     "has_branch_review": true,
-#     "branch_review_path": "{REVIEW_ROOT_PATH}/posthog/posthog/my-feature.md"
+#     "branch_review_path": "{review_root}/posthog/posthog/my-feature.md"
 #   }
 
 set -euo pipefail

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -24,7 +24,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CLEAR_MARKER_SH="${SCRIPT_DIR}/clear-marker.sh"
 PENDING_RESUME_SH="${SCRIPT_DIR}/pending-resume.sh"
-LOG_FILE="${REVIEW_CODE_HOOK_LOG:-${HOME}/.claude/skills/review-code/sessions/.session-clear-hook.log}"
+LOG_FILE="${REVIEW_CODE_HOOK_LOG:-${HOME}/.claude/skills/review-code/.sessions/.session-clear-hook.log}"
 
 # Append one line per invocation so we can confirm the hook actually fires
 # on /clear and inspect what it emitted. Bounded to ~50 entries.

--- a/skills/review-code/scripts/session-manager.sh
+++ b/skills/review-code/scripts/session-manager.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 #   session_cleanup <session-id>
 
 # Session storage directory
-SESSION_DIR="${CLAUDE_SESSION_DIR:-${HOME}/.claude/skills/review-code/sessions}"
+SESSION_DIR="${CLAUDE_SESSION_DIR:-${HOME}/.claude/skills/review-code/.sessions}"
 
 # Sanitize session ID or command name to prevent path traversal
 # Args: $1 = string to sanitize

--- a/tests/unit/test-config-helpers.bats
+++ b/tests/unit/test-config-helpers.bats
@@ -2,11 +2,13 @@
 # Tests for lib/helpers/config-helpers.sh
 #
 # Note: The config-helpers module no longer uses config files.
-# Paths are now fixed relative to the skill directory:
+# Paths are now fixed relative to the skill directory. Runtime state lives
+# in dot-prefixed directories so skill scanners that skip dot-directories
+# ignore it:
 #   ~/.claude/skills/review-code/
 #     context/     - Language, framework, and org context files
-#     reviews/     - Review output files (org/repo/pr.md)
-#     learnings/   - Learning index
+#     .reviews/    - Review output files (org/repo/pr.md)
+#     .learnings/  - Learning index
 
 setup() {
     # Get paths
@@ -36,7 +38,7 @@ teardown() {
     HOME="$FAKE_HOME" run get_review_root
 
     [ "$status" -eq 0 ]
-    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/reviews" ]
+    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/.reviews" ]
 }
 
 @test "get_review_root: path is consistent across calls" {
@@ -64,7 +66,7 @@ EOF
 
     [ "$status" -eq 0 ]
     # Should return fixed path, not config value
-    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/reviews" ]
+    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/.reviews" ]
 }
 
 # === get_context_path ===
@@ -100,7 +102,7 @@ EOF
     HOME="$FAKE_HOME" run get_learnings_dir
 
     [ "$status" -eq 0 ]
-    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/learnings" ]
+    [ "$output" = "$FAKE_HOME/.claude/skills/review-code/.learnings" ]
 }
 
 @test "get_learnings_dir: path is consistent across calls" {

--- a/tests/unit/test-review-file-path.bats
+++ b/tests/unit/test-review-file-path.bats
@@ -12,13 +12,13 @@ setup() {
     TEST_TEMP_DIR=$(cd "$TEST_TEMP_DIR" && pwd -P)
     export HOME="$TEST_TEMP_DIR"
 
-    # Setup skill directory structure (reviews path is now fixed at ~/.claude/skills/review-code/reviews)
-    mkdir -p "$TEST_TEMP_DIR/.claude/skills/review-code/reviews"
+    # Setup skill directory structure (reviews path is now fixed at ~/.claude/skills/review-code/.reviews)
+    mkdir -p "$TEST_TEMP_DIR/.claude/skills/review-code/.reviews"
     mkdir -p "$TEST_TEMP_DIR/.claude/skills/review-code/context"
-    mkdir -p "$TEST_TEMP_DIR/.claude/skills/review-code/learnings"
+    mkdir -p "$TEST_TEMP_DIR/.claude/skills/review-code/.learnings"
 
     # Set expected review root path for tests
-    EXPECTED_REVIEW_ROOT="$TEST_TEMP_DIR/.claude/skills/review-code/reviews"
+    EXPECTED_REVIEW_ROOT="$TEST_TEMP_DIR/.claude/skills/review-code/.reviews"
 }
 
 teardown() {
@@ -149,8 +149,8 @@ teardown() {
     result=$("$SCRIPT" --org "myorg" --repo "myrepo" "test")
     file_path=$(echo "$result" | jq -r '.file_path')
 
-    # Check directory structure
-    [[ "$file_path" =~ reviews/myorg/myrepo/ ]]
+    # Check directory structure (dot-prefixed review root)
+    [[ "$file_path" =~ \.reviews/myorg/myrepo/ ]]
 }
 
 @test "path safety: directory is created" {
@@ -233,8 +233,8 @@ teardown() {
     result=$("$SCRIPT" --org "myorg" --repo "myrepo" "test")
     file_path=$(echo "$result" | jq -r '.file_path')
 
-    # Should use fixed path: ~/.claude/skills/review-code/reviews
-    [[ "$file_path" == "$TEST_TEMP_DIR/.claude/skills/review-code/reviews"* ]]
+    # Should use fixed path: ~/.claude/skills/review-code/.reviews
+    [[ "$file_path" == "$TEST_TEMP_DIR/.claude/skills/review-code/.reviews"* ]]
 }
 
 @test "path: review root is consistent" {

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -48,6 +48,11 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "setup: has migrate_state_dirs function" {
+    run bash -c "grep -q '^migrate_state_dirs()' '$PROJECT_ROOT/bin/setup'"
+    [ "$status" -eq 0 ]
+}
+
 @test "setup: has smart merge functions" {
     run bash -c "grep -q '^merge_markdown_sections()' '$PROJECT_ROOT/bin/setup'"
     [ "$status" -eq 0 ]
@@ -192,8 +197,14 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+# Print the body of a top-level bin/setup function: its definition line
+# through the first closing brace at column zero.
+setup_function_body() {
+    awk -v fn="$1" 'index($0, fn "()") == 1 {f=1} f {print} /^}/ {if (f) exit}' "$PROJECT_ROOT/bin/setup"
+}
+
 @test "setup: install_skill copies uninstall script" {
-    run bash -c "awk '/^install_skill\(\)/{f=1} f{print} /^}/{if(f)exit}' '$PROJECT_ROOT/bin/setup' | grep -q 'uninstall.sh'"
+    run grep -q 'uninstall.sh' <<< "$(setup_function_body install_skill)"
     [ "$status" -eq 0 ]
 }
 
@@ -202,18 +213,27 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "setup: install_skill creates reviews directory" {
-    run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'reviews'"
+@test "setup: install_skill creates .reviews directory (not reviews)" {
+    body="$(setup_function_body install_skill)"
+    run grep -q 'dst_dir}/\.reviews' <<< "$body"
     [ "$status" -eq 0 ]
+    # Regression guard: the old non-dot directory must not come back
+    run grep -q 'dst_dir}/reviews' <<< "$body"
+    [ "$status" -ne 0 ]
 }
 
-@test "setup: install_skill creates learnings directory" {
-    run bash -c "grep -A80 'install_skill()' '$PROJECT_ROOT/bin/setup' | grep -q 'learnings'"
+@test "setup: install_skill creates .learnings directory (not learnings)" {
+    body="$(setup_function_body install_skill)"
+    run grep -q 'dst_dir}/\.learnings' <<< "$body"
     [ "$status" -eq 0 ]
+    # Regression guard: no destination path may use the old non-dot name.
+    # (Source paths like src_dir/learnings are fine - the repo layout is unchanged.)
+    run grep -q 'dst_dir}/learnings' <<< "$body"
+    [ "$status" -ne 0 ]
 }
 
 @test "setup: install_skill copies session hooks" {
-    run bash -c "awk '/^install_skill\(\)/{f=1} f{print} /^}/{if(f)exit}' '$PROJECT_ROOT/bin/setup' | grep -q 'session-hooks'"
+    run grep -q 'session-hooks' <<< "$(setup_function_body install_skill)"
     [ "$status" -eq 0 ]
 }
 
@@ -307,6 +327,144 @@ setup() {
 }
 
 # =============================================================================
+# State directory migration tests (reviews/ -> .reviews/, sessions/ ->
+# .sessions/, learnings/ -> .learnings/)
+# =============================================================================
+
+# Extract and run migrate_state_dirs from bin/setup against a temp skill dir.
+# Mirrors the executable-extraction pattern used for install_skill above.
+run_migrate_state_dirs() {
+    local skill_dir="$1"
+    run bash -c "
+        set -euo pipefail
+        info() { :; }
+        debug() { :; }
+        warn() { :; }
+        error() { :; }
+        SKILL_DIR='${skill_dir}'
+        source <(sed -n '/^migrate_state_dirs()/,/^}/p' '$PROJECT_ROOT/bin/setup')
+        migrate_state_dirs
+    "
+}
+
+@test "setup: migrate_state_dirs renames all three state dirs with nested content intact" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    mkdir -p "${skill_dir}/reviews/org/repo"
+    echo "review body" > "${skill_dir}/reviews/org/repo/pr-1.md"
+    mkdir -p "${skill_dir}/sessions/review-code"
+    echo '{"session":1}' > "${skill_dir}/sessions/review-code/abc.json"
+    mkdir -p "${skill_dir}/learnings"
+    echo '{"id":1}' > "${skill_dir}/learnings/index.jsonl"
+
+    run_migrate_state_dirs "${skill_dir}"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "${skill_dir}/reviews" ]
+    [ ! -e "${skill_dir}/sessions" ]
+    [ ! -e "${skill_dir}/learnings" ]
+    [ "$(cat "${skill_dir}/.reviews/org/repo/pr-1.md")" = "review body" ]
+    [ "$(cat "${skill_dir}/.sessions/review-code/abc.json")" = '{"session":1}' ]
+    [ "$(cat "${skill_dir}/.learnings/index.jsonl")" = '{"id":1}' ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "setup: migrate_state_dirs is a no-op on a fresh install" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    mkdir -p "${skill_dir}"
+
+    run_migrate_state_dirs "${skill_dir}"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "${skill_dir}/.reviews" ]
+    [ ! -e "${skill_dir}/.sessions" ]
+    [ ! -e "${skill_dir}/.learnings" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "setup: migrate_state_dirs is idempotent" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    mkdir -p "${skill_dir}/reviews/org/repo"
+    echo "review body" > "${skill_dir}/reviews/org/repo/pr-1.md"
+
+    run_migrate_state_dirs "${skill_dir}"
+    [ "$status" -eq 0 ]
+
+    run_migrate_state_dirs "${skill_dir}"
+    [ "$status" -eq 0 ]
+
+    [ ! -e "${skill_dir}/reviews" ]
+    [ "$(cat "${skill_dir}/.reviews/org/repo/pr-1.md")" = "review body" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "setup: migrate_state_dirs merges old dir into existing new dir" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    mkdir -p "${skill_dir}/reviews" "${skill_dir}/.reviews"
+    # Unique old file: must move into the new dir
+    echo "only in old" > "${skill_dir}/reviews/unique.md"
+    # Colliding *.jsonl: old must be appended to new (2 + 3 = 5 lines)
+    printf 'old line 1\nold line 2\n' > "${skill_dir}/reviews/token-usage.jsonl"
+    printf 'new line 1\nnew line 2\nnew line 3\n' > "${skill_dir}/.reviews/token-usage.jsonl"
+    # Colliding non-jsonl: the new dir's copy wins
+    echo "old copy" > "${skill_dir}/reviews/collision.md"
+    echo "new copy" > "${skill_dir}/.reviews/collision.md"
+
+    run_migrate_state_dirs "${skill_dir}"
+
+    [ "$status" -eq 0 ]
+    [ "$(cat "${skill_dir}/.reviews/unique.md")" = "only in old" ]
+    [ "$(wc -l < "${skill_dir}/.reviews/token-usage.jsonl")" -eq 5 ]
+    grep -q "old line 2" "${skill_dir}/.reviews/token-usage.jsonl"
+    grep -q "new line 3" "${skill_dir}/.reviews/token-usage.jsonl"
+    [ "$(cat "${skill_dir}/.reviews/collision.md")" = "new copy" ]
+    [ ! -e "${skill_dir}/reviews" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "setup: migrate_state_dirs carries dot-files when merging sessions" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    # Pre-existing .sessions forces the merge path, where a bare glob
+    # (as opposed to find) would silently drop dot-files like .pending-clear.
+    mkdir -p "${skill_dir}/sessions" "${skill_dir}/.sessions"
+    touch "${skill_dir}/sessions/.pending-clear"
+
+    run_migrate_state_dirs "${skill_dir}"
+
+    [ "$status" -eq 0 ]
+    [ -f "${skill_dir}/.sessions/.pending-clear" ]
+    [ ! -e "${skill_dir}/sessions" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+@test "setup: migrate_state_dirs folds stale root token-usage.jsonl into .reviews" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    skill_dir="${TEST_TEMP_DIR}/skill"
+    mkdir -p "${skill_dir}/.reviews"
+    printf 'live line 1\n' > "${skill_dir}/.reviews/token-usage.jsonl"
+    printf 'stale line 1\nstale line 2\n' > "${skill_dir}/token-usage.jsonl"
+
+    run_migrate_state_dirs "${skill_dir}"
+
+    [ "$status" -eq 0 ]
+    [ ! -e "${skill_dir}/token-usage.jsonl" ]
+    [ "$(wc -l < "${skill_dir}/.reviews/token-usage.jsonl")" -eq 3 ]
+    grep -q "live line 1" "${skill_dir}/.reviews/token-usage.jsonl"
+    grep -q "stale line 2" "${skill_dir}/.reviews/token-usage.jsonl"
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
+# =============================================================================
 # Workflow tests
 # =============================================================================
 
@@ -328,6 +486,20 @@ setup() {
 @test "setup: main calls install_skill" {
     run bash -c "grep -A100 '^main()' '$PROJECT_ROOT/bin/setup' | grep -q 'install_skill'"
     [ "$status" -eq 0 ]
+}
+
+@test "setup: main calls migrate_state_dirs before install_skill" {
+    # Order matters: migration must run before install_skill creates the
+    # dot-prefixed directories, or a pre-migration install would merge
+    # instead of taking the cheap whole-directory rename.
+    main_body=$(setup_function_body main)
+    # Anchor to bare invocation lines so comments mentioning the function
+    # names don't count.
+    migrate_line=$(echo "$main_body" | grep -n '^[[:space:]]*migrate_state_dirs$' | head -1 | cut -d: -f1)
+    install_line=$(echo "$main_body" | grep -n '^[[:space:]]*install_skill$' | head -1 | cut -d: -f1)
+    [ -n "$migrate_line" ]
+    [ -n "$install_line" ]
+    [ "$migrate_line" -lt "$install_line" ]
 }
 
 @test "setup: main calls install_agents" {

--- a/tests/unit/test-uninstall.bats
+++ b/tests/unit/test-uninstall.bats
@@ -174,7 +174,14 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "uninstall.sh: uses fixed REVIEWS_DIR path" {
+@test "uninstall.sh: uses fixed dot-prefixed REVIEWS_DIR path" {
+    run bash -c "grep -q 'REVIEWS_DIR=\"\${SKILL_DIR}/\.reviews\"' '$PROJECT_ROOT/uninstall.sh'"
+    [ "$status" -eq 0 ]
+}
+
+@test "uninstall.sh: falls back to legacy reviews dir when .reviews is absent" {
+    # Pre-migration installs keep reviews at ${SKILL_DIR}/reviews; the
+    # uninstaller must still find them there when .reviews doesn't exist.
     run bash -c "grep -q 'REVIEWS_DIR=\"\${SKILL_DIR}/reviews\"' '$PROJECT_ROOT/uninstall.sh'"
     [ "$status" -eq 0 ]
 }

--- a/tests/unit/test-uninstall.bats
+++ b/tests/unit/test-uninstall.bats
@@ -179,10 +179,12 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "uninstall.sh: falls back to legacy reviews dir when .reviews is absent" {
-    # Pre-migration installs keep reviews at ${SKILL_DIR}/reviews; the
-    # uninstaller must still find them there when .reviews doesn't exist.
-    run bash -c "grep -q 'REVIEWS_DIR=\"\${SKILL_DIR}/reviews\"' '$PROJECT_ROOT/uninstall.sh'"
+@test "uninstall.sh: backs up every review dir that has content" {
+    # reviews/ (pre-migration installs or stale-session strays) and .reviews/
+    # can both hold content at once; each populated dir must feed the backup.
+    run bash -c "grep -qF 'for review_candidate in \"\${SKILL_DIR}/reviews\" \"\${REVIEWS_DIR}\"' '$PROJECT_ROOT/uninstall.sh'"
+    [ "$status" -eq 0 ]
+    run bash -c "grep -qF 'REVIEW_DIRS+=(\"\${review_candidate}\")' '$PROJECT_ROOT/uninstall.sh'"
     [ "$status" -eq 0 ]
 }
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -21,7 +21,9 @@ NC='\033[0m'
 # Directories - all paths are now fixed under the skill directory
 CLAUDE_DIR="${HOME}/.claude"
 SKILL_DIR="${CLAUDE_DIR}/skills/review-code"
-REVIEWS_DIR="${SKILL_DIR}/reviews"
+REVIEWS_DIR="${SKILL_DIR}/.reviews"
+# Installs that predate the dot-dir migration keep reviews in a visible dir.
+[[ -d "${REVIEWS_DIR}" ]] || REVIEWS_DIR="${SKILL_DIR}/reviews"
 
 # PostHog Desktop agent directories remove_agents cleaned, reported in the
 # closing message.
@@ -153,8 +155,10 @@ preserve_reviews() {
     if [[ ! ${REPLY} =~ ^[Nn]$ ]]; then
         local backup_dir
         backup_dir="${HOME}/review-code-backup-$(date +%Y%m%d-%H%M%S)"
-        mkdir -p "${backup_dir}"
-        cp -r "${REVIEWS_DIR}" "${backup_dir}/"
+        # Copy contents into a visible reviews/ dir so the backup isn't a
+        # hidden .reviews directory.
+        mkdir -p "${backup_dir}/reviews"
+        cp -R "${REVIEWS_DIR}/." "${backup_dir}/reviews/"
         info "Reviews backed up to: ${backup_dir}/reviews"
     else
         warn "Reviews will be removed with skill directory"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -22,12 +22,18 @@ NC='\033[0m'
 CLAUDE_DIR="${HOME}/.claude"
 SKILL_DIR="${CLAUDE_DIR}/skills/review-code"
 REVIEWS_DIR="${SKILL_DIR}/.reviews"
-# Installs that predate the dot-dir migration keep reviews in a visible dir.
-# Prefer the legacy dir when it has content and the dot dir doesn't, so
-# preserve_reviews never skips real reviews behind an empty .reviews.
-if [[ -z "$(ls -A "${REVIEWS_DIR}" 2> /dev/null || true)" ]] && [[ -n "$(ls -A "${SKILL_DIR}/reviews" 2> /dev/null || true)" ]]; then
-    REVIEWS_DIR="${SKILL_DIR}/reviews"
-fi
+# Installs that predate the dot-dir migration keep reviews in a visible dir,
+# and both can hold content at once: a stale session running the old SKILL.md
+# recreates reviews/ after bin/setup migrated to .reviews/. Back up every
+# directory that has content so the rm -rf in remove_skill never destroys
+# reviews the user asked to preserve. Legacy first so .reviews wins
+# collisions, matching the "keep the new copy" rule in migrate_state_dirs.
+REVIEW_DIRS=()
+for review_candidate in "${SKILL_DIR}/reviews" "${REVIEWS_DIR}"; do
+    if [[ -n "$(ls -A "${review_candidate}" 2> /dev/null || true)" ]]; then
+        REVIEW_DIRS+=("${review_candidate}")
+    fi
+done
 
 # PostHog Desktop agent directories remove_agents cleaned, reported in the
 # closing message.
@@ -141,18 +147,15 @@ remove_agents() {
 }
 
 preserve_reviews() {
-    # Check if there are reviews to preserve
-    if [[ ! -d "${REVIEWS_DIR}" ]]; then
-        return
-    fi
-    local dir_contents
-    dir_contents=$(ls -A "${REVIEWS_DIR}" 2> /dev/null) || true
-    if [[ -z "${dir_contents}" ]]; then
+    if [[ ${#REVIEW_DIRS[@]} -eq 0 ]]; then
         return
     fi
 
     echo ""
-    echo "Reviews found at: ${REVIEWS_DIR}"
+    local dir
+    for dir in "${REVIEW_DIRS[@]}"; do
+        echo "Reviews found at: ${dir}"
+    done
     read -p "Preserve reviews before uninstalling? [Y/n] " -n 1 -r
     echo ""
 
@@ -162,7 +165,9 @@ preserve_reviews() {
         # Copy contents into a visible reviews/ dir so the backup isn't a
         # hidden .reviews directory.
         mkdir -p "${backup_dir}/reviews"
-        cp -R "${REVIEWS_DIR}/." "${backup_dir}/reviews/"
+        for dir in "${REVIEW_DIRS[@]}"; do
+            cp -R "${dir}/." "${backup_dir}/reviews/"
+        done
         info "Reviews backed up to: ${backup_dir}/reviews"
     else
         warn "Reviews will be removed with skill directory"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -23,7 +23,11 @@ CLAUDE_DIR="${HOME}/.claude"
 SKILL_DIR="${CLAUDE_DIR}/skills/review-code"
 REVIEWS_DIR="${SKILL_DIR}/.reviews"
 # Installs that predate the dot-dir migration keep reviews in a visible dir.
-[[ -d "${REVIEWS_DIR}" ]] || REVIEWS_DIR="${SKILL_DIR}/reviews"
+# Prefer the legacy dir when it has content and the dot dir doesn't, so
+# preserve_reviews never skips real reviews behind an empty .reviews.
+if [[ -z "$(ls -A "${REVIEWS_DIR}" 2> /dev/null || true)" ]] && [[ -n "$(ls -A "${SKILL_DIR}/reviews" 2> /dev/null || true)" ]]; then
+    REVIEWS_DIR="${SKILL_DIR}/reviews"
+fi
 
 # PostHog Desktop agent directories remove_agents cleaned, reported in the
 # closing message.


### PR DESCRIPTION
- PostHog Desktop refuses to load a skill whose directory has more than 1000 files. The installed review-code dir had ~84k: PR worktrees under `.worktrees/`, 845 review outputs under `reviews/`, plus session and learning state. The skill's actual code is 107 files.
- Runtime state now lives in dot-prefixed directories a scanner can skip: `reviews/` becomes `.reviews/`, `sessions/` becomes `.sessions/`, `learnings/` becomes `.learnings/` (`.worktrees/` already complied). `bin/setup` migrates existing installs idempotently: a plain rename when only the old dir exists, a file-level merge when both exist (jsonl appended, collisions keep the new copy), and it folds the legacy root `token-usage.jsonl` into `.reviews/`.
- Desktop counting only non-hidden files is a separate Desktop-side change; this lands the skill half so the layout is ready for it.

## Test plan

- `bin/test` passes (unit + integration), including new migration tests covering rename, fresh-install no-op, idempotency, both-exist merge, dot-file carry-over, and the token-usage fold
- Ran `bin/setup` against the live install: 845 review files, 4 learnings files, and session markers all landed in the dot dirs with counts matching the pre-migration snapshot; a second run made no changes
- Installed skill dir now has 101 non-hidden files

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*