### PR TITLE
Offer rm -rf when a leftover worktree's owning clone is gone

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -696,14 +696,22 @@ check_orphan_worktrees() {
                 gitdir_line="${gitdir_line#gitdir: }"
                 clone="${gitdir_line%/.git/worktrees/*}"
             fi
-            if [[ -n "${clone}" ]]; then
+            if [[ -n "${clone}" && -d "${clone}" ]]; then
                 echo "    ${wt}"
                 # `worktree prune` can't help: it only drops registrations whose
                 # directory is gone, and everything here is still on disk.
                 removals+=("$(printf 'git -C %q worktree remove --force --force %q' "${clone}" "${wt}")")
             else
-                # No .git pointer, so git doesn't know about this one at all.
-                echo "    ${wt}  (not a registered worktree)"
+                if [[ -n "${clone}" ]]; then
+                    # The pointer parses but names a clone that has since been
+                    # moved or deleted, so `git -C "${clone}"` would exit 128.
+                    # git still holds a registration, which is why this doesn't
+                    # claim the worktree is unregistered.
+                    echo "    ${wt}  (owning clone ${clone} is gone)"
+                else
+                    # No .git pointer, so git doesn't know about this one at all.
+                    echo "    ${wt}  (not a registered worktree)"
+                fi
                 removals+=("$(printf 'rm -rf %q' "${wt}")")
             fi
         done

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -563,6 +563,52 @@ run_check_orphan_worktrees() {
     rm -rf "${TEST_TEMP_DIR}"
 }
 
+@test "setup: check_orphan_worktrees offers rm -rf when the owning clone is gone" {
+    TEST_TEMP_DIR=$(mktemp -d)
+    local clone="${TEST_TEMP_DIR}/clone"
+    git init --quiet "${clone}"
+    git -C "${clone}" config commit.gpgsign false
+    git -C "${clone}" config user.email "test@example.com"
+    git -C "${clone}" config user.name "Test User"
+    echo "hello" > "${clone}/file.txt"
+    git -C "${clone}" add file.txt
+    git -C "${clone}" commit --quiet -m "initial"
+
+    local root="${TEST_TEMP_DIR}/worktrees"
+    local wt="${root}/myorg/myrepo/pr-11"
+    mkdir -p "$(dirname "${wt}")"
+    git -C "${clone}" worktree add --detach --quiet "${wt}" HEAD
+
+    # Resolve the clone before moving it: the .git pointer records the resolved
+    # path, and `pwd -P` can't run on a directory that no longer exists.
+    local clone_real
+    clone_real=$(cd "${clone}" && pwd -P)
+
+    # The clone is deleted or moved after provisioning, so the worktree's .git
+    # pointer still names a path no git command can chdir into.
+    mv "${clone}" "${TEST_TEMP_DIR}/clone-moved"
+
+    run_check_orphan_worktrees "${root}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"owning clone ${clone_real} is gone"* ]]
+    # git does still hold a registration here, so the other label would lie.
+    [[ "$output" != *"not a registered worktree"* ]]
+    # The bug: `git -C <clone that is gone>` exits 128, so advising it hands the
+    # user a command that cannot run.
+    [[ "$output" != *"git -C ${clone_real}"* ]]
+
+    local cmd
+    cmd=$(grep -m1 -o 'rm -rf .*' <<< "$output" || true)
+    [ -n "${cmd}" ]
+    [[ "${cmd}" == *"${TEST_TEMP_DIR}"* ]]
+
+    run bash -c "${cmd}"
+    [ "$status" -eq 0 ]
+    [ ! -d "${wt}" ]
+
+    rm -rf "${TEST_TEMP_DIR}"
+}
+
 @test "setup: check_orphan_worktrees is silent when the worktree root is empty" {
     TEST_TEMP_DIR=$(mktemp -d)
     local root="${TEST_TEMP_DIR}/worktrees"


### PR DESCRIPTION
`check_orphan_worktrees` reads each leftover worktree's `.git` pointer to find the clone that owns it, then prints `git -C <clone> worktree remove --force --force <path>`. If that clone has since been moved or deleted, the pointer still names the old path and the printed command exits 128 with `cannot change to '/gone/path': No such file or directory`. That is the same unrunnable-advice failure #134 set out to fix, reached a different way. The testing reviewer on #134 raised it.

There are three states now, not two:

| State | Printed command | Label |
|---|---|---|
| Pointer parses and the clone exists | `git -C <clone> worktree remove --force --force <path>` | none |
| No `.git` pointer at all | `rm -rf <path>` | `(not a registered worktree)` |
| Pointer parses, clone directory is gone | `rm -rf <path>` | `(owning clone <path> is gone)` |

The third case gets its own label because `(not a registered worktree)` would be false there. Git still holds a registration, it is just unreachable.

The condition is `[[ -n "${clone}" && -d "${clone}" ]]`, and the else branch picks its label from whether `clone` was empty, so the `rm -rf` line is written once.

Detecting that a clone moved rather than was deleted, and following it, is out of scope. Nothing records where a clone used to live, and `repos.conf` maps org/repo to a current path rather than a history.

## Test plan

- [x] `bin/test` green (unit and integration)
- [x] `bin/fmt` and `bin/lint` clean
- [x] New bats test verified red first: with the old condition it fails on the missing label

The new test builds a real registered worktree, moves the owning clone aside, then checks that the third label appears and that the printed `rm -rf` actually removes the directory. It resolves the clone with `pwd -P` before the move, since the `.git` pointer stores the resolved path and you cannot resolve a directory that is gone. The scraped command is guarded with `[[ "${cmd}" == *"${TEST_TEMP_DIR}"* ]]` before it runs, matching the two sibling tests.