### PR TITLE
Remove review worktrees on teardown whatever state they are in

### DIFF
--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -12,11 +12,15 @@
 #     exit 1 on fetch or worktree failure (caller falls back to diff-only)
 #
 #   pr-worktree.sh teardown <org> <repo> <pr_number> <local_clone>
-#     Removes the worktree, including one an external tool has locked. Keeps
-#     the ref (trivially small; speeds up re-reviews of the same PR). No error
-#     if the worktree is already gone. Leaves the worktree untouched if it has
-#     modified or untracked files, so in-progress edits are never destroyed;
-#     a checkout that only reports deletions is removed.
+#     Removes the worktree whatever state it is in, including one an external
+#     tool has locked and one with uncommitted edits. Keeps the ref (trivially
+#     small; speeds up re-reviews of the same PR). No error if the worktree is
+#     already gone.
+#
+#     These worktrees are orchestrator-owned scratch, not a place to work: only
+#     provision creates them, always at <org>/<repo>/pr-<N> under the skill's
+#     worktree root, and always as a detached checkout of a PR head. See
+#     teardown for why removal is unconditional.
 #
 # Both commands serialize on a per-org/repo mkdir-based lock before touching
 # the local clone, since concurrent `git fetch`/`git worktree add|remove`
@@ -239,29 +243,11 @@ teardown() {
         return 0
     fi
 
-    # force_remove_worktree discards state and overrides locks, so this check is
-    # the only guard for in-progress edits: leave the worktree alone when it has
-    # modified or untracked files.
-    local status_output
-    if ! status_output=$(git -C "${path}" status --porcelain --untracked-files=normal 2>&1); then
-        log "Leaving worktree ${path} in place (couldn't check for uncommitted changes)."
-        return 0
-    fi
-    # Deleted tracked files are recoverable from the ref we checked out;
-    # modified and untracked ones aren't, so only those block removal. A
-    # checkout whose files were deleted out from under it (an interrupted
-    # teardown, an external cleaner) reports every tracked path as deleted, and
-    # nothing would clear it short of re-reviewing that same PR.
-    # `|| true` because grep exits 1 once everything filters out. Don't switch
-    # to `grep -qv`: an empty status still feeds the herestring one blank line,
-    # which reads as unsaved work.
-    local unsaved_work
-    unsaved_work=$(grep -vE '^( D|D )' <<< "${status_output}" || true)
-    if [[ -n "${unsaved_work}" ]]; then
-        log "Leaving worktree ${path} in place (has uncommitted changes)."
-        return 0
-    fi
-
+    # Removal is unconditional, dirty checkout or not. Provision owns this
+    # directory and its reuse path already force-removes and recreates the
+    # worktree as soon as the checkout is too dirty to check out over, so
+    # declining here would only postpone the same discard until the next review
+    # of the same PR, and leave an orphan on disk until then.
     log "Removing worktree ${path}…"
     force_remove_worktree "${local_clone}" "${path}"
     # Best-effort cleanup of empty ancestor directories.

--- a/skills/review-code/scripts/pr-worktree.sh
+++ b/skills/review-code/scripts/pr-worktree.sh
@@ -12,10 +12,10 @@
 #     exit 1 on fetch or worktree failure (caller falls back to diff-only)
 #
 #   pr-worktree.sh teardown <org> <repo> <pr_number> <local_clone>
-#     Removes the worktree whatever state it is in, including one an external
-#     tool has locked and one with uncommitted edits. Keeps the ref (trivially
-#     small; speeds up re-reviews of the same PR). No error if the worktree is
-#     already gone.
+#     Removes the worktree no matter what state it is in, including one an
+#     external tool has locked and one with uncommitted edits. Keeps the ref
+#     (trivially small; speeds up re-reviews of the same PR). No error if the
+#     worktree is already gone.
 #
 #     These worktrees are orchestrator-owned scratch, not a place to work: only
 #     provision creates them, always at <org>/<repo>/pr-<N> under the skill's

--- a/tests/unit/test-pr-worktree.bats
+++ b/tests/unit/test-pr-worktree.bats
@@ -20,7 +20,10 @@ setup() {
     git -C "$seed" config user.email "test@example.com"
     git -C "$seed" config user.name "Test User"
     echo "hello" > "$seed/file.txt"
-    git -C "$seed" add file.txt
+    # A second tracked file so a test can stage a deletion on one file while
+    # leaving another modified; one file can only be in one porcelain state.
+    echo "second" > "$seed/second.txt"
+    git -C "$seed" add file.txt second.txt
     git -C "$seed" commit --quiet -m "initial"
     git -C "$seed" branch -M main
     git -C "$seed" remote add origin "$BARE_ORIGIN"
@@ -341,33 +344,19 @@ EOF
     [[ "$output" != *"$wt_path"* ]]
 }
 
-@test "pr-worktree teardown: leaves a worktree with uncommitted changes in place" {
+@test "pr-worktree teardown: removes a worktree that is modified, deleted and untracked all at once" {
     run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
     [ "$status" -eq 0 ]
     local wt_path
     wt_path=$(echo "$output" | jq -r '.worktree_path')
 
-    # Simulate in-progress edits, e.g. a reviewer applying a suggested fix.
+    # Three dirty states in one checkout, each of which used to stop removal on
+    # its own: a modified tracked file (` M`), a staged deletion (`D `, the form
+    # a checkout that lost its index reports for every path), and an untracked
+    # file (`??`). None may stop removal, or the worktree becomes an orphan.
     echo "uncommitted edit" >> "$wt_path/file.txt"
-
-    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    [ -d "$wt_path" ]
-
-    run git -C "$CLONE_DIR" worktree list --porcelain
-    [[ "$output" == *"$wt_path"* ]]
-}
-
-@test "pr-worktree teardown: removes a worktree whose tracked files were deleted" {
-    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    local wt_path
-    wt_path=$(echo "$output" | jq -r '.worktree_path')
-
-    # An interrupted teardown (or an external cleaner) can delete the checkout
-    # while leaving the registration behind. Every tracked path then reports as
-    # deleted, which is not work anyone wants preserved.
-    rm -f "$wt_path/file.txt"
+    git -C "$wt_path" rm --quiet second.txt
+    echo "scratch notes" > "$wt_path/untracked.txt"
 
     run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
     [ "$status" -eq 0 ]
@@ -375,52 +364,6 @@ EOF
 
     run git -C "$CLONE_DIR" worktree list --porcelain
     [[ "$output" != *"$wt_path"* ]]
-}
-
-@test "pr-worktree teardown: removes a worktree whose deletions are staged" {
-    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    local wt_path
-    wt_path=$(echo "$output" | jq -r '.worktree_path')
-
-    # Losing the index reports every path as staged-deleted (`D `) rather than
-    # `` D``, so the filter has to cover both forms.
-    git -C "$wt_path" rm --quiet file.txt
-
-    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    [ ! -d "$wt_path" ]
-}
-
-@test "pr-worktree teardown: leaves a worktree with deletions plus an untracked file in place" {
-    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    local wt_path
-    wt_path=$(echo "$output" | jq -r '.worktree_path')
-
-    rm -f "$wt_path/file.txt"
-    echo "scratch notes" > "$wt_path/untracked.txt"
-
-    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    [ -d "$wt_path" ]
-    [ -f "$wt_path/untracked.txt" ]
-}
-
-@test "pr-worktree teardown: leaves a worktree with untracked files in place" {
-    run bash -c "'$SCRIPT' provision \"\$@\" 2>/dev/null" _ myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    local wt_path
-    wt_path=$(echo "$output" | jq -r '.worktree_path')
-
-    echo "scratch notes" > "$wt_path/untracked.txt"
-
-    run "$SCRIPT" teardown myorg myrepo 42 "$CLONE_DIR"
-    [ "$status" -eq 0 ]
-    [ -d "$wt_path" ]
-
-    run git -C "$CLONE_DIR" worktree list --porcelain
-    [[ "$output" == *"$wt_path"* ]]
 }
 
 # =============================================================================


### PR DESCRIPTION
`teardown` skipped removal when the checkout had modified or untracked files, so that in-progress edits were never destroyed. It could not actually protect them. `provision`'s reuse path force-removes and recreates a worktree whose checkout is too dirty to check out over, so anything the guard preserved was discarded at the next review of the same PR anyway. What skipping did do was leave the worktree on disk, and those leftovers are the accumulation `bin/setup` has to warn about.

These directories are orchestrator-owned scratch. Only `provision` creates them, always at `<org>/<repo>/pr-<N>` under the skill's worktree root, and always as a detached checkout of a PR head. Three guards keep teardown from reaching anything else: provision only runs when you are not already in the PR's repo, the cleanup hook exits early unless `local_clone` is set, and the hook validates that the stored path ends in the exact `<org>/<repo>/pr-<N>` leaf.

Teardown now removes unconditionally. The `git status` call and the `^( D|D )` filter are gone, and the file header records why.

This also moots a planned follow-up that would have let a declined teardown be retried on a later sweep. With no decline there is nothing to retry.

One thing worth a reviewer's attention: this changes when uncommitted work inside a review worktree is discarded. Before, teardown left it and the next provision of that PR destroyed it. Now teardown destroys it at session end.

## Test plan

- [x] `bin/test` green (unit and integration)
- [x] `bin/fmt` and `bin/lint` clean
- [x] New test verified red first against the old guard

The five state-dependent teardown tests collapse into one that puts a modified file (` M`), a staged deletion (`D `) and an untracked file (`??`) in the same checkout and asserts removal. The fixture gains a second tracked file so one path can carry the staged deletion while another stays modified. The porcelain codes were checked against real `git status` output rather than assumed.