### PR TITLE
Lint every shell script in the repo

### DIFF
--- a/bin/debug-cleanup
+++ b/bin/debug-cleanup
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312  # Command substitutions for counting/formatting are non-critical
 # debug-cleanup - Clean up old debug sessions from review-code
 #
 # Usage:

--- a/bin/helpers/_utils.sh
+++ b/bin/helpers/_utils.sh
@@ -29,7 +29,7 @@ set_source_and_root_dir() {
     { set +x; } 2>/dev/null
     source_dir="$(cd -P "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
     root_dir=$(cd "$source_dir" && cd ../ && pwd)
-    cd "$root_dir"
+    cd "$root_dir" || fatal "Could not change to root directory: $root_dir"
 }
 
 # Check if command exists
@@ -52,7 +52,7 @@ run_command() {
     local cmd="$1"
     local desc="${2:-Running command}"
     echo "→ $desc"
-    [ "$VERBOSE" ] && echo "  $cmd"
+    [[ -n "${VERBOSE:-}" ]] && echo "  $cmd"
     if ! eval "$cmd"; then
         error "Command failed: $cmd"
         return 1
@@ -65,7 +65,7 @@ require_commands() {
     for cmd in "$@"; do
         command_exists "$cmd" || missing+=("$cmd")
     done
-    [ ${#missing[@]} -eq 0 ] || fatal "Missing commands: ${missing[*]}"
+    [[ ${#missing[@]} -eq 0 ]] || fatal "Missing commands: ${missing[*]}"
 }
 
 # Show help from script comments

--- a/bin/lint
+++ b/bin/lint
@@ -17,11 +17,22 @@ if ! command_exists shellcheck; then
     fatal "shellcheck not found - install with: brew install shellcheck"
 fi
 
-# Find all shell scripts
+# Every shell script in the repo. This is a superset of bin/fmt's
+# files_to_format, which still misses bin/helpers, the session hooks, and
+# tests; aligning fmt means reformatting those files, so it is left for its own
+# change. Tests under tests/unit and tests/integration are .bats, a dialect
+# this tool cannot parse, so bin/test covers those instead.
 shell_files=(
     bin/*
-    lib/*.sh
-    lib/helpers/*.sh
+    bin/helpers/*.sh
+    skills/review-code/scripts/*.sh
+    skills/review-code/scripts/helpers/*.sh
+    skills/review-code/scripts/session-hooks/*.sh
+    evals/scripts/*.sh
+    evals/scripts/helpers/*.sh
+    tests/*.sh
+    tests/helpers/*.sh
+    tests/helpers/*.bash
     *.sh
 )
 
@@ -29,9 +40,11 @@ actual_files=()
 for pattern in "${shell_files[@]}"; do
     for file in ${pattern}; do
         if [[ -f "${file}" ]] && [[ ! "${file}" =~ \.md$ ]]; then
-            # Skip non-shell files
-            # shellcheck disable=SC2312  # head/grep failures indicate non-bash file (correct)
-            if [[ "${file}" == *.sh ]] || [[ -x "${file}" ]] && head -1 "${file}" | grep -q '^#!/.*bash'; then
+            # A .sh or .bash extension is enough on its own; the bats helpers
+            # under tests/ use .bash and are sourced, so they are never
+            # executable. Anything else has to declare a bash shebang, which is
+            # what keeps non-shell entries in bin/ out.
+            if [[ "${file}" == *.sh || "${file}" == *.bash ]] || { [[ -x "${file}" ]] && head -1 "${file}" | grep -q '^#!/.*bash'; }; then
                 actual_files+=("${file}")
             fi
         fi
@@ -45,11 +58,21 @@ fi
 
 print_color blue "Found ${#actual_files[@]} shell scripts"
 
-# Run shellcheck with strict settings
+# Run shellcheck with strict settings.
+#
+# -P SCRIPTDIR resolves `# shellcheck source=` directives relative to the script
+# being checked rather than the repo root, so -x actually follows the helpers
+# each script sources instead of silently giving up.
+#
 # Excluded checks:
 # - SC1091: Can't follow sourced files with dynamic paths
 # - SC2250: Optional style preference for universal variable bracing (too verbose)
-if ! run_command "shellcheck -x -o all -e SC1091,SC2250 ${actual_files[*]}" "Running shellcheck"; then
+# - SC2310, SC2312: Both fire on this codebase's ordinary idiom - functions
+#   called as conditionals, and command substitution for values whose failure
+#   yields an empty string the caller already handles. Every occurrence anyone
+#   has reviewed ended in a per-file disable with that same reason, so exclude
+#   them once here rather than repeating the directive in forty files.
+if ! run_command "shellcheck -x -o all -P SCRIPTDIR -e SC1091,SC2250,SC2310,SC2312 ${actual_files[*]}" "Running shellcheck"; then
     success_status=false
 fi
 

--- a/bin/setup
+++ b/bin/setup
@@ -417,7 +417,6 @@ merge_markdown_sections() {
     while IFS= read -r section; do
         [[ -z "${section}" ]] && continue
 
-        # shellcheck disable=SC2310 # has_section returning non-zero is expected behavior
         if ! has_section "${dst}" "${section}"; then
             # Section doesn't exist in destination - append it
             local section_content
@@ -449,7 +448,6 @@ process_context_file() {
     fi
 
     local was_deduped=false
-    # shellcheck disable=SC2310 # a 1 return (no duplicates found) is expected, not an error
     if dedupe_sections_in_place "${dst}"; then
         was_deduped=true
         debug "Removed duplicate section(s): ${display_name}"

--- a/bin/test
+++ b/bin/test
@@ -32,7 +32,6 @@ else
 fi
 
 # Run integration tests if they exist
-# shellcheck disable=SC2312  # ls failure means no tests (correct behavior)
 if [[ -d "${ROOT_DIR}/tests/integration" ]] && [[ -n "$(ls -A "${ROOT_DIR}/tests/integration"/*.bats 2> /dev/null)" ]]; then
     echo -e "${YELLOW}=== Integration Tests ===${NC}"
     if bats "${ROOT_DIR}/tests/integration/"*.bats; then

--- a/evals/scripts/helpers/eval-helpers.sh
+++ b/evals/scripts/helpers/eval-helpers.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2154  # EVALS_DIR and REGISTRY are set by the sourcing script (see header)
 # eval-helpers.sh - Shared helper functions for eval scripts
 #
 # Provides:

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -464,7 +464,7 @@ run_with_approach() {
         echo "${failed} benchmark(s) failed" >&2
     fi
 
-    return ${failed}
+    return "${failed}"
 }
 
 main() {
@@ -561,6 +561,10 @@ main() {
             benchmarks=("${all_ids[${idx}]}")
             echo "Sampled benchmark: ${benchmarks[0]}"
             echo ""
+            ;;
+        *)
+            echo "Error: unhandled mode '${mode}'." >&2
+            exit 1
             ;;
     esac
 

--- a/evals/scripts/score-eval.sh
+++ b/evals/scripts/score-eval.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # jq filters and sed scripts, evaluated by those tools
 # score-eval.sh - Score eval results against answer keys
 #
 # Usage:

--- a/skills/review-code/scripts/build-agent-briefing.sh
+++ b/skills/review-code/scripts/build-agent-briefing.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312  # sget failures yield empty strings, which the templates handle
-# shellcheck disable=SC2310  # sget is intentionally used in conditionals to test for presence
 set -euo pipefail
 
 # build-agent-briefing.sh - Render the shared reviewer briefing to files.
@@ -254,6 +252,7 @@ if [[ " ${AGENTS} " == *" frontend "* ]]; then
     # directory that also holds changed .tsx/.jsx. The directory-name list covers
     # the files that usually change alongside a component; a backend with no such
     # directories still matches nothing.
+    # shellcheck disable=SC2016  # git pathspecs, expanded by git and not the shell
     write_scoped_diff frontend '
         (.file_metadata.modified_files // []) as $files
         | ([$files[] | select(.path | test("\\.(tsx|jsx|vue|svelte)$")) | .path

--- a/skills/review-code/scripts/code-language-detect.sh
+++ b/skills/review-code/scripts/code-language-detect.sh
@@ -108,6 +108,7 @@ while IFS= read -r file; do
     # even when the hunk touches only a reducer or listener body. The content
     # patterns below miss that case: the kea import sits outside the hunk, and
     # useValues/useActions live in the component, not the logic file.
+    # shellcheck disable=SC2249  # a filename filter: most files match no arm, which is correct
     case "${file##*/}" in
         *Logic.ts | *Logic.tsx | logic.ts | logic.tsx)
             seen_frameworks[kea]=1
@@ -122,7 +123,6 @@ extensions=("${!seen_extensions[@]}")
 
 # Detect frameworks from file content in single pass
 # Use awk for single-pass pattern matching instead of 6 grep invocations
-# shellcheck disable=SC2312  # awk and sort failures are non-critical for framework detection
 while IFS= read -r framework; do
     case "${framework}" in
         react | kea)

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -121,6 +121,7 @@ create_pending_review() {
     local result error_output
     local tmpfile
     tmpfile=$(mktemp)
+    # shellcheck disable=SC2064  # expand tmpfile now so the trap removes this call's file
     trap "rm -f '${tmpfile}'" RETURN
 
     # Always use JSON format with comments array for consistency, whether

--- a/skills/review-code/scripts/get-review-diff.sh
+++ b/skills/review-code/scripts/get-review-diff.sh
@@ -13,7 +13,6 @@ set -euo pipefail
 source "${SCRIPT_DIR}/helpers/exclusion-patterns.sh"
 
 # Get common exclusion patterns (minimal set for review diffs)
-# shellcheck disable=SC2312  # get_exclusion_patterns failure will result in empty array
 mapfile -t EXCLUSIONS < <(get_exclusion_patterns common)
 
 # Get context lines from env or default to 1

--- a/skills/review-code/scripts/git-context.sh
+++ b/skills/review-code/scripts/git-context.sh
@@ -32,7 +32,6 @@ get_working_dir() {
 
 has_changes() {
     # Check if there are any staged or unstaged changes
-    # shellcheck disable=SC2312  # git status failure will result in empty string (correct)
     if [[ -n "$(git status --porcelain)" ]]; then
         echo "true"
     else

--- a/skills/review-code/scripts/git-diff-filter.sh
+++ b/skills/review-code/scripts/git-diff-filter.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
-# shellcheck disable=SC2312  # Command substitutions for counting are non-critical
 # Wrapper around git-diff-context.sh that filters out noise files from diffs
 # This reduces token usage by 85-95% for PRs with snapshots, lock files, and generated files
 #

--- a/skills/review-code/scripts/helpers/debug-helpers.sh
+++ b/skills/review-code/scripts/helpers/debug-helpers.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312  # Command substitutions for debugging/formatting are non-critical
 # Debug helpers for review-code
 # Provides utilities for capturing intermediate artifacts and command logs when DEBUG mode is enabled
 

--- a/skills/review-code/scripts/helpers/gh-wrapper.sh
+++ b/skills/review-code/scripts/helpers/gh-wrapper.sh
@@ -14,6 +14,7 @@ source "${_GH_WRAPPER_DIR}/cli-timeout-helpers.sh"
 
 if command -v gh > /dev/null 2>&1; then
     gh() {
+        # shellcheck disable=SC1007  # DEBUG= scrubs the variable for this command only
         DEBUG= command gh "$@"
     }
 fi

--- a/skills/review-code/scripts/helpers/meta-review-shared.sh
+++ b/skills/review-code/scripts/helpers/meta-review-shared.sh
@@ -78,6 +78,7 @@ parse_structured_response() {
     fi
 
     # If wrapped in markdown fences, strip them and try again
+    # shellcheck disable=SC2016  # sed scripts, not shell strings
     json_text=$(printf '%s' "${text}" | sed -n '/^```/,/^```/p' | sed '1d;$d')
     if [[ -n "${json_text}" ]] && printf '%s' "${json_text}" | jq -e '.validations and .missed_issues' > /dev/null 2>&1; then
         printf '%s' "${json_text}"

--- a/skills/review-code/scripts/learn-apply.sh
+++ b/skills/review-code/scripts/learn-apply.sh
@@ -134,6 +134,7 @@ main() {
 
         # Generate proposed content based on type
         local proposed_content=""
+        # shellcheck disable=SC2249  # an unrecognized learning type leaves proposed_content empty by design
         case "${type}" in
             "false_positive")
                 # Collect unique feedback patterns

--- a/skills/review-code/scripts/load-review-context.sh
+++ b/skills/review-code/scripts/load-review-context.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
-# shellcheck disable=SC2312  # Command substitutions for counting/formatting are non-critical
 # load-review-context.sh - Load language/framework/org/repo-specific review context
 # Requires: bash 4.0+ for associative arrays
 #

--- a/skills/review-code/scripts/log-token-usage.sh
+++ b/skills/review-code/scripts/log-token-usage.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312  # date failure here would be a broken system, not a case to branch on
 set -euo pipefail
 
 # log-token-usage.sh - Append one token-usage record to the central log.

--- a/skills/review-code/scripts/parse-review-arg.sh
+++ b/skills/review-code/scripts/parse-review-arg.sh
@@ -2,7 +2,6 @@
 # Parse and validate /review-code command arguments
 # Returns JSON with mode and validated parameters
 
-# shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,6 +32,10 @@ for arg_item in "$@"; do
     if [[ -n "${expect_value}" ]]; then
         case "${expect_value}" in
             parent) PARENT_OVERRIDE="${arg_item}" ;;
+            *)
+                echo "Error: no handler for value-taking flag '${expect_value}'." >&2
+                exit 1
+                ;;
         esac
         expect_value=""
         continue
@@ -600,7 +603,6 @@ detect_learn_mode() {
 # Returns: 0 if detected (outputs JSON), 1 if not detected
 detect_area_keyword() {
     [[ -z "${arg}" ]] && return 1
-    # shellcheck disable=SC2312  # contains function failure is handled by return check
     [[ "$(contains "${arg}" "${AREA_KEYWORDS[@]}")" -eq 0 ]] && return 1
 
     build_json_output "area" "area" "${arg}"
@@ -726,7 +728,6 @@ detect_no_arg() {
     fi
     # Check for uncommitted changes
     local has_uncommitted=false
-    # shellcheck disable=SC2312  # git status failure will result in empty string (correct behavior)
     if [[ -n "$(git status --porcelain)" ]]; then
         has_uncommitted=true
     fi

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # regex literals; $ and backslashes are ERE syntax, not shell expansions
 # parse-review-findings.sh - Extract structured findings from review markdown files
 #
 # Usage:

--- a/skills/review-code/scripts/pr-context.sh
+++ b/skills/review-code/scripts/pr-context.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
 # pr-context.sh - Fetch PR data using gh CLI
 #
 # Usage:
@@ -332,7 +331,6 @@ main() {
     body=$(echo "${body}" | jq -Rs . | jq -r .)
 
     # Output combined JSON
-    # shellcheck disable=SC2312  # jq failures for title/body sanitization are non-critical
     cat << EOF
 {
     "org": "${org}",

--- a/skills/review-code/scripts/resolve-review-threads.sh
+++ b/skills/review-code/scripts/resolve-review-threads.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016  # GraphQL documents; $var are GraphQL variables bound via --arg
 # resolve-review-threads.sh - List and resolve GitHub PR review threads
 #
 # Self-contained vendoring of the gh-resolve-threads utility so the
@@ -399,6 +400,10 @@ main() {
             id_array=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
             filtered=$(echo "$unresolved" | jq --argjson ids "$id_array" '[.[] | select(.commentId as $c | $ids | index($c) != null)]')
             label="matching"
+            ;;
+        *)
+            log_error "Unhandled filter mode '${FILTER_MODE}'."
+            exit 1
             ;;
     esac
 

--- a/skills/review-code/scripts/review-delta.sh
+++ b/skills/review-code/scripts/review-delta.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2312  # git probes are checked via explicit if/else, not exit-status chaining
 set -euo pipefail
 
 # review-delta.sh - Decide whether a re-review can look at only what changed.

--- a/skills/review-code/scripts/review-orchestrator.sh
+++ b/skills/review-code/scripts/review-orchestrator.sh
@@ -328,6 +328,7 @@ build_review_data() {
     mode_args_json=$(jq -n "$@" '$ARGS.named' 2> /dev/null || echo '{}')
     local commit_messages=""
     if [[ "${in_git_repo}" == "true" ]]; then
+        # shellcheck disable=SC2249  # modes without commit history leave commit_messages empty, which is correct
         case "${mode}" in
             "branch")
                 local cm_branch cm_base
@@ -648,6 +649,7 @@ Comparison: ${comparison}
 "
 
             local base_label=""
+            # shellcheck disable=SC2249  # an unmatched source leaves base_label empty, which the next if handles
             case "${base_source}" in
                 "pr-base") base_label="from PR base" ;;
                 "stack-parent") base_label="from stack parent" ;;

--- a/skills/review-code/scripts/session-clear-hook.sh
+++ b/skills/review-code/scripts/session-clear-hook.sh
@@ -33,7 +33,9 @@ log_line() {
     mkdir -p "$(dirname "${LOG_FILE}")"
     printf '%s | %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${msg}" >> "${LOG_FILE}"
     if [[ -f "${LOG_FILE}" ]]; then
-        tail -50 "${LOG_FILE}" > "${LOG_FILE}.tmp" 2> /dev/null && mv "${LOG_FILE}.tmp" "${LOG_FILE}" || true
+        if tail -50 "${LOG_FILE}" > "${LOG_FILE}.tmp" 2> /dev/null; then
+            mv "${LOG_FILE}.tmp" "${LOG_FILE}" 2> /dev/null || true
+        fi
     fi
 }
 

--- a/skills/review-code/scripts/session-hooks/review-code-cleanup.sh
+++ b/skills/review-code/scripts/session-hooks/review-code-cleanup.sh
@@ -44,7 +44,7 @@ IFS=$'\t' read -r wt_org wt_repo wt_pr wt_clone wt_path <<< "${jq_out}"
 expected_leaf=$(worktree_leaf_for "${wt_org}" "${wt_repo}" "${wt_pr}")
 [[ "${wt_path}" == /* && "${wt_path}" == *"/${expected_leaf}" ]] || exit 0
 
-wt_root="${wt_path%/${expected_leaf}}"
+wt_root="${wt_path%/"${expected_leaf}"}"
 [[ -n "${wt_root}" ]] || exit 0
 
 wt_script="${SCRIPT_DIR}/../pr-worktree.sh"

--- a/skills/review-code/scripts/session-manager.sh
+++ b/skills/review-code/scripts/session-manager.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck disable=SC2310  # Functions in conditionals intentionally check return values
-# shellcheck disable=SC2312  # Command substitutions for directory resolution are non-critical
 set -euo pipefail
 
 # Session Manager - Generic session state management for Claude Code slash commands
@@ -226,7 +224,9 @@ session_cleanup() {
     # provisioned worktree). Hooks are optional and keyed by command name; a
     # missing or non-executable hook is silently skipped. The hook must not
     # fail the cleanup, so all errors are swallowed.
-    local hook="$(dirname "${BASH_SOURCE[0]}")/session-hooks/${command_name}-cleanup.sh"
+    local hook_dir
+    hook_dir="$(dirname "${BASH_SOURCE[0]}")"
+    local hook="${hook_dir}/session-hooks/${command_name}-cleanup.sh"
     if [[ -f "${session_file}" && -x "${hook}" ]]; then
         "${hook}" "${session_file}" > /dev/null 2>&1 || true
     fi

--- a/tests/helpers/debug.sh
+++ b/tests/helpers/debug.sh
@@ -12,12 +12,12 @@ debug_test_env() {
     echo "OSTYPE: $OSTYPE" >&2
 
     # Check new config location
-    if [ -f "$HOME/.claude/skills/review-code/.env" ]; then
+    if [[ -f "$HOME/.claude/skills/review-code/.env" ]]; then
         echo "Config file exists at: $HOME/.claude/skills/review-code/.env" >&2
         echo "Config contents:" >&2
         cat "$HOME/.claude/skills/review-code/.env" >&2
     # Check old config location (for backward compatibility)
-    elif [ -f "$HOME/.claude/review-code.env" ]; then
+    elif [[ -f "$HOME/.claude/review-code.env" ]]; then
         echo "Config file exists at (old location): $HOME/.claude/review-code.env" >&2
         echo "Config contents:" >&2
         cat "$HOME/.claude/review-code.env" >&2
@@ -25,9 +25,9 @@ debug_test_env() {
         echo "No config file found" >&2
     fi
 
-    if [ -n "${CANONICAL_REVIEW_PATH:-}" ]; then
+    if [[ -n "${CANONICAL_REVIEW_PATH:-}" ]]; then
         echo "CANONICAL_REVIEW_PATH: $CANONICAL_REVIEW_PATH" >&2
-        echo "CANONICAL_REVIEW_PATH exists: $([ -d "$CANONICAL_REVIEW_PATH" ] && echo "yes" || echo "no")" >&2
+        echo "CANONICAL_REVIEW_PATH exists: $([[ -d "$CANONICAL_REVIEW_PATH" ]] && echo "yes" || echo "no")" >&2
     fi
 
     echo "Git config:" >&2

--- a/tests/test-zsh-compatibility.sh
+++ b/tests/test-zsh-compatibility.sh
@@ -55,7 +55,7 @@ echo ""
 echo "Test 4: Test has_frontend field extraction with null handling"
 mock_data='{"languages":null}'
 result=$(echo "$mock_data" | jq -r ".languages.has_frontend // false")
-if [ "$result" = "false" ]; then
+if [[ "$result" = "false" ]]; then
     echo "✓ PASS: Null languages field handled gracefully"
 else
     echo "✗ FAIL: Expected 'false', got: $result"
@@ -66,7 +66,7 @@ echo ""
 # Test 5: Test has_frontend with valid data
 echo "Test 5: Test has_frontend with valid languages data"
 result=$(echo "" | "$LIB_DIR/code-language-detect.sh" | jq -r ".has_frontend")
-if [ "$result" = "false" ]; then
+if [[ "$result" = "false" ]]; then
     echo "✓ PASS: has_frontend is false for empty diff"
 else
     echo "✗ FAIL: Expected 'false', got: $result"


### PR DESCRIPTION
`bin/lint`'s globs covered `bin/*`, `*.sh`, and two `lib/` paths that have never existed in this repo, so it checked 8 files. The other 67 (the scripts that make up the skill, the evals, `bin/helpers`, and the test helpers) were formatted by `bin/fmt` but never linted, and CI runs `bin/lint`. It now checks all 75.

Two of those are the bats helpers under `tests/helpers`. They use a `.bash` extension and are sourced rather than run, so they carry no executable bit. The file test accepts `.bash` alongside `.sh`; matching on the executable bit alone would have kept skipping them.

## Config changes

Turning the globs on surfaced 145 findings, so the config moved with them.

`-P SCRIPTDIR` resolves `# shellcheck source=` relative to the script being checked rather than the repo root, so `-x` follows each script's helpers instead of silently giving up and reporting their variables as unassigned. That alone cleared 6 `SC2154`s and an `SC2034`.

`SC2310` and `SC2312` are now excluded repo-wide. Both fire on ordinary idiom here: functions called as conditionals, and command substitution for a value whose failure yields an empty string the caller already handles. All 24 occurrences anyone had reviewed carried a per-file disable saying exactly that, so the exclusion states it once and those 24 directives are gone.

## Real fixes

`set_source_and_root_dir` ran against whatever directory it started in when `cd` failed, and every `bin/` script goes through it.

A worktree leaf containing a glob character would have been pattern-matched out of `wt_path` in the session cleanup hook.

The rest are quoting, and `[ ]` to `[[ ]]` in helpers and tests.

The three `case` statements dispatching on an internally-set mode grew a default arm that names the unhandled value. The four whose unmatched branch is already the intended behavior carry a disable saying which.

## Test plan

- [x] `bin/test` passes, 1612 assertions
- [x] `bin/fmt -c` clean
- [x] `bin/lint` green under shellcheck 0.11.0
- [x] `bin/lint` green under shellcheck 0.9.0, which is what CI's `apt-get install` provides on ubuntu-latest

The two shellcheck versions genuinely disagree, which is worth knowing now that lint covers 75 files instead of 8. 0.9.0 alone flagged `SC2015` in `session-clear-hook.sh`, now rewritten as an `if`. Both report zero findings over all 75 files.

To check the coverage claim: `bin/lint` prints "Found 75 shell scripts", and that matches every tracked file that either ends in `.sh` or `.bash` or carries a bash shebang.

## Not in this change

`bin/fmt` still misses `bin/helpers`, the session hooks, and `tests`. Aligning its globs reformats 87 lines in files this change does not otherwise touch, so it is left for its own commit.

https://claude.ai/code/session_015SDcYARRktEj5mpnqPNVJZ