### PR TITLE
Pin shellcheck to v0.11.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,10 @@ jobs:
         git config --global user.email "ci@github.com"
         git config --global user.name "GitHub CI"
 
-        # Install system dependencies
-        sudo apt-get update
-        sudo apt-get install -y shellcheck
+        # Install shellcheck 0.11.0 (apt has older 0.9.0, which reports different findings under bin/lint's -o all)
+        SHELLCHECK_VERSION="0.11.0"
+        curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJ -C /tmp
+        sudo install -m 755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
 
         # Install jq 1.7.1 (apt has older 1.6 which has syntax incompatibilities)
         JQ_VERSION="1.7.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
         # Install shellcheck 0.11.0 (apt has older 0.9.0, which reports different findings under bin/lint's -o all)
         SHELLCHECK_VERSION="0.11.0"
-        curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJ -C /tmp
+        curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" | tar -xJf - -C /tmp
         sudo install -m 755 "/tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
 
         # Install jq 1.7.1 (apt has older 1.6 which has syntax incompatibilities)


### PR DESCRIPTION
CI installed shellcheck from apt on ubuntu-latest, which is 0.9.0, while a brew-current dev machine has 0.11.0. The two versions genuinely disagree under `bin/lint`'s `-o all` config: 0.9.0 flagged an SC2015 in `session-clear-hook.sh` that 0.11.0 does not report at all. That one is already fixed so both are green today, but #138 took lint coverage from 8 files to 75, so the surface for a red CI that a dev cannot reproduce locally grew about ninefold.

This downloads the pinned release binary instead, in the same shape as the jq step directly below it. The whole apt block goes rather than just the install line, because shellcheck was the only package in it and `apt-get update` had nothing left to do.

0.11.0 is both the latest upstream release and what brew currently ships, so CI and a brew-current dev now agree without pinning ahead of upstream.

## Test plan

- [x] `bin/lint` green under local shellcheck 0.11.0, 75 files
- [x] `bin/test` passes
- [x] `tar -tJf` on the real tarball confirms the nested `shellcheck-v0.11.0/shellcheck` path the install line uses

The `shellcheck --version` echo in the verification step is unchanged, and that is what confirms the binary runs on the runner and wins the PATH race. `/usr/local/bin` precedes `/usr/bin`, the same mechanism the jq step already relies on.

## Not in this change

No checksum verification. The jq step this mirrors does not do it either, and adding it only here would make the two steps diverge. `bin/README.md`'s `brew install shellcheck` line also stays, since brew is how a dev gets 0.11.0 in the first place.

https://claude.ai/code/session_01SAv3sg4k4vZeupnhbvLaHi