### PR TITLE
Merge delta re-reviews into the review file without reading it

### DIFF
--- a/skills/review-code/handlers/review-carry-forward.md
+++ b/skills/review-code/handlers/review-carry-forward.md
@@ -16,9 +16,10 @@ Follow `review-compose.md` as written, with three changes:
 2. Open it with `# Re-review at <first 7 of pr.head_sha>` instead of the usual title, followed by one line saying what the delta covered and that findings on files it did not touch are kept above. Everything below that heading keeps the normal shape, `## Security Review` and the rest at H2, because that is what the next re-review parses.
 3. Leave out the metadata header. The script moves the existing one forward: `review_commit` to this run's head, `reviewed_at`, `review_mode: delta`, and `delta_from`. The `scope` and `token_usage` blocks in that header stay as the earlier run left them; report this run's usage to the user as usual and log it with `log-token-usage.sh`.
 
-In PR mode the Suggested Comments section belongs in the same file. Compose it at
-its usual point in the flow (see `review-pr-output.md`), then write
-`review-append.md` once, with everything in it, and run the merge below.
+In PR mode the Suggested Comments section goes into `review-append.md` too.
+Write the file at the compose step rather than holding the composed document
+across the intervening turns, and append that section to it when you reach it.
+Run the merge below once the file is complete.
 
 ## Merge it in
 
@@ -34,17 +35,18 @@ its usual point in the flow (see `review-pr-output.md`), then write
 The script cuts the previous review's findings on files the delta touched, since
 the agents have just re-derived those against the new code, keeps every other
 finding with its body untouched, appends what you composed, and advances the
-header. It prints counts and the identity of each carried finding (agent, file,
-line) and never a description, which is what keeps this step cheap.
+header. It prints counts and flags only, never finding bodies, which is what
+keeps this step cheap.
 
 ## Tell the user what happened
 
-Say how many findings carried forward and how many were re-derived. Three fields
+Say how many findings carried forward and how many were re-derived. Four fields
 need saying out loud when they are not the happy path:
 
 - `pruned: false` with a `prune_reason`: nothing was cut, so the document now lists the previous findings on changed files next to the new ones. Say so plainly; the user is about to read a review with duplicates in it.
 - `kept_unattributed`: findings the parser could not tie to a file. They are kept deliberately. A delta review only looks at changed files, so dropping one would lose it for good rather than have an agent re-derive it.
 - `kept_undeletable`: findings on changed files whose extent in the document could not be determined safely. Same reasoning, kept rather than guessed at.
+- `header_updated: false`: the document had no metadata header to advance, so this run's head SHA was not recorded anywhere. The next re-review has no point to compute a delta from and falls back to a full review. Say it: the saving is gone until someone puts a header back.
 
 Carry-forward is conservative in one direction worth a line in the review itself:
 a change in one file can invalidate a finding about a file the delta never

--- a/skills/review-code/handlers/review-carry-forward.md
+++ b/skills/review-code/handlers/review-carry-forward.md
@@ -1,0 +1,51 @@
+# Handler: Carry Findings Forward (Delta Re-review)
+
+Loaded at the compose step when `$review_mode` is `delta`. Kept out of `review.md`
+because it applies to re-reviews only.
+
+**Do not Read the previous review document.** `carry-forward-findings.sh` merges
+this run into it on disk. Reading it would hold the whole document (median ~12KB,
+p90 ~30KB across saved reviews) in this conversation for every remaining turn, on
+the run that exists to be the cheap one.
+
+## Compose into an append file
+
+Follow `review-compose.md` as written, with three changes:
+
+1. Write the document to `<artifacts_dir>/review-append.md` (Write tool, new file), not to `$review_file`.
+2. Open it with `# Re-review at <first 7 of pr.head_sha>` instead of the usual title, followed by one line saying what the delta covered and that findings on files it did not touch are kept above. Everything below that heading keeps the normal shape, `## Security Review` and the rest at H2, because that is what the next re-review parses.
+3. Leave out the metadata header. The script moves the existing one forward: `review_commit` to this run's head, `reviewed_at`, `review_mode: delta`, and `delta_from`. The `scope` and `token_usage` blocks in that header stay as the earlier run left them; report this run's usage to the user as usual and log it with `log-token-usage.sh`.
+
+In PR mode the Suggested Comments section belongs in the same file. Compose it at
+its usual point in the flow (see `review-pr-output.md`), then write
+`review-append.md` once, with everything in it, and run the merge below.
+
+## Merge it in
+
+```bash
+~/.claude/skills/review-code/scripts/carry-forward-findings.sh \
+  --review-file "<file_info.file_path>" \
+  --delta-diff "<diff_path from review-delta.sh>" \
+  --append-file "<artifacts_dir>/review-append.md" \
+  --head-sha "<pr.head_sha>" \
+  --delta-from "$delta_from"
+```
+
+The script cuts the previous review's findings on files the delta touched, since
+the agents have just re-derived those against the new code, keeps every other
+finding with its body untouched, appends what you composed, and advances the
+header. It prints counts and the identity of each carried finding (agent, file,
+line) and never a description, which is what keeps this step cheap.
+
+## Tell the user what happened
+
+Say how many findings carried forward and how many were re-derived. Three fields
+need saying out loud when they are not the happy path:
+
+- `pruned: false` with a `prune_reason`: nothing was cut, so the document now lists the previous findings on changed files next to the new ones. Say so plainly; the user is about to read a review with duplicates in it.
+- `kept_unattributed`: findings the parser could not tie to a file. They are kept deliberately. A delta review only looks at changed files, so dropping one would lose it for good rather than have an agent re-derive it.
+- `kept_undeletable`: findings on changed files whose extent in the document could not be determined safely. Same reasoning, kept rather than guessed at.
+
+Carry-forward is conservative in one direction worth a line in the review itself:
+a change in one file can invalidate a finding about a file the delta never
+touched, and that finding still carries forward.

--- a/skills/review-code/handlers/review-compose.md
+++ b/skills/review-code/handlers/review-compose.md
@@ -57,7 +57,7 @@ diff_tokens: <diff_tokens from session data>
 
 The `token_usage` block records per-step token consumption (agents, context explorer, validators, and other steps) and the aggregate total. Always include the `total` field as the sum of all steps in `$token_usage`.
 
-This metadata is used by the learning system to determine when the review was created. The `review_commit` field records the PR's HEAD SHA at review time, enabling drift detection when creating draft reviews later and giving the next re-review the point to compute its delta from. On `--append`, update the existing header in place; a second header would leave the stale SHA first in the file, where `review-delta.sh` reads it. The `diff_tokens` field is an estimated token count of the diff (~4 chars per token).
+This metadata is used by the learning system to determine when the review was created. The `review_commit` field records the PR's HEAD SHA at review time, enabling drift detection when creating draft reviews later and giving the next re-review the point to compute its delta from. On `--append`, update the existing header in place; a second header would leave the stale SHA first in the file, where `review-delta.sh` reads it. On the `delta` path the merge script writes the header, so skip it (see below). The `diff_tokens` field is an estimated token count of the diff (~4 chars per token).
 
 If `mode` is `branch` and `base_source` is not `"default"`, add a scope note directly under the metadata header (before the Fix Summary and any chunked "Review Scope" note) so the reader can tell at a glance what the diff was compared against:
 
@@ -70,6 +70,8 @@ An Overview paragraph in the right register reads like:
 > Adds a soft-hide for stale suggestion names. The new boolean ships in an additive migration, the GET returns hidden names separately, and hide/restore is admin-gated. The hidden row and any flags using it are preserved, so hiding is reversible.
 
 **Gate the Overview.** The voice agent never sees narrative prose, so after drafting the Overview paragraph, send it through the comprehension gate as a one-item batch: invoke the Task tool with subagent_type `comprehension-gate` and the array `[{"id": 1, "severity": "overview", "location": null, "description": "<overview text>", "proposed_fix": null, "kind": "prose"}]` in a four-backtick `json` fence. On `REWRITE`, you wrote this paragraph, so apply the notes yourself: lead with what the change does, one idea per sentence. Re-check the rewritten paragraph at most once, then proceed with your best version regardless of the second verdict. On any error or malformed response, keep the drafted Overview (fail open). Record usage in `$token_usage["comprehension-gate-overview"]`. In debug mode, save the stage `11e-overview-gate` artifacts (see `review-debug.md`).
+
+**On the `delta` path** (`$review_mode` is `delta`), everything above still governs what you compose, but not where it goes: Read `~/.claude/skills/review-code/handlers/review-carry-forward.md` and follow it instead of saving over `$review_file`. Do not Read the existing review.
 
 Save the complete review to `$review_file` and inform the user with a clickable file link:
 

--- a/skills/review-code/handlers/review-pr-output.md
+++ b/skills/review-code/handlers/review-pr-output.md
@@ -129,7 +129,7 @@ List findings where existing comments are sufficient:
 | Already covered | Z |
 ```
 
-5. **Append to review file**: Add the "Suggested Comments" section after the main review content.
+5. **Append to review file**: Add the "Suggested Comments" section after the main review content. On the `delta` path it goes into the append file instead, alongside the rest of what this run composed (see `review-carry-forward.md`).
 
 6. **Display summary to user**: After saving, show:
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -119,7 +119,7 @@ Read `mode` from the JSON it prints:
 
 **Advance the recorded SHA.** `review_commit` in the metadata header must end up at the head this run actually reviewed. If it keeps the old value, the next re-review computes its delta from the original SHA and the saving disappears after one round. On `--append`, update the existing header rather than adding a second one.
 
-**Carrying findings forward.** On the `delta` path, Read `~/.claude/skills/review-code/handlers/review-carry-forward.md` at the compose step and follow it. A script merges this run's sections into the existing review, cuts the previous findings on files the delta touched so the agents' fresh ones stand alone, and advances the header. Never Read the previous review document: its bodies are the cost the delta path exists to avoid.
+**Carrying findings forward.** On the `delta` path the compose step loads `review-carry-forward.md`, which merges this run's sections into the existing review on disk, cuts the previous findings on files the delta touched so the agents' fresh ones stand alone, and advances the header. Never Read the previous review document: its bodies are the cost the delta path exists to avoid.
 
 ### Classify Review Scope
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -117,9 +117,9 @@ Read `mode` from the JSON it prints:
 
 **Always tell the user which path this took, and for `full`, the `reason` the script gave.** A silent fallback looks identical to a delta review that found nothing, and the difference matters: a full re-review costs what it always did.
 
-**Advance the recorded SHA.** When composing the review, `review_commit` in the metadata header must be set to the head this run actually reviewed. If it keeps the old value, the next re-review computes its delta from the original SHA and the saving disappears after one round. On `--append`, update the existing header rather than adding a second one.
+**Advance the recorded SHA.** `review_commit` in the metadata header must end up at the head this run actually reviewed. If it keeps the old value, the next re-review computes its delta from the original SHA and the saving disappears after one round. On `--append`, update the existing header rather than adding a second one.
 
-**Carrying findings forward.** On the `delta` path, parse the previous review's findings and carry forward only those whose file the delta does not touch. Findings in files the delta changed are dropped and re-derived by the agents against the new code. This is deliberately conservative and it has a known limit worth stating in the review: a change in one file can invalidate a finding about a file the delta never touched. Record `review_mode: delta` and `delta_from: <sha>` in the review's metadata header so every carried-forward finding is traceable to the SHA it was derived at.
+**Carrying findings forward.** On the `delta` path, Read `~/.claude/skills/review-code/handlers/review-carry-forward.md` at the compose step and follow it. A script merges this run's sections into the existing review, cuts the previous findings on files the delta touched so the agents' fresh ones stand alone, and advances the header. Never Read the previous review document: its bodies are the cost the delta path exists to avoid.
 
 ### Classify Review Scope
 

--- a/skills/review-code/scripts/carry-forward-findings.sh
+++ b/skills/review-code/scripts/carry-forward-findings.sh
@@ -226,7 +226,7 @@ awk -v head_sha="${HEAD_SHA}" -v reviewed_at="${REVIEWED_AT}" \
     -v delta_from="${DELTA_FROM}" '
     BEGIN { in_meta = 0; done_meta = 0 }
     {
-        if (!done_meta && !in_meta && $0 ~ /review-metadata/) {
+        if (!done_meta && !in_meta && $0 ~ /^<!-- review-metadata/) {
             in_meta = 1
             print
             next

--- a/skills/review-code/scripts/carry-forward-findings.sh
+++ b/skills/review-code/scripts/carry-forward-findings.sh
@@ -20,16 +20,15 @@ set -euo pipefail
 #   --append-file <path>  Markdown to append after the carried-forward content
 #   --head-sha <sha>      New review_commit for the metadata header
 #   --delta-from <sha>    Recorded as delta_from in the metadata header
-#   --reviewed-at <iso>   Header timestamp (default: now, UTC)
 #   --dry-run             Report what would happen; change nothing
 #
-# Output: a JSON object on stdout. It carries finding identity (agent, file,
-# line) and never a description, which is the whole point: identity is small,
-# bodies are not.
+# Output: a JSON object on stdout. Counts and flags only, plus the list of files
+# whose findings were cut, which is bounded by the delta. No finding bodies and
+# no per-finding array: this output lands in the orchestrator's conversation and
+# stays there for the rest of the run.
 #   {"review_file": "...", "carried": 7, "dropped": 3, "kept_unattributed": 1,
 #    "kept_undeletable": 0, "delta_files": 2, "pruned": true, "appended": true,
-#    "header_updated": true, "dropped_files": ["a.py"],
-#    "carried_findings": [{"agent": "security", "file": "b.py", "line": 45}]}
+#    "header_updated": true, "dropped_files": ["a.py"]}
 #
 # Safety: after cutting, the pruned document is re-parsed and its findings must
 # match the set that was meant to survive. On any mismatch the cut is abandoned
@@ -47,7 +46,6 @@ DELTA_DIFF=""
 APPEND_FILE=""
 HEAD_SHA=""
 DELTA_FROM=""
-REVIEWED_AT=""
 DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
@@ -70,10 +68,6 @@ while [[ $# -gt 0 ]]; do
             ;;
         --delta-from)
             DELTA_FROM="${2:-}"
-            shift 2
-            ;;
-        --reviewed-at)
-            REVIEWED_AT="${2:-}"
             shift 2
             ;;
         --dry-run)
@@ -108,61 +102,67 @@ if [[ -n "${APPEND_FILE}" && ! -f "${APPEND_FILE}" ]]; then
     exit 1
 fi
 
-REVIEWED_AT="${REVIEWED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+REVIEWED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "${WORK_DIR}"' EXIT
 
 # ------------------------------------------------------------- the delta's files
-# Both sides of each header are taken: a rename or a delete names the old path.
+# Read from the "diff --git a/OLD b/NEW" header rather than the ---/+++ lines,
+# which git omits for a pure rename and for a mode-only change. Both sides are
+# taken: a finding recorded before a rename cites the old path. Matching on
+# " b/" with its leading space is the same idiom as chunk-diff.sh and
+# split-diff-by-path.sh, and for the same reason: a last-field split would
+# truncate any path containing a space.
 extract_delta_files() {
-    sed -n -e 's/^--- a\///p' -e 's/^+++ b\///p' "${DELTA_DIFF}" \
-        | grep -v '^/dev/null$' \
-        | sed 's/[[:space:]]*$//' \
-        | grep -v '^$' \
-        | sort -u
+    awk '
+        /^diff --git / {
+            if (match($0, / b\//)) {
+                old = substr($0, 14, RSTART - 14)
+                new = substr($0, RSTART + 3)
+                if (old != "") print old
+                if (new != "") print new
+            }
+        }
+    ' "${DELTA_DIFF}" | sort -u
 }
 
 DELTA_FILES_TXT="${WORK_DIR}/delta-files.txt"
 extract_delta_files > "${DELTA_FILES_TXT}"
 DELTA_FILES_JSON=$(jq -R -s 'split("\n") | map(select(length > 0))' < "${DELTA_FILES_TXT}")
-DELTA_FILE_COUNT=$(jq 'length' <<< "${DELTA_FILES_JSON}")
 
 # ------------------------------------------------------------------- classify
-FINDINGS=$("${SCRIPT_DIR}/parse-review-findings.sh" --with-spans "${REVIEW_FILE}")
-
 # A finding belongs to the delta when the paths match outright, or when the
 # review cited a bare filename that matches a delta file's basename. Nothing
 # looser: a fuzzy match drops a finding no agent will re-derive.
-CLASSIFIED=$(jq -c --argjson touched "${DELTA_FILES_JSON}" '
-    ($touched | map(split("/") | last)) as $bases
-    | [ .[] as $f
-        | $f + { touched: (
-            $f.file != ""
-            and (
-                ($touched | index($f.file)) != null
-                or (($f.file | contains("/") | not) and ($bases | index($f.file)) != null)
-            )
-        ) } ]
-' <<< "${FINDINGS}")
+#
+# One pass emits the three partitions the rest of the script needs; the counts
+# are read off them at output time rather than tallied into variables here.
+CLASSIFIED=$("${SCRIPT_DIR}/parse-review-findings.sh" --with-spans "${REVIEW_FILE}" \
+    | jq -c --argjson touched "${DELTA_FILES_JSON}" '
+        ($touched | map(split("/") | last)) as $bases
+        | [ .[] as $f
+            | $f + { touched: (
+                $f.file != ""
+                and (
+                    ($touched | index($f.file)) != null
+                    or (($f.file | contains("/") | not) and ($bases | index($f.file)) != null)
+                )
+            ) } ]
+        | { dropped: [ .[] | select(.touched and .deletable) ],
+            kept_undeletable: [ .[] | select(.touched and (.deletable | not)) ],
+            carried: [ .[] | select(.touched | not) ] }')
 
-DELETABLE=$(jq -c '[ .[] | select(.touched and .deletable) ]' <<< "${CLASSIFIED}")
-KEPT_UNDELETABLE=$(jq -c '[ .[] | select(.touched and (.deletable | not)) ]' <<< "${CLASSIFIED}")
-CARRIED=$(jq -c '[ .[] | select(.touched | not) ]' <<< "${CLASSIFIED}")
+RANGES=$(jq -r '[ .dropped[] | select(.start_line > 0 and .end_line >= .start_line)
+    | "\(.start_line)-\(.end_line)" ] | join(",")' <<< "${CLASSIFIED}")
 
-DROPPED_COUNT=$(jq 'length' <<< "${DELETABLE}")
-KEPT_UNDELETABLE_COUNT=$(jq 'length' <<< "${KEPT_UNDELETABLE}")
-CARRIED_COUNT=$(jq 'length' <<< "${CARRIED}")
-UNATTRIBUTED_COUNT=$(jq '[ .[] | select(.file == "") ] | length' <<< "${CARRIED}")
-
-RANGES=$(jq -r '[ .[] | select(.start_line > 0 and .end_line >= .start_line)
-    | "\(.start_line)-\(.end_line)" ] | join(",")' <<< "${DELETABLE}")
-
-# Identity of everything that must still be there once the cut is made.
+# What must still be there once the cut is made. The description is part of it:
+# comparing {agent, file, line} alone would pass on a cut that left a dropped
+# finding's trailing prose behind for a surviving finding to absorb, which is
+# the exact failure this check exists to catch.
 identity() {
-    jq -S -c '[ .[] | {agent, file, line} ] | sort'
+    jq -S -c '[ .[] | {agent, file, line, description} ] | sort'
 }
-EXPECTED=$(jq -c -s 'add' <<< "${CARRIED}"$'\n'"${KEPT_UNDELETABLE}" | identity)
 
 # ----------------------------------------------------------------------- prune
 PRUNED_FILE="${WORK_DIR}/pruned.md"
@@ -170,9 +170,11 @@ PRUNE_REASON=""
 PRUNED=false
 
 if [[ -z "${RANGES}" ]]; then
-    cp "${REVIEW_FILE}" "${PRUNED_FILE}"
+    # Nothing to cut, so the original stands as the base the append lands on.
+    PRUNED_FILE="${REVIEW_FILE}"
     PRUNE_REASON="no findings on the delta's files"
 else
+    EXPECTED=$(jq -c '.carried + .kept_undeletable' <<< "${CLASSIFIED}" | identity)
     # Cut each finding's lines, then swallow the blank lines it left behind so
     # exactly one blank separates the neighbours it stood between.
     awk -v ranges="${RANGES}" '
@@ -207,18 +209,18 @@ else
     if [[ "${ACTUAL}" == "${EXPECTED}" ]]; then
         PRUNED=true
     else
-        cp "${REVIEW_FILE}" "${PRUNED_FILE}"
+        PRUNED_FILE="${REVIEW_FILE}"
         PRUNE_REASON="the pruned document did not re-parse to the expected findings; kept every finding instead"
     fi
 fi
 
 # --------------------------------------------------------------- header, append
 OUT_FILE="${WORK_DIR}/out.md"
-HEADER_UPDATED=false
 
-if grep -q 'review-metadata' "${REVIEW_FILE}"; then
-    HEADER_UPDATED=true
-fi
+# The awk below is the only thing that knows whether a header was actually
+# advanced, so it reports that itself rather than having a grep guess at it
+# over a different file.
+HEADER_UPDATED=true
 
 awk -v head_sha="${HEAD_SHA}" -v reviewed_at="${REVIEWED_AT}" \
     -v delta_from="${DELTA_FROM}" '
@@ -263,7 +265,8 @@ awk -v head_sha="${HEAD_SHA}" -v reviewed_at="${REVIEWED_AT}" \
         }
         print
     }
-' "${PRUNED_FILE}" > "${OUT_FILE}"
+    END { exit(done_meta ? 0 : 1) }
+' "${PRUNED_FILE}" > "${OUT_FILE}" || HEADER_UPDATED=false
 
 APPENDED=false
 if [[ -n "${APPEND_FILE}" ]]; then
@@ -283,29 +286,23 @@ fi
 jq -nc \
     --arg review_file "${REVIEW_FILE}" \
     --arg prune_reason "${PRUNE_REASON}" \
-    --argjson carried "${CARRIED_COUNT}" \
-    --argjson dropped "${DROPPED_COUNT}" \
-    --argjson kept_unattributed "${UNATTRIBUTED_COUNT}" \
-    --argjson kept_undeletable "${KEPT_UNDELETABLE_COUNT}" \
-    --argjson delta_files "${DELTA_FILE_COUNT}" \
+    --argjson classified "${CLASSIFIED}" \
+    --argjson delta_files_list "${DELTA_FILES_JSON}" \
     --argjson pruned "${PRUNED}" \
     --argjson appended "${APPENDED}" \
     --argjson header_updated "${HEADER_UPDATED}" \
     --argjson dry_run "${DRY_RUN}" \
-    --argjson dropped_list "${DELETABLE}" \
-    --argjson carried_list "${CARRIED}" \
     '{
         review_file: $review_file,
-        carried: $carried,
-        dropped: $dropped,
-        kept_unattributed: $kept_unattributed,
-        kept_undeletable: $kept_undeletable,
-        delta_files: $delta_files,
+        carried: ($classified.carried | length),
+        dropped: ($classified.dropped | length),
+        kept_unattributed: ([ $classified.carried[] | select(.file == "") ] | length),
+        kept_undeletable: ($classified.kept_undeletable | length),
+        delta_files: ($delta_files_list | length),
         pruned: $pruned,
         appended: $appended,
         header_updated: $header_updated,
         dry_run: $dry_run,
-        dropped_files: ($dropped_list | map(.file) | unique),
-        carried_findings: ($carried_list | map({agent, file, line}))
+        dropped_files: ($classified.dropped | map(.file) | unique)
     }
     + (if $prune_reason != "" then {prune_reason: $prune_reason} else {} end)'

--- a/skills/review-code/scripts/carry-forward-findings.sh
+++ b/skills/review-code/scripts/carry-forward-findings.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# carry-forward-findings.sh - Update a review document in place after a delta review.
+#
+# A delta re-review looks only at the files that changed since the last pass, so
+# the earlier review's findings on untouched files are still good and its
+# findings on touched files have just been re-derived. Merging those two by hand
+# means the orchestrator reads the old document (median 11.7KB, p90 29.7KB) and
+# writes it back out, on the run that is supposed to be the cheap one. This does
+# the merge on disk instead: the old bodies never enter a conversation.
+#
+# The work is: cut the findings whose file the delta touched, append whatever the
+# run composed, and move the metadata header forward to the SHA just reviewed.
+#
+# Usage:
+#   carry-forward-findings.sh --review-file <path> --delta-diff <path> [options]
+#
+# Options:
+#   --append-file <path>  Markdown to append after the carried-forward content
+#   --head-sha <sha>      New review_commit for the metadata header
+#   --delta-from <sha>    Recorded as delta_from in the metadata header
+#   --reviewed-at <iso>   Header timestamp (default: now, UTC)
+#   --dry-run             Report what would happen; change nothing
+#
+# Output: a JSON object on stdout. It carries finding identity (agent, file,
+# line) and never a description, which is the whole point: identity is small,
+# bodies are not.
+#   {"review_file": "...", "carried": 7, "dropped": 3, "kept_unattributed": 1,
+#    "kept_undeletable": 0, "delta_files": 2, "pruned": true, "appended": true,
+#    "header_updated": true, "dropped_files": ["a.py"],
+#    "carried_findings": [{"agent": "security", "file": "b.py", "line": 45}]}
+#
+# Safety: after cutting, the pruned document is re-parsed and its findings must
+# match the set that was meant to survive. On any mismatch the cut is abandoned
+# and the original content is kept ("pruned": false, with a reason). A review
+# that still lists a stale finding is a nuisance; one whose bodies got spliced
+# together is a liability.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=helpers/error-helpers.sh
+source "${SCRIPT_DIR}/helpers/error-helpers.sh"
+
+REVIEW_FILE=""
+DELTA_DIFF=""
+APPEND_FILE=""
+HEAD_SHA=""
+DELTA_FROM=""
+REVIEWED_AT=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --review-file)
+            REVIEW_FILE="${2:-}"
+            shift 2
+            ;;
+        --delta-diff)
+            DELTA_DIFF="${2:-}"
+            shift 2
+            ;;
+        --append-file)
+            APPEND_FILE="${2:-}"
+            shift 2
+            ;;
+        --head-sha)
+            HEAD_SHA="${2:-}"
+            shift 2
+            ;;
+        --delta-from)
+            DELTA_FROM="${2:-}"
+            shift 2
+            ;;
+        --reviewed-at)
+            REVIEWED_AT="${2:-}"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        *)
+            error "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "${REVIEW_FILE}" ]]; then
+    error "--review-file is required"
+    exit 1
+fi
+if [[ ! -f "${REVIEW_FILE}" ]]; then
+    error "Review file not found: ${REVIEW_FILE}"
+    exit 1
+fi
+if [[ -z "${DELTA_DIFF}" ]]; then
+    error "--delta-diff is required"
+    exit 1
+fi
+if [[ ! -f "${DELTA_DIFF}" ]]; then
+    error "Delta diff not found: ${DELTA_DIFF}"
+    exit 1
+fi
+if [[ -n "${APPEND_FILE}" && ! -f "${APPEND_FILE}" ]]; then
+    error "Append file not found: ${APPEND_FILE}"
+    exit 1
+fi
+
+REVIEWED_AT="${REVIEWED_AT:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+# ------------------------------------------------------------- the delta's files
+# Both sides of each header are taken: a rename or a delete names the old path.
+extract_delta_files() {
+    sed -n -e 's/^--- a\///p' -e 's/^+++ b\///p' "${DELTA_DIFF}" \
+        | grep -v '^/dev/null$' \
+        | sed 's/[[:space:]]*$//' \
+        | grep -v '^$' \
+        | sort -u
+}
+
+DELTA_FILES_TXT="${WORK_DIR}/delta-files.txt"
+extract_delta_files > "${DELTA_FILES_TXT}"
+DELTA_FILES_JSON=$(jq -R -s 'split("\n") | map(select(length > 0))' < "${DELTA_FILES_TXT}")
+DELTA_FILE_COUNT=$(jq 'length' <<< "${DELTA_FILES_JSON}")
+
+# ------------------------------------------------------------------- classify
+FINDINGS=$("${SCRIPT_DIR}/parse-review-findings.sh" --with-spans "${REVIEW_FILE}")
+
+# A finding belongs to the delta when the paths match outright, or when the
+# review cited a bare filename that matches a delta file's basename. Nothing
+# looser: a fuzzy match drops a finding no agent will re-derive.
+CLASSIFIED=$(jq -c --argjson touched "${DELTA_FILES_JSON}" '
+    ($touched | map(split("/") | last)) as $bases
+    | [ .[] as $f
+        | $f + { touched: (
+            $f.file != ""
+            and (
+                ($touched | index($f.file)) != null
+                or (($f.file | contains("/") | not) and ($bases | index($f.file)) != null)
+            )
+        ) } ]
+' <<< "${FINDINGS}")
+
+DELETABLE=$(jq -c '[ .[] | select(.touched and .deletable) ]' <<< "${CLASSIFIED}")
+KEPT_UNDELETABLE=$(jq -c '[ .[] | select(.touched and (.deletable | not)) ]' <<< "${CLASSIFIED}")
+CARRIED=$(jq -c '[ .[] | select(.touched | not) ]' <<< "${CLASSIFIED}")
+
+DROPPED_COUNT=$(jq 'length' <<< "${DELETABLE}")
+KEPT_UNDELETABLE_COUNT=$(jq 'length' <<< "${KEPT_UNDELETABLE}")
+CARRIED_COUNT=$(jq 'length' <<< "${CARRIED}")
+UNATTRIBUTED_COUNT=$(jq '[ .[] | select(.file == "") ] | length' <<< "${CARRIED}")
+
+RANGES=$(jq -r '[ .[] | select(.start_line > 0 and .end_line >= .start_line)
+    | "\(.start_line)-\(.end_line)" ] | join(",")' <<< "${DELETABLE}")
+
+# Identity of everything that must still be there once the cut is made.
+identity() {
+    jq -S -c '[ .[] | {agent, file, line} ] | sort'
+}
+EXPECTED=$(jq -c -s 'add' <<< "${CARRIED}"$'\n'"${KEPT_UNDELETABLE}" | identity)
+
+# ----------------------------------------------------------------------- prune
+PRUNED_FILE="${WORK_DIR}/pruned.md"
+PRUNE_REASON=""
+PRUNED=false
+
+if [[ -z "${RANGES}" ]]; then
+    cp "${REVIEW_FILE}" "${PRUNED_FILE}"
+    PRUNE_REASON="no findings on the delta's files"
+else
+    # Cut each finding's lines, then swallow the blank lines it left behind so
+    # exactly one blank separates the neighbours it stood between.
+    awk -v ranges="${RANGES}" '
+        BEGIN {
+            n = split(ranges, parts, ",")
+            for (i = 1; i <= n; i++) {
+                split(parts[i], se, "-")
+                start[i] = se[1] + 0
+                end[i] = se[2] + 0
+            }
+            swallow = 0
+        }
+        {
+            cut = 0
+            for (i = 1; i <= n; i++) {
+                if (NR >= start[i] && NR <= end[i]) {
+                    cut = 1
+                    if (NR == end[i]) swallow = 1
+                    break
+                }
+            }
+            if (cut) next
+            if (swallow) {
+                if ($0 ~ /^[[:space:]]*$/) next
+                swallow = 0
+            }
+            print
+        }
+    ' "${REVIEW_FILE}" > "${PRUNED_FILE}"
+
+    ACTUAL=$("${SCRIPT_DIR}/parse-review-findings.sh" "${PRUNED_FILE}" | identity)
+    if [[ "${ACTUAL}" == "${EXPECTED}" ]]; then
+        PRUNED=true
+    else
+        cp "${REVIEW_FILE}" "${PRUNED_FILE}"
+        PRUNE_REASON="the pruned document did not re-parse to the expected findings; kept every finding instead"
+    fi
+fi
+
+# --------------------------------------------------------------- header, append
+OUT_FILE="${WORK_DIR}/out.md"
+HEADER_UPDATED=false
+
+if grep -q 'review-metadata' "${REVIEW_FILE}"; then
+    HEADER_UPDATED=true
+fi
+
+awk -v head_sha="${HEAD_SHA}" -v reviewed_at="${REVIEWED_AT}" \
+    -v delta_from="${DELTA_FROM}" '
+    BEGIN { in_meta = 0; done_meta = 0 }
+    {
+        if (!done_meta && !in_meta && $0 ~ /review-metadata/) {
+            in_meta = 1
+            print
+            next
+        }
+        if (in_meta) {
+            if ($0 ~ /^[[:space:]]*-->/) {
+                if (head_sha != "" && !seen_commit) print "review_commit: " head_sha
+                if (!seen_reviewed) print "reviewed_at: " reviewed_at
+                if (!seen_mode) print "review_mode: delta"
+                if (delta_from != "" && !seen_from) print "delta_from: " delta_from
+                in_meta = 0
+                done_meta = 1
+                print
+                next
+            }
+            if (head_sha != "" && $0 ~ /^review_commit:/) {
+                print "review_commit: " head_sha
+                seen_commit = 1
+                next
+            }
+            if ($0 ~ /^reviewed_at:/) {
+                print "reviewed_at: " reviewed_at
+                seen_reviewed = 1
+                next
+            }
+            if ($0 ~ /^review_mode:/) {
+                print "review_mode: delta"
+                seen_mode = 1
+                next
+            }
+            if (delta_from != "" && $0 ~ /^delta_from:/) {
+                print "delta_from: " delta_from
+                seen_from = 1
+                next
+            }
+        }
+        print
+    }
+' "${PRUNED_FILE}" > "${OUT_FILE}"
+
+APPENDED=false
+if [[ -n "${APPEND_FILE}" ]]; then
+    printf '\n---\n\n' >> "${OUT_FILE}"
+    cat "${APPEND_FILE}" >> "${OUT_FILE}"
+    APPENDED=true
+fi
+
+if [[ "${DRY_RUN}" == false ]]; then
+    # Same directory, so the rename is atomic: a reader sees the old document or
+    # the new one, never a half-written merge.
+    TARGET_TMP="${REVIEW_FILE}.carry-forward.$$"
+    cp "${OUT_FILE}" "${TARGET_TMP}"
+    mv "${TARGET_TMP}" "${REVIEW_FILE}"
+fi
+
+jq -nc \
+    --arg review_file "${REVIEW_FILE}" \
+    --arg prune_reason "${PRUNE_REASON}" \
+    --argjson carried "${CARRIED_COUNT}" \
+    --argjson dropped "${DROPPED_COUNT}" \
+    --argjson kept_unattributed "${UNATTRIBUTED_COUNT}" \
+    --argjson kept_undeletable "${KEPT_UNDELETABLE_COUNT}" \
+    --argjson delta_files "${DELTA_FILE_COUNT}" \
+    --argjson pruned "${PRUNED}" \
+    --argjson appended "${APPENDED}" \
+    --argjson header_updated "${HEADER_UPDATED}" \
+    --argjson dry_run "${DRY_RUN}" \
+    --argjson dropped_list "${DELETABLE}" \
+    --argjson carried_list "${CARRIED}" \
+    '{
+        review_file: $review_file,
+        carried: $carried,
+        dropped: $dropped,
+        kept_unattributed: $kept_unattributed,
+        kept_undeletable: $kept_undeletable,
+        delta_files: $delta_files,
+        pruned: $pruned,
+        appended: $appended,
+        header_updated: $header_updated,
+        dry_run: $dry_run,
+        dropped_files: ($dropped_list | map(.file) | unique),
+        carried_findings: ($carried_list | map({agent, file, line}))
+    }
+    + (if $prune_reason != "" then {prune_reason: $prune_reason} else {} end)'

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -57,9 +57,9 @@ save_finding() {
     local file="$3"
     local line="$4"
     local desc="$5"
-    local start="${6:-0}"
-    local end="${7:-0}"
-    local deletable="${8:-false}"
+    local start="$6"
+    local end="$7"
+    local deletable="$8"
 
     desc=$(echo "${desc}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
     local entry
@@ -68,10 +68,10 @@ save_finding() {
         --arg file "${file}" \
         --arg line "${line}" \
         --arg desc "${desc}" \
-        --arg start "${start}" \
-        --arg end "${end}" \
-        --arg deletable "${deletable}" \
-        --arg spans "${WITH_SPANS}" \
+        --argjson start "${start}" \
+        --argjson end "${end}" \
+        --argjson deletable "${deletable}" \
+        --argjson spans "${WITH_SPANS}" \
         '{
             agent: $agent,
             confidence: ($conf | tonumber),
@@ -79,12 +79,30 @@ save_finding() {
             line: ($line | tonumber),
             description: $desc
         }
-        + (if $spans == "true" then {
-            start_line: ($start | tonumber),
-            end_line: ($end | tonumber),
-            deletable: ($deletable == "true")
+        + (if $spans then {
+            start_line: $start,
+            end_line: $end,
+            deletable: $deletable
         } else {} end)')
     findings_jsonl+="${entry}"$'\n'
+}
+
+# Open a finding block at the current line.
+# Args: $1=deletable (default true; false when the opener is body text, where
+#       the finding's extent is a guess no caller may cut on)
+begin_finding() {
+    in_finding=true
+    finding_start="${lineno}"
+    finding_end=0
+    finding_deletable="${1:-true}"
+}
+
+# Append one body line to the pending finding's description. Both the in-fence
+# and the ordinary accumulation path go through here so the two cannot drift.
+# Once the span has ended the finding is over, so nothing more is taken.
+append_description() {
+    [[ "${finding_end}" -eq 0 ]] || return 0
+    finding_description="${finding_description:+${finding_description} }$1"
 }
 
 # Flush any pending finding to the findings array
@@ -98,7 +116,7 @@ flush_pending_finding() {
             end="${prev_nonblank}"
         fi
         save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file:-}" "${finding_line:-0}" "${finding_description}" \
-            "${finding_start:-0}" "${end}" "${finding_deletable:-false}"
+            "${finding_start}" "${end}" "${finding_deletable}"
     fi
 }
 
@@ -185,7 +203,9 @@ main() {
             fi
         fi
 
-        if [[ "${fence_depth}" -eq 0 ]] && [[ "${is_fence_line}" == false ]] \
+        # No fence delimiter can also match block_break_re: one is a run of
+        # backticks or tildes, the other of #, - or *.
+        if [[ "${fence_depth}" -eq 0 ]] \
             && [[ "${line}" =~ ${block_break_re} ]] \
             && [[ "${in_finding}" == true ]] && [[ "${finding_end}" -eq 0 ]]; then
             finding_end="${prev_nonblank}"
@@ -199,11 +219,7 @@ main() {
             # Inside a code block only description accumulation applies, and it
             # skips lines starting with `#` exactly as it always has.
             if [[ "${in_finding}" == true ]] && [[ -n "${line}" ]] && [[ ! "${line}" =~ ^# ]]; then
-                if [[ -n "${finding_description}" ]]; then
-                    finding_description="${finding_description} ${line}"
-                else
-                    finding_description="${line}"
-                fi
+                append_description "${line}"
             fi
             continue
         fi
@@ -231,10 +247,7 @@ main() {
             finding_line="${BASH_REMATCH[3]}"
             finding_description=""
             current_confidence=""
-            in_finding=true
-            finding_start="${lineno}"
-            finding_end=0
-            finding_deletable=true
+            begin_finding
             continue
         fi
 
@@ -248,10 +261,7 @@ main() {
             finding_line=""
             finding_description="${BASH_REMATCH[1]}"
             current_confidence=""
-            in_finding=true
-            finding_start="${lineno}"
-            finding_end=0
-            finding_deletable=true
+            begin_finding
             continue
         fi
 
@@ -272,10 +282,7 @@ main() {
             finding_description="${BASH_REMATCH[2]}"
             finding_file=""
             finding_line="0"
-            in_finding=true
-            finding_start="${lineno}"
-            finding_end=0
-            finding_deletable=true
+            begin_finding
             continue
         fi
 
@@ -328,12 +335,7 @@ main() {
             finding_line="${BASH_REMATCH[2]}"
             finding_description=""
             current_confidence=""
-            in_finding=true
-            finding_start="${lineno}"
-            finding_end=0
-            # The opener is body text rather than a heading, so where this
-            # finding ends is a guess. Report it, never let a caller cut on it.
-            finding_deletable=false
+            begin_finding false
             continue
         fi
 
@@ -371,11 +373,7 @@ main() {
             if [[ "${line}" =~ ^\[([0-9]+)%\]$ ]] || [[ "${line}" =~ ^\(([0-9]+)%[[:space:]]*confidence\)$ ]]; then
                 continue
             fi
-            if [[ -n "${finding_description}" ]]; then
-                finding_description="${finding_description} ${line}"
-            else
-                finding_description="${line}"
-            fi
+            append_description "${line}"
         fi
     done < "${review_file}"
 

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -61,7 +61,14 @@ save_finding() {
     local end="$7"
     local deletable="$8"
 
-    desc=$(echo "${desc}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
+    # Truncated for the orchestrator, which only needs enough to identify a
+    # finding. Not under --with-spans: carry-forward-findings.sh compares whole
+    # descriptions to catch a cut that spliced one finding's prose onto
+    # another, and a truncated one hides any splice past the cutoff.
+    desc=$(echo "${desc}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    if [[ "${WITH_SPANS}" != "true" ]]; then
+        desc=$(echo "${desc}" | head -c 500)
+    fi
     local entry
     entry=$(jq -nc --arg agent "${agent}" \
         --arg conf "${conf}" \

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -3,7 +3,7 @@
 # parse-review-findings.sh - Extract structured findings from review markdown files
 #
 # Usage:
-#   parse-review-findings.sh <review-file-path>
+#   parse-review-findings.sh [--with-spans] <review-file-path>
 #
 # Description:
 #   Parses a code review markdown file and extracts structured findings.
@@ -11,6 +11,12 @@
 #   - File:line references in headers: #### `path/to/file.py:123`
 #   - Confidence markers: [Security 85%], (75% confidence)
 #   - Agent section headers: ## Security Review, ## Performance Review
+#
+# Options:
+#   --with-spans  Add the line range each finding occupies in the file, plus
+#                 whether that range is safe to cut. carry-forward-findings.sh
+#                 uses it to prune a review in place without the document
+#                 entering a conversation.
 #
 # Output:
 #   JSON array of findings:
@@ -23,6 +29,13 @@
 #       "description": "SQL injection risk"
 #     }
 #   ]
+#
+#   With --with-spans, each finding also carries:
+#     "start_line": 12, "end_line": 30, "deletable": true
+#   `start_line` is the finding's opening line and `end_line` the last non-blank
+#   line before the next heading or thematic break. `deletable` is false when the
+#   opener is not a heading (a `**Location**:` line, say), where the extent is a
+#   guess and cutting on it could take a sibling's text along.
 
 set -euo pipefail
 
@@ -31,8 +44,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Source error helpers
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 
+WITH_SPANS=false
+
 # Append a finding as a single JSONL line.
-# Args: $1=agent, $2=confidence, $3=file, $4=line, $5=description
+# Args: $1=agent, $2=confidence, $3=file, $4=line, $5=description,
+#       $6=start_line, $7=end_line, $8=deletable
 # Uses: findings_jsonl variable (must be in scope)
 # Modifies: findings_jsonl variable
 save_finding() {
@@ -41,6 +57,9 @@ save_finding() {
     local file="$3"
     local line="$4"
     local desc="$5"
+    local start="${6:-0}"
+    local end="${7:-0}"
+    local deletable="${8:-false}"
 
     desc=$(echo "${desc}" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -c 500)
     local entry
@@ -49,13 +68,22 @@ save_finding() {
         --arg file "${file}" \
         --arg line "${line}" \
         --arg desc "${desc}" \
+        --arg start "${start}" \
+        --arg end "${end}" \
+        --arg deletable "${deletable}" \
+        --arg spans "${WITH_SPANS}" \
         '{
             agent: $agent,
             confidence: ($conf | tonumber),
             file: $file,
             line: ($line | tonumber),
             description: $desc
-        }')
+        }
+        + (if $spans == "true" then {
+            start_line: ($start | tonumber),
+            end_line: ($end | tonumber),
+            deletable: ($deletable == "true")
+        } else {} end)')
     findings_jsonl+="${entry}"$'\n'
 }
 
@@ -64,15 +92,34 @@ save_finding() {
 #   finding_line, current_agent, current_confidence, findings
 flush_pending_finding() {
     if [[ "${in_finding}" == true ]] && [[ -n "${finding_description}" ]]; then
-        save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file:-}" "${finding_line:-0}" "${finding_description}"
+        local end="${finding_end}"
+        # A finding that never met a heading runs to the last non-blank line seen.
+        if [[ "${end}" -eq 0 ]]; then
+            end="${prev_nonblank}"
+        fi
+        save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file:-}" "${finding_line:-0}" "${finding_description}" \
+            "${finding_start:-0}" "${end}" "${finding_deletable:-false}"
     fi
 }
 
 main() {
-    local review_file="${1:-}"
+    local review_file=""
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --with-spans)
+                WITH_SPANS=true
+                shift
+                ;;
+            *)
+                review_file="$1"
+                shift
+                ;;
+        esac
+    done
 
     if [[ -z "${review_file}" ]]; then
-        error "Usage: parse-review-findings.sh <review-file-path>"
+        error "Usage: parse-review-findings.sh [--with-spans] <review-file-path>"
         exit 1
     fi
 
@@ -89,6 +136,13 @@ main() {
     local finding_file=""
     local finding_line=""
     local finding_description=""
+    local finding_start=0
+    local finding_end=0
+    local finding_deletable=false
+    local lineno=0
+    local prev_nonblank=0
+    local fence_depth=0
+    local fence_stack=()
 
     # H3/H4 finding header with optional numbering and optional backticks
     # around the path:line token (see Pattern 1 below). Kept in variables
@@ -99,8 +153,61 @@ main() {
     # Standalone location line under a prose-titled finding: `path/file.sh:14`
     # or `path/file.sh:73-74`
     local standalone_loc_re='^`([^:`]+):([0-9]+)(-[0-9]+)?`[[:space:]]*$'
+    # Fenced code block delimiter, with the marker run and whatever follows it
+    # captured separately. Nesting is counted rather than toggled: this repo's
+    # own finding format puts a ```suggestion block inside a ```text body, which
+    # a strict CommonMark toggle reads as a close followed by an open, and every
+    # heading after it then looks like code.
+    local fence_re='^[[:space:]]{0,3}(`{3,}|~{3,})(.*)$'
+    # A heading or thematic break ends the finding block above it.
+    local block_break_re='^(#{1,6}([[:space:]]|$)|-{3,}[[:space:]]*$|\*{3,}[[:space:]]*$)'
 
     while IFS= read -r line || [[ -n "${line}" ]]; do
+        lineno=$((lineno + 1))
+
+        # Track fenced code blocks. A `#` inside one is a comment, not a
+        # heading, and a finding pattern inside one is an example, not a finding.
+        # A delimiter carrying an info string (```suggestion) always opens a
+        # block; a bare delimiter closes the innermost open block, or opens one
+        # when nothing is open.
+        local is_fence_line=false
+        if [[ "${line}" =~ ${fence_re} ]]; then
+            local fence_char="${BASH_REMATCH[1]:0:1}"
+            local fence_rest="${BASH_REMATCH[2]}"
+            is_fence_line=true
+            if [[ "${fence_rest}" =~ ^[[:space:]]*$ ]] && [[ "${fence_depth}" -gt 0 ]] \
+                && [[ "${fence_stack[$((fence_depth - 1))]}" == "${fence_char}" ]]; then
+                unset 'fence_stack[fence_depth-1]'
+                fence_depth=$((fence_depth - 1))
+            else
+                fence_stack[fence_depth]="${fence_char}"
+                fence_depth=$((fence_depth + 1))
+            fi
+        fi
+
+        if [[ "${fence_depth}" -eq 0 ]] && [[ "${is_fence_line}" == false ]] \
+            && [[ "${line}" =~ ${block_break_re} ]] \
+            && [[ "${in_finding}" == true ]] && [[ "${finding_end}" -eq 0 ]]; then
+            finding_end="${prev_nonblank}"
+        fi
+
+        if [[ -n "${line}" ]]; then
+            prev_nonblank="${lineno}"
+        fi
+
+        if [[ "${fence_depth}" -gt 0 ]] || [[ "${is_fence_line}" == true ]]; then
+            # Inside a code block only description accumulation applies, and it
+            # skips lines starting with `#` exactly as it always has.
+            if [[ "${in_finding}" == true ]] && [[ -n "${line}" ]] && [[ ! "${line}" =~ ^# ]]; then
+                if [[ -n "${finding_description}" ]]; then
+                    finding_description="${finding_description} ${line}"
+                else
+                    finding_description="${line}"
+                fi
+            fi
+            continue
+        fi
+
         # Detect agent section headers (## Security Review, ## Performance Review, etc.)
         if [[ "${line}" =~ ^##[[:space:]]+(Security|Performance|Correctness|Maintainability|Testing|Compatibility|Architecture|Frontend)[[:space:]]+Review ]]; then
             flush_pending_finding
@@ -125,6 +232,9 @@ main() {
             finding_description=""
             current_confidence=""
             in_finding=true
+            finding_start="${lineno}"
+            finding_end=0
+            finding_deletable=true
             continue
         fi
 
@@ -139,6 +249,9 @@ main() {
             finding_description="${BASH_REMATCH[1]}"
             current_confidence=""
             in_finding=true
+            finding_start="${lineno}"
+            finding_end=0
+            finding_deletable=true
             continue
         fi
 
@@ -160,6 +273,9 @@ main() {
             finding_file=""
             finding_line="0"
             in_finding=true
+            finding_start="${lineno}"
+            finding_end=0
+            finding_deletable=true
             continue
         fi
 
@@ -193,7 +309,8 @@ main() {
             fi
 
             # This pattern includes the description inline, so save it immediately
-            save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file}" "${finding_line}" "${finding_description}"
+            save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file}" "${finding_line}" "${finding_description}" \
+                "${lineno}" "${lineno}" true
 
             finding_file=""
             finding_line=""
@@ -212,6 +329,11 @@ main() {
             finding_description=""
             current_confidence=""
             in_finding=true
+            finding_start="${lineno}"
+            finding_end=0
+            # The opener is body text rather than a heading, so where this
+            # finding ends is a guess. Report it, never let a caller cut on it.
+            finding_deletable=false
             continue
         fi
 
@@ -227,7 +349,8 @@ main() {
             finding_line="${BASH_REMATCH[5]}"
 
             # Save this finding immediately (inline pattern)
-            save_finding "${agent_name}" "${current_confidence}" "${finding_file}" "${finding_line}" "${finding_description}"
+            save_finding "${agent_name}" "${current_confidence}" "${finding_file}" "${finding_line}" "${finding_description}" \
+                "${lineno}" "${lineno}" true
 
             finding_file=""
             finding_line=""

--- a/tests/unit/test-carry-forward-findings.bats
+++ b/tests/unit/test-carry-forward-findings.bats
@@ -107,11 +107,15 @@ teardown() {
     grep -q "Typo in the heading." "$TEST_DIR/review.md"
 }
 
-@test "carry-forward-findings.sh: reports carried findings by identity, never by body" {
+@test "carry-forward-findings.sh: reports counts, never finding bodies" {
     run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
     [ "$status" -eq 0 ]
-    echo "$output" | jq -e '[.carried_findings[] | keys] | flatten | unique == ["agent", "file", "line"]' > /dev/null
+    # stdout lands in the orchestrator's conversation, so it stays small: counts,
+    # flags, and the cut files, with no per-finding array and no bodies.
     [[ "$output" != *"Missing input validation"* ]]
+    [[ "$output" != *"constant time"* ]]
+    echo "$output" | jq -e 'has("carried_findings") | not' > /dev/null
+    echo "$output" | jq -e '[paths(type == "array") ] | length == 1' > /dev/null
 }
 
 @test "carry-forward-findings.sh: appends the composed sections after a separator" {
@@ -128,25 +132,24 @@ teardown() {
 
 @test "carry-forward-findings.sh: advances the metadata header" {
     run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
-        --head-sha bbbbbbb --delta-from aaaaaaa --reviewed-at 2026-08-19T12:00:00Z
+        --head-sha bbbbbbb --delta-from aaaaaaa
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.header_updated == true' > /dev/null
     grep -q "^review_commit: bbbbbbb$" "$TEST_DIR/review.md"
-    grep -q "^reviewed_at: 2026-08-19T12:00:00Z$" "$TEST_DIR/review.md"
+    grep -qE '^reviewed_at: [0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' "$TEST_DIR/review.md"
     grep -q "^review_mode: delta$" "$TEST_DIR/review.md"
     grep -q "^delta_from: aaaaaaa$" "$TEST_DIR/review.md"
     [ "$(grep -c '^review_commit:' "$TEST_DIR/review.md")" -eq 1 ]
 }
 
 @test "carry-forward-findings.sh: --dry-run leaves the review file alone" {
-    before=$(md5 -q "$TEST_DIR/review.md" 2> /dev/null || md5sum "$TEST_DIR/review.md" | cut -d' ' -f1)
+    cp "$TEST_DIR/review.md" "$TEST_DIR/before.md"
     run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
         --append-file "$TEST_DIR/append.md" --head-sha bbbbbbb --dry-run
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.dry_run == true' > /dev/null
     echo "$output" | jq -e '.dropped == 1' > /dev/null
-    after=$(md5 -q "$TEST_DIR/review.md" 2> /dev/null || md5sum "$TEST_DIR/review.md" | cut -d' ' -f1)
-    [ "$before" = "$after" ]
+    cmp -s "$TEST_DIR/before.md" "$TEST_DIR/review.md"
 }
 
 @test "carry-forward-findings.sh: keeps findings it cannot tie to a file" {
@@ -240,7 +243,9 @@ EOF
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.pruned == true' > /dev/null
     # the finding round one appended is attributed and carried, not orphaned
-    echo "$output" | jq -e '[.carried_findings[] | select(.file == "src/auth.py" and .line == 47 and .agent == "security")] | length == 1' > /dev/null
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '[.[] | select(.file == "src/auth.py" and .line == 47 and .agent == "security")] | length == 1' > /dev/null
     grep -q "the fallback path still leaks length" "$TEST_DIR/review.md"
     ! grep -q "Missing input validation" "$TEST_DIR/review.md"
     grep -q "^review_commit: ccccccc$" "$TEST_DIR/review.md"
@@ -259,4 +264,23 @@ EOF
     echo "$output" | jq -e '.dropped == 0' > /dev/null
     echo "$output" | jq -e '.carried == 3' > /dev/null
     echo "$output" | jq -e '.prune_reason == "no findings on the delta'"'"'s files"' > /dev/null
+}
+
+@test "carry-forward-findings.sh: a pure rename counts as a touched file" {
+    # git writes no ---/+++ lines for a rename with no content change, so the
+    # delta's files come from the "diff --git a/OLD b/NEW" header, both sides:
+    # a finding recorded before the rename cites the old path.
+    cat > "$TEST_DIR/rename.patch" << 'EOF'
+diff --git a/src/auth.py b/src/authentication.py
+similarity index 100%
+rename from src/auth.py
+rename to src/authentication.py
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/rename.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.delta_files == 2' > /dev/null
+    echo "$output" | jq -e '.dropped == 1' > /dev/null
+    echo "$output" | jq -e '.dropped_files == ["src/auth.py"]' > /dev/null
+    ! grep -q "constant time" "$TEST_DIR/review.md"
+    grep -q "Missing input validation" "$TEST_DIR/review.md"
 }

--- a/tests/unit/test-carry-forward-findings.bats
+++ b/tests/unit/test-carry-forward-findings.bats
@@ -1,0 +1,262 @@
+#!/usr/bin/env bats
+# Tests for carry-forward-findings.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/carry-forward-findings.sh"
+    export SCRIPT
+
+    TEST_DIR=$(mktemp -d)
+    export TEST_DIR
+
+    cat > "$TEST_DIR/review.md" << 'EOF'
+<!-- review-metadata
+reviewed_at: 2026-08-01T10:00:00Z
+mode: pr
+pr_number: 42
+review_commit: aaaaaaa
+-->
+
+# Pull Request Review: #42 - Add a thing
+
+## Security Review
+
+#### `src/auth.py:45`
+
+Token comparison is not constant time, so a remote attacker can time it.
+
+```bash
+# this comment must not look like a heading
+compare a b
+```
+
+#### `src/untouched.py:10`
+
+Missing input validation on the forwarded header.
+
+## Testing Review
+
+### Nits
+
+#### `docs/readme.md:3`
+
+Typo in the heading.
+EOF
+
+    cat > "$TEST_DIR/delta.patch" << 'EOF'
+diff --git a/src/auth.py b/src/auth.py
+--- a/src/auth.py
++++ b/src/auth.py
+@@ -40,6 +40,7 @@
+ unchanged
+EOF
+
+    cat > "$TEST_DIR/append.md" << 'EOF'
+# Re-review at deadbee
+
+## Security Review
+
+#### `src/auth.py:47`
+
+The compare is fixed, the fallback path still leaks length.
+EOF
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+@test "carry-forward-findings.sh: exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "carry-forward-findings.sh: requires a review file" {
+    run "$SCRIPT" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--review-file is required"* ]]
+}
+
+@test "carry-forward-findings.sh: requires a delta diff" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--delta-diff is required"* ]]
+}
+
+@test "carry-forward-findings.sh: errors when the review file is missing" {
+    run "$SCRIPT" --review-file "$TEST_DIR/nope.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not found"* ]]
+}
+
+@test "carry-forward-findings.sh: cuts findings on files the delta touched" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.pruned == true' > /dev/null
+    echo "$output" | jq -e '.dropped == 1' > /dev/null
+    echo "$output" | jq -e '.dropped_files == ["src/auth.py"]' > /dev/null
+    ! grep -q "constant time" "$TEST_DIR/review.md"
+    ! grep -q "must not look like a heading" "$TEST_DIR/review.md"
+}
+
+@test "carry-forward-findings.sh: keeps findings on files the delta left alone, bodies intact" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.carried == 2' > /dev/null
+    grep -q "Missing input validation on the forwarded header." "$TEST_DIR/review.md"
+    grep -q "Typo in the heading." "$TEST_DIR/review.md"
+}
+
+@test "carry-forward-findings.sh: reports carried findings by identity, never by body" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '[.carried_findings[] | keys] | flatten | unique == ["agent", "file", "line"]' > /dev/null
+    [[ "$output" != *"Missing input validation"* ]]
+}
+
+@test "carry-forward-findings.sh: appends the composed sections after a separator" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
+        --append-file "$TEST_DIR/append.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.appended == true' > /dev/null
+    grep -q "^# Re-review at deadbee" "$TEST_DIR/review.md"
+    grep -q "^---$" "$TEST_DIR/review.md"
+    # the appended section lands after the carried-forward content
+    [ "$(grep -n 'Typo in the heading' "$TEST_DIR/review.md" | cut -d: -f1)" -lt \
+      "$(grep -n 'Re-review at deadbee' "$TEST_DIR/review.md" | cut -d: -f1)" ]
+}
+
+@test "carry-forward-findings.sh: advances the metadata header" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
+        --head-sha bbbbbbb --delta-from aaaaaaa --reviewed-at 2026-08-19T12:00:00Z
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.header_updated == true' > /dev/null
+    grep -q "^review_commit: bbbbbbb$" "$TEST_DIR/review.md"
+    grep -q "^reviewed_at: 2026-08-19T12:00:00Z$" "$TEST_DIR/review.md"
+    grep -q "^review_mode: delta$" "$TEST_DIR/review.md"
+    grep -q "^delta_from: aaaaaaa$" "$TEST_DIR/review.md"
+    [ "$(grep -c '^review_commit:' "$TEST_DIR/review.md")" -eq 1 ]
+}
+
+@test "carry-forward-findings.sh: --dry-run leaves the review file alone" {
+    before=$(md5 -q "$TEST_DIR/review.md" 2> /dev/null || md5sum "$TEST_DIR/review.md" | cut -d' ' -f1)
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
+        --append-file "$TEST_DIR/append.md" --head-sha bbbbbbb --dry-run
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.dry_run == true' > /dev/null
+    echo "$output" | jq -e '.dropped == 1' > /dev/null
+    after=$(md5 -q "$TEST_DIR/review.md" 2> /dev/null || md5sum "$TEST_DIR/review.md" | cut -d' ' -f1)
+    [ "$before" = "$after" ]
+}
+
+@test "carry-forward-findings.sh: keeps findings it cannot tie to a file" {
+    cat > "$TEST_DIR/unattributed.md" << 'EOF'
+<!-- review-metadata
+review_commit: aaaaaaa
+-->
+
+## Security Review
+
+### 1. The rate limiter has no ceiling
+
+Nothing bounds the retry count, so a client can hold the worker open.
+
+#### `src/auth.py:45`
+
+Token comparison is not constant time.
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/unattributed.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.kept_unattributed == 1' > /dev/null
+    grep -q "Nothing bounds the retry count" "$TEST_DIR/unattributed.md"
+    ! grep -q "Token comparison is not constant time" "$TEST_DIR/unattributed.md"
+}
+
+@test "carry-forward-findings.sh: keeps touched findings whose extent is a guess" {
+    cat > "$TEST_DIR/location.md" << 'EOF'
+<!-- review-metadata
+review_commit: aaaaaaa
+-->
+
+## Security Review
+
+**Location**: `src/auth.py:45`
+
+Token comparison is not constant time.
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/location.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.kept_undeletable == 1' > /dev/null
+    echo "$output" | jq -e '.dropped == 0' > /dev/null
+    grep -q "Token comparison is not constant time" "$TEST_DIR/location.md"
+}
+
+@test "carry-forward-findings.sh: abandons the cut when the pruned document reparses differently" {
+    # The second finding stays open past `## Notes` and takes its file from
+    # there. Cutting it hands that line to the first finding, which changes what
+    # the first finding is about, so nothing may be cut.
+    cat > "$TEST_DIR/leaky.md" << 'EOF'
+<!-- review-metadata
+review_commit: aaaaaaa
+-->
+
+## Security Review
+
+### 1. First finding
+
+Something about the first thing.
+
+**File:** `src/untouched.py`
+
+### 2. Second finding
+
+Something about the second thing.
+
+## Notes
+
+**File:** `src/auth.py`
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/leaky.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.pruned == false' > /dev/null
+    echo "$output" | jq -e '.prune_reason | test("did not re-parse")' > /dev/null
+    grep -q "Something about the second thing." "$TEST_DIR/leaky.md"
+}
+
+@test "carry-forward-findings.sh: a second delta round still finds the first round's findings" {
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch" \
+        --append-file "$TEST_DIR/append.md" --head-sha bbbbbbb --delta-from aaaaaaa
+    [ "$status" -eq 0 ]
+
+    cat > "$TEST_DIR/delta2.patch" << 'EOF'
+diff --git a/src/untouched.py b/src/untouched.py
+--- a/src/untouched.py
++++ b/src/untouched.py
+@@ -8,6 +8,7 @@
+ unchanged
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta2.patch" \
+        --head-sha ccccccc --delta-from bbbbbbb
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.pruned == true' > /dev/null
+    # the finding round one appended is attributed and carried, not orphaned
+    echo "$output" | jq -e '[.carried_findings[] | select(.file == "src/auth.py" and .line == 47 and .agent == "security")] | length == 1' > /dev/null
+    grep -q "the fallback path still leaks length" "$TEST_DIR/review.md"
+    ! grep -q "Missing input validation" "$TEST_DIR/review.md"
+    grep -q "^review_commit: ccccccc$" "$TEST_DIR/review.md"
+}
+
+@test "carry-forward-findings.sh: reports when the delta touches nothing the review flagged" {
+    cat > "$TEST_DIR/other.patch" << 'EOF'
+diff --git a/src/elsewhere.py b/src/elsewhere.py
+--- a/src/elsewhere.py
++++ b/src/elsewhere.py
+@@ -1,3 +1,4 @@
+ unchanged
+EOF
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/other.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.dropped == 0' > /dev/null
+    echo "$output" | jq -e '.carried == 3' > /dev/null
+    echo "$output" | jq -e '.prune_reason == "no findings on the delta'"'"'s files"' > /dev/null
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -546,6 +546,121 @@ EOF
     echo "$output" | jq -e '.[0].end_line == 5' > /dev/null
 }
 
+
+@test "parse-review-findings.sh: a Location-line finding is reported as not deletable" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+**Location**: `auth.py:45`
+
+SQL injection vulnerability
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].deletable == false' > /dev/null
+}
+
+@test "parse-review-findings.sh: a description stops where the span stops" {
+    # The span and the description must end at the same place. When they did
+    # not, cutting a finding's span left the tail of its body in the document
+    # for the finding above it to absorb on the next parse.
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+Body of the finding.
+
+---
+
+Prose after the thematic break.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].end_line == 5' > /dev/null
+    echo "$output" | jq -e '.[0].description == "Body of the finding."' > /dev/null
+}
+
+# =============================================================================
+# Fenced code blocks
+#
+# Fence tracking decides what counts as a finding at all, so it applies to
+# every caller, not just --with-spans. These run in default mode except where
+# the assertion is itself about a span.
+# =============================================================================
+
+@test "parse-review-findings.sh: headings inside a code block are not findings" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+The review format looks like this:
+
+```markdown
+#### `example.py:12`
+
+Example finding
+```
+
+Real body text.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].file == "auth.py"' > /dev/null
+}
+
+@test "parse-review-findings.sh: a suggestion block nested in a text block does not desync fences" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+```text
+suggestion: use a constant-time compare
+
+```suggestion
+hmac.compare_digest(a, b)
+```
+```
+
+#### `auth.py:80`
+
+Second finding, after the nested fences.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 2' > /dev/null
+    echo "$output" | jq -e '.[1].line == 80' > /dev/null
+}
+
+@test "parse-review-findings.sh: a tilde fence nested in a backtick fence does not close it" {
+    # Only a delimiter of the same marker character closes a block, so the
+    # inner ~~~ must not reopen the document to heading parsing. Tracking depth
+    # alone would end the outer block here and read the example as a finding.
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+```text
+~~~
+#### `fake.py:99`
+~~~
+```
+
+#### `auth.py:80`
+
+Second finding.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 2' > /dev/null
+    echo "$output" | jq -e '[.[].file] == ["auth.py", "auth.py"]' > /dev/null
+    echo "$output" | jq -e '[.[].line] == [45, 80]' > /dev/null
+}
+
 @test "parse-review-findings.sh: a # comment inside a code block does not end a span" {
     cat > "$TEST_DIR/review.md" << 'EOF'
 ## Security Review
@@ -567,63 +682,4 @@ EOF
     [ "$status" -eq 0 ]
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].end_line == 12' > /dev/null
-}
-
-@test "parse-review-findings.sh: a suggestion block nested in a text block does not desync fences" {
-    cat > "$TEST_DIR/review.md" << 'EOF'
-## Security Review
-
-#### `auth.py:45`
-
-```text
-suggestion: use a constant-time compare
-
-```suggestion
-hmac.compare_digest(a, b)
-```
-```
-
-#### `auth.py:80`
-
-Second finding, after the nested fences.
-EOF
-    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
-    [ "$status" -eq 0 ]
-    echo "$output" | jq -e 'length == 2' > /dev/null
-    echo "$output" | jq -e '.[1].line == 80' > /dev/null
-}
-
-@test "parse-review-findings.sh: headings inside a code block are not findings" {
-    cat > "$TEST_DIR/review.md" << 'EOF'
-## Security Review
-
-#### `auth.py:45`
-
-The review format looks like this:
-
-```markdown
-#### `example.py:12`
-
-Example finding
-```
-
-Real body text.
-EOF
-    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
-    [ "$status" -eq 0 ]
-    echo "$output" | jq -e 'length == 1' > /dev/null
-    echo "$output" | jq -e '.[0].file == "auth.py"' > /dev/null
-}
-
-@test "parse-review-findings.sh: a Location-line finding is reported as not deletable" {
-    cat > "$TEST_DIR/review.md" << 'EOF'
-## Security Review
-
-**Location**: `auth.py:45`
-
-SQL injection vulnerability
-EOF
-    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
-    [ "$status" -eq 0 ]
-    echo "$output" | jq -e '.[0].deletable == false' > /dev/null
 }

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -487,3 +487,143 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"sourced ok"* ]]
 }
+
+# =============================================================================
+# Spans (--with-spans)
+# =============================================================================
+
+@test "parse-review-findings.sh: default output carries no span fields" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+SQL injection vulnerability
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0] | has("start_line") | not' > /dev/null
+    echo "$output" | jq -e '.[0] | has("deletable") | not' > /dev/null
+}
+
+@test "parse-review-findings.sh: --with-spans reports the finding's line range" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+SQL injection vulnerability
+
+#### `auth.py:60`
+
+Second finding
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].start_line == 3' > /dev/null
+    echo "$output" | jq -e '.[0].end_line == 5' > /dev/null
+    echo "$output" | jq -e '.[0].deletable == true' > /dev/null
+    echo "$output" | jq -e '.[1].start_line == 7' > /dev/null
+}
+
+@test "parse-review-findings.sh: a span stops before the next heading, container headings included" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+SQL injection vulnerability
+
+### Nits
+
+#### `docs/readme.md:3`
+
+Typo
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    # ends at line 5, so cutting it leaves "### Nits" on line 7 in place
+    echo "$output" | jq -e '.[0].end_line == 5' > /dev/null
+}
+
+@test "parse-review-findings.sh: a # comment inside a code block does not end a span" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+Use a constant-time compare:
+
+```bash
+# not a heading
+compare a b
+```
+
+Trailing prose.
+
+## Testing Review
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].end_line == 12' > /dev/null
+}
+
+@test "parse-review-findings.sh: a suggestion block nested in a text block does not desync fences" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+```text
+suggestion: use a constant-time compare
+
+```suggestion
+hmac.compare_digest(a, b)
+```
+```
+
+#### `auth.py:80`
+
+Second finding, after the nested fences.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 2' > /dev/null
+    echo "$output" | jq -e '.[1].line == 80' > /dev/null
+}
+
+@test "parse-review-findings.sh: headings inside a code block are not findings" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `auth.py:45`
+
+The review format looks like this:
+
+```markdown
+#### `example.py:12`
+
+Example finding
+```
+
+Real body text.
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e 'length == 1' > /dev/null
+    echo "$output" | jq -e '.[0].file == "auth.py"' > /dev/null
+}
+
+@test "parse-review-findings.sh: a Location-line finding is reported as not deletable" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+**Location**: `auth.py:45`
+
+SQL injection vulnerability
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --with-spans "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.[0].deletable == false' > /dev/null
+}


### PR DESCRIPTION
review.md's carrying-forward step pulled the whole previous review into the orchestrator's context on the run meant to be the cheap one. Across the 863 saved reviews that is a median of 11.8KB and a p90 of 29.8KB, and it was read at the re-review decision step, so it sat in context for nearly the whole run.

The compose step now edits the existing document on disk through a script instead. The previous review never enters the conversation.

## Why edit in place rather than rewrite

A wholesale rewrite is the more expensive branch even setting the read aside, because the orchestrator would have to emit every carried-forward body as output tokens, and it can only do that after reading them. It pays both sides.

The one way around that is reconstructing bodies from `parse-review-findings.sh`, and that does not work: its `description` field truncates at 500 chars and drops code blocks, so carried findings would come back mangled.

Two consequences shaped the implementation. The orchestrator cannot append with Edit or Write, since both require having Read the file, so it writes its new sections to a fresh file in `artifacts_dir` and the script does prune, append and header patch in one pass. And findings the parser cannot tie to a file are kept rather than dropped, because a delta review only looks at changed files, so a dropped unattributable finding is gone permanently rather than re-derived.

## What changed

`parse-review-findings.sh` gains `--with-spans`, adding `start_line`, `end_line` and `deletable`. A span ends at the next heading or thematic break. `deletable` is false for findings opened by a `**Location**:` line, where the extent is a guess. Fence tracking counts nesting rather than toggling, because this repo's finding format nests a ```suggestion block inside a ```text body, and a strict CommonMark toggle reads that as close-then-open and turns every later heading into code.

`carry-forward-findings.sh` is new. It derives the delta's file set from the patch, cuts findings on those files, keeps the rest byte for byte, appends the new sections, and patches the metadata header. It self-verifies: after cutting it re-parses the pruned document and requires the survivors to equal the intended set, and on any mismatch it abandons the cut, keeps everything, and reports `pruned: false`.

Its output is counts, flags and the cut file list only. No bodies and no per-finding array, since that output lands in the orchestrator's conversation and stays there.

`review-carry-forward.md` is new and read only on the delta path. review.md's step is now a pointer plus "never Read the previous review", and is 180 bytes shorter, which matters because that file is read every run.

## Measured

Net context change on a delta run is about 2.0k tokens saved at the median and 6.3k at p90, at the repo's 4 chars per token convention. The turn multiplier favors it further, since the document was read before the agents ran and the new handler is read at compose, near the end.

The follow-up estimated 3k to 34k. The median matches; the p90 document is about 7.4k tokens, not 34k.

## Test plan

- [x] `bin/test` green, 1622 unit and 12 integration, including 22 new cases
- [x] Default parser output unchanged on 861 of 863 real reviews. The 2 that differ have unbalanced fences of their own, and both move toward fewer findings, never phantom deletion
- [x] Prune safety across the corpus, marking half of each review's cited files as touched: 555 pruned and verified, 4 fell back safely, 304 had nothing deletable
- [x] Round-2 invariant checked by test and by a manual two-round run: identity and agent attribution survive because the appended chapter is H1 and its per-agent sections stay at H2
- [x] `bin/lint` and `bin/fmt` clean

No before-and-after `bin/token-report`. It reads real session transcripts, so it needs live end-to-end delta runs against a PR; the corpus numbers above are what can be measured without one.

## Worth a look before merging

The parser's default output moved on 2 of 863 documents. `learn-from-pr.sh` and `evals/scripts/score-eval.sh` consume that default. Both changes are fewer findings on malformed documents, but the default did change.

After a delta round the header carries `review_mode: delta` and `delta_from`. Nothing resets them if a later re-review takes the full path. Nothing machine-reads those two fields, so it is informational drift; fixing it means touching full-path compose.

An emptied container heading is left in place rather than swept. It reads honestly, since those findings were re-derived in the appended section, but it is a visible artifact.

https://claude.ai/code/session_01SAv3sg4k4vZeupnhbvLaHi