### PR TITLE
Focus small-review architectural reconnaissance

### DIFF
--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -252,16 +252,19 @@ Focus on:
 Do NOT search for code callers, function patterns, or application architecture.
 
 {If exploration_depth == "minimal" (non-infra):}
-Time-box yourself to 30 seconds. Focus on understanding what changed:
-- Read only the modified files to understand their purpose and the change
-- Skip caller search, pattern search, git history, and reference implementations
+Time-box yourself to 45 seconds. Gather only context that can change the review outcome:
+- Read the modified files to identify changed symbols and newly introduced calls
+- Find direct callers of changed symbols, limiting results to the 3 most relevant callers per symbol
+- Read implementations of newly called methods when their behavior is not obvious at the call site
+- Check nearby tests and public boundaries such as APIs, schemas, events, and configuration
+- Skip broad pattern searches, reference implementations, and git history
 
 {If exploration_depth == "standard":}
 Time-box yourself to 1-2 minutes. Explore:
 - Full context of modified files
-- Related code and dependencies
-- Callers of modified functions (who calls the changed code and might be affected?)
-  (grep for function/method names, report top 3-5 callers per significantly modified function)
+- Direct callers of changed symbols, reporting the top 3-5 relevant callers per significantly modified symbol
+- Implementations of newly called methods and dependencies whose behavior is not obvious at the call site
+- Nearby tests and public boundaries such as APIs, schemas, events, and configuration
 - Skip pattern search, reference implementations, and git history
 
 {If exploration_depth == "thorough":}

--- a/tests/unit/test-inject-handler.bats
+++ b/tests/unit/test-inject-handler.bats
@@ -75,12 +75,15 @@ teardown() {
 # Review mode tests (default handler)
 # =============================================================================
 
-@test "inject-handler: outputs review.md content for area keyword" {
+@test "inject-handler: outputs review.md with focused context for area keyword" {
     run "$SCRIPT" security
     [ "$status" -eq 0 ]
 
     expected_start="$(head -1 "$HANDLER_DIR/review.md")"
     [[ "$output" == *"$expected_start"* ]]
+    [[ "$output" == *"Find direct callers of changed symbols"* ]]
+    [[ "$output" == *"Read implementations of newly called methods"* ]]
+    [[ "$output" == *"Check nearby tests and public boundaries"* ]]
 }
 
 @test "inject-handler: outputs review.md content for PR number" {


### PR DESCRIPTION
- Keeps the context explorer enabled for small reviews so callers outside the diff remain visible.
- Limits minimal and standard exploration to direct callers, newly called implementations, nearby tests, and public boundaries. Broad pattern searches, reference implementations, and git history remain out of scope.
- Verifies the focused reconnaissance instructions through the existing handler injection test without adding another handler invocation.

## Test plan

- [x] `bin/fmt`
- [x] `bats tests/unit/test-inject-handler.bats tests/unit/test-classify-review-scope.bats` (19 tests)
- [ ] `bin/test` (existing Codex, Copilot, and learn-orchestrator stub tests fail in this environment)
