### PR TITLE
Add a comment-voice linter and a calibration harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ skills/review-code/learnings/status-cache.json
 
 # Package manager files (not applicable here, but good to have)
 node_modules/
+
+# Python interpreter caches
+__pycache__/
+*.pyc

--- a/bin/calibrate-voice-lint
+++ b/bin/calibrate-voice-lint
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Run lint-comment-voice over recent review files and report per-rule hit rates.
+
+This is the tuning loop for the linter before it acts on findings: lint a set
+of historical reviews, see which rules fire and how often, and decide whether
+the pattern needs to be narrowed (too many false positives), kept (clean hits
+on real violations), or split (one pattern catching two different phenomena).
+
+Reads review files only; never writes to them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def find_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "-C", str(Path(__file__).parent), "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def load_linter(repo_root: Path):
+    script = repo_root / "skills" / "review-code" / "scripts" / "lint-comment-voice.py"
+    script_str = str(script)
+    spec = importlib.util.spec_from_file_location("lint_comment_voice", script_str)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load linter at {script_str}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def recent_reviews(directory: Path, count: int) -> list[Path]:
+    paths = glob.glob(str(directory / "**" / "*.md"), recursive=True)
+    paths = [p for p in paths if Path(p).is_file()]
+    paths.sort(key=lambda p: Path(p).stat().st_mtime, reverse=True)
+    return [Path(p) for p in paths[:count]]
+
+
+def parse_args(repo_root: Path) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dir",
+        metavar="<path>",
+        default=os.path.expanduser("~/.claude/skills/review-code/.reviews"),
+        help="Directory of review .md files (default: installed reviews directory)",
+    )
+    parser.add_argument(
+        "--limit-files",
+        type=int,
+        default=30,
+        metavar="<n>",
+        help="Lint at most n most-recently-modified review files (default: 30)",
+    )
+    parser.add_argument(
+        "--per-category-limit",
+        type=int,
+        default=0,
+        metavar="<n>",
+        help="Cap warnings shown per category to n before counting "
+        "(0 counts them all)",
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="Emit machine-readable JSON instead of a table"
+    )
+    parser.add_argument(
+        "--show-samples",
+        type=int,
+        metavar="<k>",
+        default=3,
+        help="Print up to k example warnings per category (default: 3; 0 hides samples)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args(find_repo_root())
+    linter = load_linter(find_repo_root())
+    reviews_dir = Path(args.dir)
+
+    files = recent_reviews(reviews_dir, args.limit_files)
+    if not files:
+        print(f"no .md review files under {reviews_dir}", file=sys.stderr)
+        return 1
+
+    per_category: dict[str, int] = collections.Counter()
+    per_file: dict[str, dict[str, int]] = {}
+    samples: dict[str, list[dict]] = collections.defaultdict(list)
+    total_files = len(files)
+    files_with_warnings = 0
+
+    for path in files:
+        text = path.read_text(encoding="utf-8", errors="replace")
+        warnings = linter.lint(text)
+        capped, suppressed = linter.cap_warnings(warnings, args.per_category_limit)
+        if suppressed:
+            for category, count in suppressed.items():
+                per_category[category] += count
+        for item in capped:
+            category = item["category"]
+            per_category[category] += 1
+            per_file.setdefault(str(path), collections.Counter())[category] += 1
+            if len(samples[category]) < args.show_samples:
+                samples[category].append(
+                    {
+                        "file": str(path.relative_to(reviews_dir)),
+                        "line": item["line"],
+                        "text": item["text"][:160],
+                    }
+                )
+        if warnings:
+            files_with_warnings += 1
+
+    if args.json:
+        payload = {
+            "reviews_dir": str(reviews_dir),
+            "files_linted": total_files,
+            "files_with_warnings": files_with_warnings,
+            "per_category": dict(per_category),
+            "per_file": per_file,
+            "samples": dict(samples),
+        }
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    print(f"Linted {total_files} review files under {reviews_dir}")
+    print(f"Files with at least one warning: {files_with_warnings}")
+    print()
+
+    if not per_category:
+        print("No warnings recorded.")
+        return 0
+
+    widths = [len(category) for category in per_category] + [len("category")]
+    span = max(widths)
+    print(f"{'category':<{span}}  total  per-file-avg  files-hit")
+    print(f"{'-' * span}  -----  ------------  ---------")
+    for category, total in sorted(per_category.items(), key=lambda kv: -kv[1]):
+        files_hit = sum(1 for counts in per_file.values() if category in counts)
+        avg = total / files_hit if files_hit else 0.0
+        print(f"{category:<{span}}  {total:>5}  {avg:>12.2f}  {files_hit:>9}")
+        if args.show_samples:
+            for sample in samples.get(category, [])[: args.show_samples]:
+                print(f"  {sample['file']}:{sample['line']}: {sample['text']}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/review-code/scripts/lint-comment-voice.py
+++ b/skills/review-code/scripts/lint-comment-voice.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""Report review-comment style violations without scoring the prose.
+
+Reads text (one or more comment bodies, or a whole review document) and emits
+one JSON line per warning. The rules come from the review-code voice agent
+(agents/code-reviewer-voice.md): the checks a regex can perform deterministically
+so a cheap script can gate what three LLM passes let through.
+
+Code blocks, inline code, URLs, review-metadata comment blocks, and severity
+prefixes are masked before any rule runs: they are structure, not prose.
+
+Warnings are advisory. Nothing here exits nonzero unless --fail-on-warnings is
+passed, so a malformed rule or a surprising input can never block a review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Iterable, TypedDict
+
+# Rules drawn from agents/code-reviewer-voice.md, limited to what a regex can
+# judge without reading the surrounding code. Each pattern is prose-only: code,
+# URLs, and severity prefixes are masked before these run.
+RAW_PATTERNS: dict[str, tuple[str, ...]] = {
+    # Reviewer-internal vocabulary. "Sibling" only when it names a test or
+    # function (siblings in the tree sense are fine); anchor/corroborate as
+    # pipeline bookkeeping. Prefix-anchored attribution labels ("Raised by",
+    # "Agents:") stay exempt because the review writes them deliberately for
+    # the reader.
+    "reviewer_vocabulary": (
+        r"\bsiblings?\b(?=[^.]{0,40}\b(?:test|case|function|files?)\b)",
+        r"(?<!\*\*)\bcorroborat\w+\b(?!\*\*)",
+        r"\banchor(?:s|ed|ing)?\b(?=[^.]{0,40}\b(?:reference|claim|term|permalinks?|finding|point)\b)",
+    ),
+    # Formal logic register. "Predicate" and "invariant" are fine as nouns for
+    # what the code *is* (a predicate function); the violation is using them as
+    # proof labels: asserting one "holds" or is "satisfied" without a check.
+    "logic_register": (
+        r"\bvacuously\b",
+        r"\btautolog\w+\b",
+        r"\bconjuncts?\b",
+        r"\bdisjuncts?\b",
+        r"\bbiff\b",
+        r"\binvariants?\s+(?:holds?|is|are|remains?|stays?)\s+(?:intact|satisfied|preserved|maintained|true|unchanged|enforced|upheld|respected)\b",
+        r"\b(?:holds?|satisfies|satisfied|preserves|preserved)\s+(?:vacuously|the\s+invariants?)\b",
+        r"\bpredicates?\s+(?:holds?|is satisfied|are satisfied)\b",
+    ),
+    # "Pin" as a verb for what a test covers. The regex must not fire on literal
+    # version or SHA pinning, which is allowed by the voice agent ("Version and
+    # SHA pinning are literal and stay as written").
+    "pinning": (
+        r"\bpinned by\b",
+        r"\bpin down\b",
+        r"\bpins? (?:the|that|this|down)\b",
+        r"\bpinning (?:the|this|that|down)\b",
+        r"\bis(?:n['’]t| not) pinned\b",
+        r"\bunpinned\b",
+        r"\bnot pinned\b",
+        r"\bpinned (?:elsewhere|here|now|already|in)\b",
+        r"\bpinned to the (?:behaviour|behavior)\b",
+    ),
+    # Applying a named shortcut where the behavior belongs. The voice agent
+    # bans coined labels ("the withholding boundary"), test-theory categories
+    # ("weak positive assertion"), and metaphor-jargon ("load-bearing").
+    "labeling": (
+        r"\bload-bearing\b",
+        r"\bhappy paths?\b",
+        r"\bcode smells?\b",
+        r"\bthe \w+ (?:window|boundary|hazard|trap|gap|wart) is\b",
+        r"\bweak positive assertions?\b",
+        r"\bweak negative assertions?\b",
+        r"\btautological tests?\b",
+        r"\bthe contract isn['’]t pinned\b",
+        r"\bweak asserts?\b",
+    ),
+    # Filler, hype, and chatbot closers that inflate a finding without content.
+    "filler": (
+        r"\blet(?:'|’)s (?:dive in|dive into|explore|break this down)\b",
+        r"\bhere(?:'|’)s what you need to know\b",
+        r"\bit is (?:important|worth) to note\b",
+        r"\bin order to\b",
+        r"\bdue to the fact that\b",
+        r"\bat this point in time\b",
+        r"\bin the event that\b",
+        r"\bi hope this helps\b",
+        r"\blet me know\b",
+        r"\bgreat work\b",
+        r"\bnice approach\b",
+        r"\bawesome pr\b",
+    ),
+    "hype": (
+        r"\b(?:robust|seamless|powerful|pivotal|groundbreaking|revolutionary)\b",
+        r"\b(?:world-class|cutting-edge|effortless|game-changing|best-in-class)\b",
+        r"\bcomprehensive\b",
+        r"\bcritical\b",
+        r"\bmeaningful state change\b",
+    ),
+    # AI vocabulary clichés. The voice agent lists these with the same words.
+    "ai_vocabulary": (
+        r"\bleverag(?:e|es|ed|ing)\b",
+        r"\butiliz(?:e|es|ed|ing|ation)\b",
+        r"\bfacilitat(?:e|es|ed|ing)\b",
+        r"\bnavigat(?:e|es|ed|ing)\b",
+        r"\bensure\b",
+        r"\bdelve\b",
+    ),
+    # Named shorthand for a category where the behavior belongs, per the voice
+    # agent's "no coined labels" rule. Anchored to a small set of nouns that the
+    # voice agent itself calls out; broader noun lists drown in false positives.
+    "coined_label": (
+        r"\bthe \w+ (?:window|boundary|hazard) is\b",
+        r"\bthe (?:window|boundary|hazard) collapses\b",
+    ),
+    # Pipeline provenance that leaked into the body. The voice agent strips
+    # these when rewriting; flagging them upstream lets the drafting pass drop
+    # them before the voice agent ever sees them. Author-attribution labels that
+    # the review itself writes for the reader ("Raised by: … (corroborated)")
+    # are structure, not leaks, and stay exempt.
+    "provenance_leak": (
+        r"\*\s*\((?:corroborat\w+|flagged|disputed)[^*]*\)\*",
+    ),
+    # Verdict-first openers. The voice agent bans opening with a label or
+    # adjective stack ("This is a real upgrade-window risk", "Sound and
+    # proportionate"); these patterns catch the common shapes.
+    "verdict_opener": (
+        r"^\s*This is a (?:real|genuine|significant|serious|major|critical|subtle|classic|common|textbook)\b",
+        r"^\s*This (?:will|would) (?:likely|probably|potentially|silently|quietly|easily)\b",
+        r"^\s*Sound and\b",
+        r"^\s*Proportionate to the goal\b",
+        r"^\s*Direct, well-scoped\b",
+        r"^\s*In good shape\b",
+        r"^\s*The new machinery is\b",
+    ),
+    # Pseudo-headers the voice agent strips. These read as labels where the
+    # sentence should just say the thing.
+    "pseudo_header": (
+        r"\*\*Issue\*\*:",
+        r"\*\*Impact\*\*:",
+        r"\*\*Recommendation\*\*:",
+        r"\*\*Fix\*\*:",
+        r"\*\*Problem\*\*:",
+        r"\*\*Solution\*\*:",
+        r"\*\*Vulnerability\*\*:",
+        r"\*\*Problem\*\* \S",
+        r"\*\*Solution\*\* \S",
+    ),
+    # Hedging and throat-clearing that inflate the body.
+    "hedging": (
+        r"\bjust a thought,? but\b",
+        r"\bi might be wrong,? but\b",
+        r"\bto be honest\b",
+        r"\bto be fair\b",
+        r"\bi['’]d argue that\b",
+        r"\bit seems like\b",
+        r"\bit appears that\b",
+        r"\bkind of\b",
+        r"\bsort of\b",
+    ),
+    # Signposting and repeated-summary patterns that pad a body.
+    "signposting": (
+        r"\bfirst,?\s+.{0,40}\bsecond,?\s+.{0,40}\bthird,?\s+",
+        r"\bin summary\b",
+        r"\bto summarize\b",
+        r"\bin conclusion\b",
+        r"\bas (?:we|i) (?:mentioned|discussed|saw|noted) (?:above|earlier|before)\b",
+        r"\bobviously\b",
+        r"\bclearly,?\s+(?:this|the|it)\b",
+    ),
+    # Compound-framework register. Words like "orthogonal" label code instead
+    # of describing it. "Idiomatic", "canonical", "ergonomic", "elegant", and
+    # "seamless" fire too often on prose the repo itself treats as fine, so the
+    # linter stays silent on them until a sharper discriminator exists.
+    "framework_jargon": (
+        r"\borthogonally?\b",
+        r"\bfirst-class\b",
+    ),
+}
+
+PATTERNS: dict[str, tuple[re.Pattern[str], ...]] = {
+    category: tuple(re.compile(pattern, re.I) for pattern in patterns)
+    for category, patterns in RAW_PATTERNS.items()
+}
+
+FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+METADATA_COMMENT = re.compile(r"<!--\s*review-metadata(?:\s[^-]*)?.*?-->", re.S)
+# Structural Markdown that should never be read as prose: section headers,
+# table rows and separators, horizontal rules, and boilerplate labels that name
+# a finding's position rather than argue about code.
+HEADING = re.compile(r"^ {0,3}#{1,6}\s+")
+TABLE_ROW = re.compile(r"^\s*\|.*\|\s*$")
+HR = re.compile(r"^\s*(?:[-*_]\s*){3,}$")
+LABEL_LINE = re.compile(
+    r"^\s*(?:\*\*)?(?:Location|Found by|Raised by|Resolution|Agents?|Severity|"
+    r"Confidence|Status|Assessment|Source|Thread|Review scope|Fix summary)\s*"
+    r"(?:\*\*)?\s*:\s*$",
+    re.I,
+)
+INLINE_CODE = re.compile(r"`[^`]*`")
+URL = re.compile(r"https?://[^\s)>]+")
+WORD = re.compile(r"[A-Za-z0-9][A-Za-z0-9'’/-]*")
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
+
+SEVERITY_PREFIX = re.compile(
+    r"^(?:`\*\*`\s*)?`?(?:blocking|suggestion|question|nit)`?\s*:",
+    re.I,
+)
+
+# Rules whose findings should not fire when the only matches sit inside a
+# severity prefix at the start of a line. Everything else masks inline code,
+# which already neutralizes the backticked prefix forms; the bare case needed
+# its own guard.
+RULES_RESPECTING_PREFIX = {
+    "pseudo_header",
+    "verdict_opener",
+}
+
+# Categories that are only worth reporting once per line, so a body with three
+# em dashes doesn't triple-report.
+CAPPED_CATEGORIES = {"dash"}
+
+
+class LintWarning(TypedDict):
+    line: int
+    category: str
+    message: str
+    text: str
+
+
+def prose_lines(text: str) -> Iterable[tuple[int, str, str]]:
+    """Yield (line_number, original_line, prose) with code and metadata masked."""
+    # Strip whole-document review-metadata blocks before line iteration. A
+    # block comment that spans lines would otherwise survive per-line masking.
+    text = METADATA_COMMENT.sub("", text)
+
+    fence = ""
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        marker = FENCE.match(line)
+        token = marker.group(1) if marker else ""
+        if fence:
+            if marker and token.startswith(fence) and not line[marker.end():].strip():
+                fence = ""
+            continue
+        if token:
+            fence = token
+            continue
+
+        if (
+            HEADING.match(line)
+            or TABLE_ROW.match(line)
+            or HR.match(line)
+            or LABEL_LINE.match(line)
+        ):
+            continue
+
+        prose = URL.sub("", INLINE_CODE.sub("", line))
+        yield line_number, line, prose
+
+
+def strip_severity_prefix(prose: str) -> str:
+    """Drop a leading severity prefix so rules don't flag the prefix itself."""
+    return SEVERITY_PREFIX.sub("", prose, count=1)
+
+
+def warning(line: int, category: str, message: str, text: str) -> LintWarning:
+    return {
+        "line": line,
+        "category": category,
+        "message": message,
+        "text": text.strip(),
+    }
+
+
+def lint(text: str) -> list[LintWarning]:
+    warnings: list[LintWarning] = []
+
+    for line_number, original, raw_prose in prose_lines(text):
+        prose = raw_prose.strip()
+        if not prose:
+            continue
+
+        for category, patterns in PATTERNS.items():
+            if category in RULES_RESPECTING_PREFIX:
+                subject = strip_severity_prefix(raw_prose)
+            else:
+                subject = raw_prose
+            if any(pattern.search(subject) for pattern in patterns):
+                warnings.append(
+                    warning(
+                        line_number,
+                        category,
+                        f"Possible {category.replace('_', ' ')}; use concrete, direct wording.",
+                        original,
+                    )
+                )
+
+        if "—" in raw_prose or "–" in raw_prose:
+            warnings.append(
+                warning(
+                    line_number,
+                    "dash",
+                    "Restructure the sentence without an em dash or en dash.",
+                    original,
+                )
+            )
+
+    # A long-sentence check belongs to strict technical writing, not review
+    # comments. The voice agent's own length guidance is shaped by finding
+    # severity, not by a fixed word count, so the linter stays silent here.
+
+    return warnings
+
+
+def render_jsonl(warnings: list[LintWarning]) -> str:
+    return "\n".join(json.dumps(item) for item in warnings)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to lint; read stdin when omitted or when the path is '-'",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        metavar="<n>",
+        help="Keep at most n warnings per category and note how many were suppressed "
+        "(0 keeps them all)",
+    )
+    parser.add_argument(
+        "--fail-on-warnings",
+        action="store_true",
+        help="Exit 1 when warnings exist; warnings do not fail by default",
+    )
+    return parser.parse_args()
+
+
+def cap_warnings(
+    warnings: list[LintWarning], limit: int
+) -> tuple[list[LintWarning], dict[str, int]]:
+    if limit <= 0:
+        return warnings, {}
+    kept: list[LintWarning] = []
+    suppressed: dict[str, int] = {}
+    seen: dict[str, int] = {}
+    for item in warnings:
+        category = item["category"]
+        count = seen.get(category, 0)
+        if count < limit:
+            kept.append(item)
+            seen[category] = count + 1
+        else:
+            suppressed[category] = suppressed.get(category, 0) + 1
+    return kept, suppressed
+
+
+def main() -> int:
+    args = parse_args()
+    inputs = args.files or ["-"]
+
+    all_warnings: list[LintWarning] = []
+    for name in inputs:
+        text = (
+            sys.stdin.read() if name == "-" else Path(name).read_text(encoding="utf-8")
+        )
+        all_warnings.extend(lint(text))
+
+    all_warnings.sort(key=lambda item: (item["line"], item["category"]))
+    kept, suppressed = cap_warnings(all_warnings, args.limit)
+    if not kept and not suppressed:
+        print("[]")
+        return 0
+    rendered = render_jsonl(kept)
+    for category, count in sorted(suppressed.items()):
+        if rendered:
+            rendered += "\n"
+        rendered += json.dumps(
+            {
+                "note": f"Further {category} warning(s) suppressed by --limit.",
+                "suppressed": count,
+            }
+        )
+    print(rendered)
+
+    has_warnings = bool(all_warnings)
+    return 1 if args.fail_on_warnings and has_warnings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/review-code/scripts/lint-comment-voice.py
+++ b/skills/review-code/scripts/lint-comment-voice.py
@@ -2,9 +2,10 @@
 """Report review-comment style violations without scoring the prose.
 
 Reads text (one or more comment bodies, or a whole review document) and emits
-one JSON line per warning. The rules come from the review-code voice agent
-(agents/code-reviewer-voice.md): the checks a regex can perform deterministically
-so a cheap script can gate what three LLM passes let through.
+one JSON line per warning, or the literal "[]" when the input is clean. The
+rules come from the review-code voice agent (agents/code-reviewer-voice.md):
+the checks a regex can perform deterministically so a cheap script can gate
+what three LLM passes let through.
 
 Code blocks, inline code, URLs, review-metadata comment blocks, and severity
 prefixes are masked before any rule runs: they are structure, not prose.

--- a/tests/unit/test-lint-comment-voice.bats
+++ b/tests/unit/test-lint-comment-voice.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# Tests for skills/review-code/scripts/lint-comment-voice.py
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    LINTER="$PROJECT_ROOT/skills/review-code/scripts/lint-comment-voice.py"
+}
+
+# =============================================================================
+# Script structure tests
+# =============================================================================
+
+@test "lint-comment-voice: script exists and is executable" {
+    [ -f "$LINTER" ]
+    [ -x "$LINTER" ]
+}
+
+@test "lint-comment-voice: has python3 shebang" {
+    run head -1 "$LINTER"
+    [[ "$output" == "#!/usr/bin/env python3" ]]
+}
+
+# =============================================================================
+# Clean input
+# =============================================================================
+
+@test "lint-comment-voice: clean comment body produces no warnings" {
+    run "$LINTER" - <<'EOF'
+`blocking`: `validate_user` doesn't check whether `email` is `None`, so a request without an email raises a 500. Add a null check at the top of the function.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: exit 1 with --fail-on-warnings when warnings exist" {
+    run bash -c "printf 'The cache — see client.py — stays stale.\n' | '$LINTER' --fail-on-warnings - >/dev/null"
+    [ "$status" -eq 1 ]
+}
+
+@test "lint-comment-voice: exit 0 without --fail-on-warnings even when warnings exist" {
+    run bash -c "printf 'The cache — see client.py — stays stale.\n' | '$LINTER' - >/dev/null"
+    [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Masking: code and metadata are not prose
+# =============================================================================
+
+@test "lint-comment-voice: fenced code blocks are ignored" {
+    run "$LINTER" - <<'EOF'
+`suggestion`: Publish the invalidation instead.
+```python
+cache.publish_invalidation(key)  # leverage the existing channel — it works
+```
+The body reads fine.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: inline code is ignored" {
+    run "$LINTER" - <<'EOF'
+`nit`: Call `cache.invalidate — fast path` directly here instead.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: URLs are ignored" {
+    run "$LINTER" - <<'EOF'
+See https://example.com/leverage—the-docs for background on the format.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: review-metadata comment block is ignored" {
+    run "$LINTER" - <<'EOF'
+<!-- review-metadata
+reasoning: comprehensive — leverage the full agent set
+-->
+`nit`: Drop the unused import.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: severity prefix is not prose" {
+    run "$LINTER" - <<'EOF'
+`**Issue**: blocking`: The rename drops the old key without a fallback.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+# =============================================================================
+# Review-dialect rules
+# =============================================================================
+
+@test "lint-comment-voice: flags em dashes and en dashes in prose" {
+    run "$LINTER" - <<'EOF'
+The cache stays stale for up to an hour after deploy — every gate switched off in that window.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"dash"'* ]]
+}
+
+@test "lint-comment-voice: flags 'pin' used as a test-coverage verb" {
+    run "$LINTER" - <<'EOF'
+The TTL argument is already pinned elsewhere in the suite.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"pinning"'* ]]
+}
+
+@test "lint-comment-voice: allows literal version and SHA pinning" {
+    run "$LINTER" - <<'EOF'
+The base image is pinned to sha256:4a1f and the action pins v2.3.1.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == "[]" ]]
+}
+
+@test "lint-comment-voice: flags AI vocabulary" {
+    run "$LINTER" - <<'EOF'
+This leverages the existing validator to ensure the robust, comprehensive handling of every case.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"ai_vocabulary"'* ]]
+}
+
+@test "lint-comment-voice: flags verdict-first opinion openers" {
+    run "$LINTER" - <<'EOF'
+This is a real upgrade-window risk on self-hosted.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"verdict_opener"'* ]]
+}
+
+@test "lint-comment-voice: flags pseudo-headers" {
+    run "$LINTER" - <<'EOF'
+**Issue**: the rename drops the old key. **Impact**: self-hosted orgs lose the gate.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"pseudo_header"'* ]]
+}
+
+# =============================================================================
+# Input handling
+# =============================================================================
+
+@test "lint-comment-voice: reads a file argument" {
+    printf 'The cache — see client.py — stays stale.\n' > "$BATS_TEST_TMPDIR/body.md"
+    run "$LINTER" "$BATS_TEST_TMPDIR/body.md"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"line": 1'* ]]
+}
+
+@test "lint-comment-voice: --limit caps reported messages per category" {
+    run bash -c "{ for i in 1 2 3; do echo \"The cache — stale again — on run \$i.\"; done } | '$LINTER' --limit 1 -"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"suppressed": 2'* ]]
+    [ "$(grep -c '"category": "dash"' <<<"$output")" -eq 1 ]
+}
+
+@test "lint-comment-voice: each warning carries line, message, and text" {
+    run "$LINTER" - <<'EOF'
+first line fine
+The cache — see client.py — stays stale.
+EOF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"line": 2'* ]]
+    [[ "$output" == *'"message":'* ]]
+    [[ "$output" == *'"text":'* ]]
+}


### PR DESCRIPTION
Foundation for gating review comments on voice. Two new scripts, both run locally and never invoked from a review yet:

- `skills/review-code/scripts/lint-comment-voice.py` — lints review text (one body or a whole document). Flags what a regex can catch deterministically: em dashes in prose, "pinned" as a test-coverage verb, reviewer-internal vocabulary, pseudo-headers ("**Issue**:", "**Impact**:"), verdict-first openers ("Sound and proportionate", "This is a real upgrade-window risk"), AI vocabulary, and pipeline provenance leaks. Masks fenced code, inline code, URLs, the review-metadata comment block, structural Markdown (headers, tables, horizontal rules, label lines), and severity prefixes, so rules only fire on prose. Emits JSON Lines; exit 0 unless `--fail-on-warnings` is passed.
- `bin/calibrate-voice-lint` — runs the linter over the N most recent installed reviews and reports per-rule hit rates and samples, so rules can be tuned against real output before the pipeline acts on them.

## Why this layering

Review-code already teaches these rules to its drafting agents and its voice agent, and they still leak: the last 30 installed reviews carry 87 em dashes in prose (about 5.7 per review), 19 uses of "pin/pinned/pins the …" as test-coverage vocabulary, and recurring verdict-first openers. A deterministic linter catches what three LLM passes let through, at a fraction of the cost of another model call.

## Design choices worth knowing

- **Warnings, never a quality score.** Mirrors the dotfiles `plain-writing-lint.py` contract so the pipeline can't be blocked by a buggy rule.
- **`--limit` caps warnings per category.** Useful against dense bodies where one rule would otherwise fire ten times on one em dash.
- **Review-dialect specific.** Rule set derives from `agents/code-reviewer-voice.md`, not from generic prose linting. Review-specific categories (pinning, reviewer_vocabulary, verdict_opener, pseudo_header, provenance_leak) do the real work.

Calibration on the last 30 installed reviews:

| category | total | files-hit |
|---|---|---|
| dash | 87 | 14 |
| pinning | 19 | 9 |
| reviewer_vocabulary | 12 | 7 |
| labeling | 8 | 6 |
| verdict_opener | 2 | 2 |
| signposting | 1 | 1 |
| coined_label | 1 | 1 |
| hedging | 1 | 1 |

Pipeline wiring (voice-pass revert trigger, compose-stage narrative lint, drafting-side rule reinforcement) comes in a follow-up PR.

## Test plan

- `bats tests/unit/test-lint-comment-voice.bats` — 19 new tests covering masking, severity-prefix handling, the pinning family, and the `--limit` behavior.
- `bin/test` — full suite passes.
- `bin/calibrate-voice-lint` on the last 30 installed reviews produced the table above.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*