### PR TITLE
Require every finding to ask the author for something

### DIFF
--- a/agents/code-reviewer-architecture.md
+++ b/agents/code-reviewer-architecture.md
@@ -115,7 +115,7 @@ Location: `utils.rs:67` | Confidence: 65%
 
 Is this abstraction earning its complexity? Abstractions should emerge from repeated use, not be imposed speculatively.
 
-**Rule of thumb:** Abstract when you have 3+ similar implementations. Until then, keep it concrete.
+**Rule of thumb:** Abstract when the extraction costs less than the copies, not when a count is reached. Two implementations that one shared function with a plain signature replaces are worth consolidating; two that need generics, a new trait, or a behavior flag threaded through several decision points in the shared path are not.
 
 **Example finding:**
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -14,7 +14,7 @@ You are a senior code reviewer specializing in CODE MAINTAINABILITY. Your role i
 - **Boring is better than clever** - Simple solutions beat elegant complexity
 - **Clear intent over conciseness** - Code should explain its purpose
 - **Single responsibility** - One function, one job
-- **No premature abstraction** - Don't generalize until you have 3+ use cases
+- **No premature abstraction** - Don't build for uses that don't exist yet; code already written twice is two uses, not zero
 - **If it needs explanation, it's too complex** - Code should be self-documenting
 
 ## Before You Review
@@ -127,6 +127,14 @@ Review code changes for these maintainability concerns in priority order.
 - Test code (some duplication aids clarity)
 - Configuration or data definitions
 - When abstraction would be more complex than the duplication
+
+**Two copies: ask, or stay silent.**
+
+Two near-identical blocks are a finding when the consolidation is small enough to write into the comment: the copies differ by a string literal, a config value, or one extra parameter, and one shared function with a plain signature replaces both. Ask for that consolidation outright, with the signature.
+
+When collapsing them needs real machinery (generics or type parameters, a new trait or interface, a behavior flag threaded through several decision points in the shared path), the abstraction costs more than the duplication and the finding is cleared. Record it in your Investigation Summary and say nothing in the review. Never write the halfway version: a comment that lays out the duplication in detail, then declines to ask for the extraction, or defers it to a third copy that doesn't exist, leaves the author a wall of text and nothing to do.
+
+Duplication that has already cost something is a finding either way, whatever the extraction would take. Name the cost (a field added to one copy and missed in the other, a bug fixed in one and still live in the other) and ask for the change that stops the next miss, which may be a shared test or a pointer comment rather than an extraction.
 
 ### 5. Documentation & Comments (Important)
 

--- a/agents/code-reviewer-maintainability.md
+++ b/agents/code-reviewer-maintainability.md
@@ -119,14 +119,13 @@ Review code changes for these maintainability concerns in priority order.
 - Magic numbers/strings repeated throughout code
 - Validation rules duplicated instead of centralized
 - Error handling patterns duplicated instead of abstracted
-- New functions nearly identical to existing ones (same structure, different string literals or one extra parameter); these should be consolidated
+- New functions nearly identical to existing ones (same structure, different string literals or one extra parameter)
 
 **When Duplication is Acceptable:**
 
 - Different domains that happen to look similar now
 - Test code (some duplication aids clarity)
 - Configuration or data definitions
-- When abstraction would be more complex than the duplication
 
 **Two copies: ask, or stay silent.**
 

--- a/evals/benchmarks/crafted/analytics-emitter-batching/answer-key.json
+++ b/evals/benchmarks/crafted/analytics-emitter-batching/answer-key.json
@@ -1,0 +1,50 @@
+{
+  "version": 1,
+  "expected_findings": [
+    {
+      "id": "track-event-string-literal-copies",
+      "description": "trackSignup and trackLogin are the same function apart from the event name string, so one trackEvent(event: string, payload: EventPayload) replaces both",
+      "area": "maintainability",
+      "severity": "suggestion",
+      "weight": 8,
+      "file": "src/analytics/emitters.ts",
+      "line_start": 43,
+      "line_end": 69,
+      "keywords": ["tracksignup", "tracklogin", "string literal", "event name", "shared function", "consolidat", "single function"]
+    },
+    {
+      "id": "chunk-events-drops-remainder",
+      "description": "chunkEvents loops while i + size <= events.length, so a trailing partial batch is never produced and those events are silently never sent",
+      "area": "correctness",
+      "severity": "blocking",
+      "weight": 8,
+      "file": "src/analytics/emitters.ts",
+      "line_start": 24,
+      "line_end": 31,
+      "keywords": ["partial", "remainder", "last batch", "final batch", "leftover", "off-by-one", "silently drop"]
+    },
+    {
+      "id": "flush-all-foreach-async",
+      "description": "flushAll passes an async callback to forEach, so it resolves before any POST completes and a rejected request becomes an unhandled rejection",
+      "area": "correctness",
+      "severity": "blocking",
+      "weight": 7,
+      "file": "src/analytics/emitters.ts",
+      "line_start": 33,
+      "line_end": 41,
+      "keywords": ["foreach", "does not await", "not awaited", "floating promise", "unhandled rejection", "promise.all", "resolves before"]
+    }
+  ],
+  "false_positive_traps": [
+    {
+      "id": "share-retry-policy-constants",
+      "description": "CAPTURE_RETRY and BATCH_RETRY hold the same values today, but they are per-endpoint configuration tuned independently, and the comment on BATCH_RETRY says so. Collapsing them into one constant couples two endpoints that are meant to diverge. Configuration that happens to match is cleared, not a comment.",
+      "area": "maintainability",
+      "file": "src/analytics/emitters.ts",
+      "line_start": 10,
+      "line_end": 22,
+      "trap_keywords": ["consolidat", "shared constant", "single constant", "one constant", "deduplicat", "same values", "extract a", "extract into"]
+    }
+  ],
+  "clean_areas": ["security", "compatibility"]
+}

--- a/evals/benchmarks/crafted/analytics-emitter-batching/diff.patch
+++ b/evals/benchmarks/crafted/analytics-emitter-batching/diff.patch
@@ -1,0 +1,75 @@
+diff --git a/src/analytics/emitters.ts b/src/analytics/emitters.ts
+new file mode 100644
+index 0000000..3b9a17c
+--- /dev/null
++++ b/src/analytics/emitters.ts
+@@ -0,0 +1,69 @@
++import { httpPost } from "../transport/http";
++import { logger } from "../logging";
++
++export interface EventPayload {
++  userId: string;
++  teamId: number;
++  properties: Record<string, unknown>;
++}
++
++/** Retry policy for the single-event capture endpoint. */
++export const CAPTURE_RETRY = {
++  maxAttempts: 3,
++  initialDelayMs: 100,
++  maxDelayMs: 2000,
++};
++
++/** Retry policy for the batch endpoint. Tuned independently of capture. */
++export const BATCH_RETRY = {
++  maxAttempts: 3,
++  initialDelayMs: 100,
++  maxDelayMs: 2000,
++};
++
++/** Split events into fixed-size batches for the batch endpoint. */
++export function chunkEvents(events: EventPayload[], size: number): EventPayload[][] {
++  const batches: EventPayload[][] = [];
++  for (let i = 0; i + size <= events.length; i += size) {
++    batches.push(events.slice(i, i + size));
++  }
++  return batches;
++}
++
++/** Send every batch to the batch endpoint. */
++export async function flushAll(batches: EventPayload[][]): Promise<void> {
++  batches.forEach(async (batch) => {
++    const response = await httpPost("/batch", { events: batch });
++    if (!response.ok) {
++      logger.warn("batch failed", { size: batch.length, status: response.status });
++    }
++  });
++}
++
++export async function trackSignup(payload: EventPayload): Promise<void> {
++  const body = {
++    event: "user_signed_up",
++    distinct_id: payload.userId,
++    team_id: payload.teamId,
++    properties: payload.properties,
++    timestamp: new Date().toISOString(),
++  };
++  const response = await httpPost("/capture", body);
++  if (!response.ok) {
++    logger.warn("capture failed", { event: "user_signed_up", status: response.status });
++  }
++}
++
++export async function trackLogin(payload: EventPayload): Promise<void> {
++  const body = {
++    event: "user_logged_in",
++    distinct_id: payload.userId,
++    team_id: payload.teamId,
++    properties: payload.properties,
++    timestamp: new Date().toISOString(),
++  };
++  const response = await httpPost("/capture", body);
++  if (!response.ok) {
++    logger.warn("capture failed", { event: "user_logged_in", status: response.status });
++  }
++}

--- a/evals/benchmarks/crafted/analytics-emitter-batching/metadata.json
+++ b/evals/benchmarks/crafted/analytics-emitter-batching/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "analytics-emitter-batching",
+  "name": "Analytics Event Emitters",
+  "description": "TypeScript module that sends analytics events to the capture and batch endpoints, with per-endpoint retry settings and a batching helper",
+  "languages": ["typescript"],
+  "frameworks": [],
+  "areas": ["maintainability", "correctness"],
+  "difficulty": "medium",
+  "expected_finding_count": 3,
+  "false_positive_trap_count": 1
+}

--- a/evals/benchmarks/crafted/shadow-diff-duplication/answer-key.json
+++ b/evals/benchmarks/crafted/shadow-diff-duplication/answer-key.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "expected_findings": [
+    {
+      "id": "prune-stale-index-shift",
+      "description": "prune_stale removes from the vec while walking it by index, so every entry after a removal shifts down and gets skipped, and the index runs past the shrunken length",
+      "area": "correctness",
+      "severity": "blocking",
+      "weight": 9,
+      "file": "src/flags/shadow_diff.rs",
+      "line_start": 111,
+      "line_end": 117,
+      "keywords": ["retain", "shift", "skip", "index", "out of bounds", "while iterating"]
+    },
+    {
+      "id": "drift-percent-divide-by-zero",
+      "description": "drift_percent divides by total with no zero guard, so an empty payload panics instead of reporting no drift",
+      "area": "correctness",
+      "severity": "blocking",
+      "weight": 8,
+      "file": "src/flags/shadow_diff.rs",
+      "line_start": 120,
+      "line_end": 123,
+      "keywords": ["divide", "division", "zero", "checked_div", "empty payload"]
+    }
+  ],
+  "false_positive_traps": [
+    {
+      "id": "extract-generic-shadow-diff",
+      "description": "diff_flags and diff_cohorts run the same three-phase by-id diff, but the id types, field sets, and issue enums differ, so collapsing them needs generics and a trait for id extraction. The flag_issue_id and cohort_issue_id extractors below them repeat the same match arms over different enums and id types, and are the same cleared duplication. Two copies with no drift and no cheap consolidation is cleared, not a comment. A comment that describes the duplication and then declines to ask for the extraction, or defers it to a third copy that does not exist, is the same false positive.",
+      "area": "maintainability",
+      "file": "src/flags/shadow_diff.rs",
+      "line_start": 33,
+      "line_end": 109,
+      "trap_keywords": ["duplication", "duplicated", "near-identical", "generic", "shared helper", "consolidat", "written twice", "extract a", "extract into", "extract them", "third copy", "repeat yourself"]
+    }
+  ],
+  "clean_areas": ["compatibility"]
+}

--- a/evals/benchmarks/crafted/shadow-diff-duplication/answer-key.json
+++ b/evals/benchmarks/crafted/shadow-diff-duplication/answer-key.json
@@ -27,10 +27,10 @@
   "false_positive_traps": [
     {
       "id": "extract-generic-shadow-diff",
-      "description": "diff_flags and diff_cohorts run the same three-phase by-id diff, but the id types, field sets, and issue enums differ, so collapsing them needs generics and a trait for id extraction. The flag_issue_id and cohort_issue_id extractors below them repeat the same match arms over different enums and id types, and are the same cleared duplication. Two copies with no drift and no cheap consolidation is cleared, not a comment. A comment that describes the duplication and then declines to ask for the extraction, or defers it to a third copy that does not exist, is the same false positive.",
+      "description": "diff_flags and diff_cohorts run the same three-phase by-id diff, but the id types, field sets, and issue enums differ, so collapsing them needs generics and a trait for id extraction. The FlagIssue and CohortIssue enums above them carry the same three variants over different id types, and the flag_issue_id and cohort_issue_id extractors below them repeat the same match arms, and both are the same cleared duplication. Two copies with no drift and no cheap consolidation is cleared, not a comment. A comment that describes the duplication and then declines to ask for the extraction, or defers it to a third copy that does not exist, is the same false positive.",
       "area": "maintainability",
       "file": "src/flags/shadow_diff.rs",
-      "line_start": 33,
+      "line_start": 19,
       "line_end": 109,
       "trap_keywords": ["duplication", "duplicated", "near-identical", "generic", "shared helper", "consolidat", "written twice", "extract a", "extract into", "extract them", "third copy", "repeat yourself"]
     }

--- a/evals/benchmarks/crafted/shadow-diff-duplication/diff.patch
+++ b/evals/benchmarks/crafted/shadow-diff-duplication/diff.patch
@@ -1,0 +1,129 @@
+diff --git a/src/flags/shadow_diff.rs b/src/flags/shadow_diff.rs
+new file mode 100644
+index 0000000..7c1d4e2
+--- /dev/null
++++ b/src/flags/shadow_diff.rs
+@@ -0,0 +1,123 @@
++use std::collections::{HashMap, HashSet};
++
++pub type FeatureFlagId = i64;
++
++#[derive(Debug, Clone, PartialEq)]
++pub struct CachedFlag {
++    pub id: FeatureFlagId,
++    pub key: String,
++    pub active: bool,
++}
++
++#[derive(Debug, Clone, PartialEq)]
++pub struct CachedCohort {
++    pub id: i32,
++    pub name: String,
++    pub version: u32,
++}
++
++#[derive(Debug, PartialEq)]
++pub enum FlagIssue {
++    MissingInCache(FeatureFlagId),
++    FieldMismatch(FeatureFlagId, &'static str),
++    StaleInCache(FeatureFlagId),
++}
++
++#[derive(Debug, PartialEq)]
++pub enum CohortIssue {
++    MissingInCache(i32),
++    FieldMismatch(i32, &'static str),
++    StaleInCache(i32),
++}
++
++/// Compare the freshly built flag payload against what the cache served.
++pub fn diff_flags(built: &[CachedFlag], live: &[CachedFlag]) -> Vec<FlagIssue> {
++    let built_by_id: HashMap<FeatureFlagId, &CachedFlag> = built.iter().map(|f| (f.id, f)).collect();
++    let live_by_id: HashMap<FeatureFlagId, &CachedFlag> = live.iter().map(|f| (f.id, f)).collect();
++
++    let mut issues = Vec::new();
++
++    for flag in built {
++        match live_by_id.get(&flag.id) {
++            None => issues.push(FlagIssue::MissingInCache(flag.id)),
++            Some(cached) => {
++                if cached.key != flag.key {
++                    issues.push(FlagIssue::FieldMismatch(flag.id, "key"));
++                }
++                if cached.active != flag.active {
++                    issues.push(FlagIssue::FieldMismatch(flag.id, "active"));
++                }
++            }
++        }
++    }
++
++    for flag in live {
++        if !built_by_id.contains_key(&flag.id) {
++            issues.push(FlagIssue::StaleInCache(flag.id));
++        }
++    }
++
++    issues.sort_by_key(flag_issue_id);
++    issues
++}
++
++/// Compare the freshly built cohort payload against what the cache served.
++pub fn diff_cohorts(built: &[CachedCohort], live: &[CachedCohort]) -> Vec<CohortIssue> {
++    let built_by_id: HashMap<i32, &CachedCohort> = built.iter().map(|c| (c.id, c)).collect();
++    let live_by_id: HashMap<i32, &CachedCohort> = live.iter().map(|c| (c.id, c)).collect();
++
++    let mut issues = Vec::new();
++
++    for cohort in built {
++        match live_by_id.get(&cohort.id) {
++            None => issues.push(CohortIssue::MissingInCache(cohort.id)),
++            Some(cached) => {
++                if cached.name != cohort.name {
++                    issues.push(CohortIssue::FieldMismatch(cohort.id, "name"));
++                }
++                if cached.version != cohort.version {
++                    issues.push(CohortIssue::FieldMismatch(cohort.id, "version"));
++                }
++            }
++        }
++    }
++
++    for cohort in live {
++        if !built_by_id.contains_key(&cohort.id) {
++            issues.push(CohortIssue::StaleInCache(cohort.id));
++        }
++    }
++
++    issues.sort_by_key(cohort_issue_id);
++    issues
++}
++
++fn flag_issue_id(issue: &FlagIssue) -> FeatureFlagId {
++    match issue {
++        FlagIssue::MissingInCache(id) => *id,
++        FlagIssue::FieldMismatch(id, _) => *id,
++        FlagIssue::StaleInCache(id) => *id,
++    }
++}
++
++fn cohort_issue_id(issue: &CohortIssue) -> i32 {
++    match issue {
++        CohortIssue::MissingInCache(id) => *id,
++        CohortIssue::FieldMismatch(id, _) => *id,
++        CohortIssue::StaleInCache(id) => *id,
++    }
++}
++
++/// Drop the cache entries the shadow diff reported as stale.
++pub fn prune_stale(cache: &mut Vec<CachedFlag>, stale: &HashSet<FeatureFlagId>) {
++    for i in 0..cache.len() {
++        if stale.contains(&cache[i].id) {
++            cache.remove(i);
++        }
++    }
++}
++
++/// Share of the built payload that disagreed with the cache, for the drift metric.
++pub fn drift_percent(issues: usize, total: usize) -> u32 {
++    ((issues * 100) / total) as u32
++}

--- a/evals/benchmarks/crafted/shadow-diff-duplication/metadata.json
+++ b/evals/benchmarks/crafted/shadow-diff-duplication/metadata.json
@@ -1,0 +1,11 @@
+{
+  "id": "shadow-diff-duplication",
+  "name": "Shadow Diff Duplication",
+  "description": "Rust module that compares freshly built feature flag and cohort payloads against what the cache served, then prunes stale entries and reports drift",
+  "languages": ["rust"],
+  "frameworks": [],
+  "areas": ["correctness", "maintainability"],
+  "difficulty": "medium",
+  "expected_finding_count": 2,
+  "false_positive_trap_count": 1
+}

--- a/evals/benchmarks/crafted/unsafe-api/metadata.json
+++ b/evals/benchmarks/crafted/unsafe-api/metadata.json
@@ -7,5 +7,5 @@
   "areas": ["security", "correctness", "performance"],
   "difficulty": "medium",
   "expected_finding_count": 5,
-  "false_positive_trap_count": 1
+  "false_positive_trap_count": 2
 }

--- a/evals/benchmarks/registry.json
+++ b/evals/benchmarks/registry.json
@@ -29,6 +29,24 @@
       "difficulty": "medium"
     },
     {
+      "id": "shadow-diff-duplication",
+      "category": "crafted",
+      "name": "Shadow Diff Duplication",
+      "description": "Rust shadow diff with two by-id copies that should not be consolidated, plus real bugs elsewhere",
+      "languages": ["rust"],
+      "areas": ["correctness", "maintainability"],
+      "difficulty": "medium"
+    },
+    {
+      "id": "analytics-emitter-batching",
+      "category": "crafted",
+      "name": "Analytics Event Emitters",
+      "description": "TypeScript emitters where two functions differing by one string literal should be consolidated, next to identical per-endpoint config that should not be; the ask-branch counterpart to shadow-diff-duplication",
+      "languages": ["typescript"],
+      "areas": ["maintainability", "correctness"],
+      "difficulty": "medium"
+    },
+    {
       "id": "canonical-log-parallel",
       "category": "posthog",
       "name": "Canonical Log Lines No-Op in Parallel Path",

--- a/evals/scripts/run-eval.sh
+++ b/evals/scripts/run-eval.sh
@@ -267,7 +267,14 @@ run_crafted_benchmark() {
         return 1
     fi
 
-    local tmp_branch="eval-tmp-${id}"
+    # The reviewing agent is handed the branch name (skill_prompt puts it in the
+    # prompt) and reads the commit messages, so neither may carry the benchmark
+    # id: names like shadow-diff-duplication or unsafe-api tell it what to look
+    # for before it sees any code. Hash the id instead, which keeps the branch
+    # unique per benchmark for cleanup and for concurrent runs.
+    local bench_tag
+    bench_tag=$(printf '%s' "${id}" | git -C "${TARGET_REPO}" hash-object --stdin | cut -c1-12)
+    local tmp_branch="eval-tmp-${bench_tag}"
     local original_ref
     original_ref=$(git -C "${TARGET_REPO}" branch --show-current 2> /dev/null)
     # Detached HEAD: restore by commit SHA instead of branch name
@@ -281,7 +288,7 @@ run_crafted_benchmark() {
         git -C "${TARGET_REPO}" branch -D "${tmp_branch}" --quiet 2> /dev/null || true
     }
 
-    echo "  Applying patch to ${tmp_branch}…"
+    echo "  Applying patch for ${id} to ${tmp_branch}…"
 
     # Create a temporary branch from HEAD, apply the patch, and commit
     git -C "${TARGET_REPO}" checkout -b "${tmp_branch}" --quiet 2> /dev/null || {
@@ -300,7 +307,7 @@ run_crafted_benchmark() {
             return 1
         fi
         git -C "${TARGET_REPO}" add -A
-        git -C "${TARGET_REPO}" commit -m "eval: base state for ${id}" --quiet --no-gpg-sign
+        git -C "${TARGET_REPO}" commit -m "eval: base state ${bench_tag}" --quiet --no-gpg-sign
     fi
 
     if ! git -C "${TARGET_REPO}" apply --check "${patch}" 2> /dev/null; then
@@ -315,9 +322,9 @@ run_crafted_benchmark() {
     fi
 
     git -C "${TARGET_REPO}" add -A
-    git -C "${TARGET_REPO}" commit -m "eval: apply benchmark ${id}" --quiet --no-gpg-sign
+    git -C "${TARGET_REPO}" commit -m "eval: apply patch ${bench_tag}" --quiet --no-gpg-sign
 
-    echo "  Running review on ${tmp_branch}…"
+    echo "  Running review on ${tmp_branch} (${id})…"
 
     # Determine the org/repo for locating the review output. Plain string
     # slicing instead of sed: BSD sed rejects the lazy quantifier a trailing
@@ -384,7 +391,7 @@ run_crafted_benchmark() {
         cp "${review_file}" "${result_dir}/review.md"
         echo "  Review saved to ${result_dir}/review.md"
     else
-        echo "  Warning: no review output found for ${tmp_branch}" >&2
+        echo "  Warning: no review output found for ${id} (${tmp_branch})" >&2
     fi
 
     cleanup_crafted_benchmark

--- a/skills/review-code/briefing/shared-instructions.md
+++ b/skills/review-code/briefing/shared-instructions.md
@@ -6,6 +6,7 @@ For each finding you report:
 3. Only flag code in the diff. Do not flag pre-existing issues in unchanged code.
 4. For bug claims: read surrounding code to confirm the behavior before reporting
 5. For every `blocking:` or `suggestion:` finding, include a **concrete code fix**: show the recommended change as a diff (`- old` / `+ new`) or replacement code block. If you cannot provide a concrete fix, demote the finding to `question:`.
+6. Every finding has to ask the author for something: a change to make, or a question only they can answer. If your own analysis lands on "leave it as it is", the finding is cleared. Record it in your Investigation Summary and don't report it. A finding whose trigger hasn't happened yet is the same thing ("if a third caller is ever added…", "once this grows past N"): file it when the trigger arrives. Rewriting a no-ask finding as a `question:` or a `nit:` doesn't rescue it, and neither does describing the problem and then talking yourself out of the fix. Deferring the decision to the author ("your call", "worth considering") is fine; leaving them nothing to decide is not.
 
 **Comment Prefixes:**
 

--- a/skills/review-code/handlers/review.md
+++ b/skills/review-code/handlers/review.md
@@ -419,10 +419,11 @@ Synthesize the remaining findings using extended thinking into a coherent, dedup
 **Cross-agent corroboration:** Two findings are corroborated if they reference the same file within 10 lines, or the same logical concern in the same function. Cross-model corroboration (an adversary meta-review `CONFIRMED` verdict, only when an adversary pass ran) also counts as corroboration even if only one Claude agent flagged the issue.
 
 **Filtering rules:**
+- **No ask (every severity, applied first):** drop any finding whose recommendation is that the author change nothing now, or whose trigger hasn't happened yet ("if a third caller is ever added"). Leaving a real change to the author's judgment ("your call") is fine; leaving them nothing to decide is not.
 - **Corroborated (2+ agents or chunks):** Keep even if individual confidence is below 40%.
 - **Solo finding, confidence >= 40%:** Include as-is.
 - **Solo finding, confidence < 40%:** Drop silently.
-- **Questions and nits:** Exempt from filtering. Include regardless of confidence.
+- **Questions and nits:** Exempt from the confidence filter, not from the no-ask rule. Include regardless of confidence.
 - When consolidating corroborated findings, merge into a single entry using the highest confidence value. Corroboration is synthesis-time metadata used for prioritization; never embed it in the comment body (see "Comment Body Hygiene" below).
 
 **Comment Body Hygiene:**

--- a/tests/unit/test-eval-benchmarks.bats
+++ b/tests/unit/test-eval-benchmarks.bats
@@ -1,0 +1,171 @@
+#!/usr/bin/env bats
+# Structural checks on evals/benchmarks: every registry entry resolves to a
+# benchmark directory, and each benchmark's metadata agrees with its answer key.
+#
+# Nothing in evals/scripts reads expected_finding_count or false_positive_trap_count,
+# so without these checks the two fields drift from the answer key unnoticed and the
+# only way to find a malformed benchmark is to pay for an eval run.
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+
+    BENCHMARKS_DIR="$PROJECT_ROOT/evals/benchmarks"
+    export BENCHMARKS_DIR
+
+    REGISTRY="$BENCHMARKS_DIR/registry.json"
+    export REGISTRY
+}
+
+# Print "<category>/<id>" for every registry entry.
+benchmark_paths() {
+    jq -r '.benchmarks[] | "\(.category)/\(.id)"' "$REGISTRY"
+}
+
+@test "eval benchmarks: registry.json is valid JSON with a benchmarks array" {
+    run jq -e '.benchmarks | type == "array" and length > 0' "$REGISTRY"
+    [ "$status" -eq 0 ]
+}
+
+@test "eval benchmarks: registry ids are unique" {
+    local total unique
+    total=$(jq '.benchmarks | length' "$REGISTRY")
+    unique=$(jq '[.benchmarks[].id] | unique | length' "$REGISTRY")
+    [ "$total" -eq "$unique" ]
+}
+
+@test "eval benchmarks: every registry entry resolves to a directory with the required files" {
+    local problems=""
+    while read -r bench; do
+        local dir="$BENCHMARKS_DIR/$bench"
+        if [[ ! -d "$dir" ]]; then
+            problems+="$bench: directory not found"$'\n'
+            continue
+        fi
+        local required
+        for required in metadata.json answer-key.json diff.patch; do
+            [[ -f "$dir/$required" ]] || problems+="$bench: missing $required"$'\n'
+        done
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: metadata.json and answer-key.json parse" {
+    local problems=""
+    while read -r bench; do
+        local file
+        for file in metadata.json answer-key.json; do
+            local path="$BENCHMARKS_DIR/$bench/$file"
+            [[ -f "$path" ]] || continue
+            jq empty "$path" 2> /dev/null || problems+="$bench: $file is not valid JSON"$'\n'
+        done
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: metadata id matches the registry id" {
+    local problems=""
+    while read -r bench; do
+        local path="$BENCHMARKS_DIR/$bench/metadata.json"
+        [[ -f "$path" ]] || continue
+        local registry_id metadata_id
+        registry_id="${bench##*/}"
+        metadata_id=$(jq -r '.id // ""' "$path")
+        [[ "$metadata_id" == "$registry_id" ]] ||
+            problems+="$bench: metadata id is '$metadata_id'"$'\n'
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: metadata counts match the answer key's list lengths" {
+    local problems=""
+    while read -r bench; do
+        local meta="$BENCHMARKS_DIR/$bench/metadata.json"
+        local key="$BENCHMARKS_DIR/$bench/answer-key.json"
+        [[ -f "$meta" && -f "$key" ]] || continue
+
+        local declared_findings actual_findings declared_traps actual_traps
+        declared_findings=$(jq -r '.expected_finding_count // "unset"' "$meta")
+        actual_findings=$(jq '.expected_findings | length' "$key")
+        declared_traps=$(jq -r '.false_positive_trap_count // "unset"' "$meta")
+        actual_traps=$(jq '.false_positive_traps | length' "$key")
+
+        [[ "$declared_findings" == "$actual_findings" ]] ||
+            problems+="$bench: expected_finding_count is $declared_findings, answer key has $actual_findings"$'\n'
+        [[ "$declared_traps" == "$actual_traps" ]] ||
+            problems+="$bench: false_positive_trap_count is $declared_traps, answer key has $actual_traps"$'\n'
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: expected findings and traps carry the fields the scorer reads" {
+    local problems=""
+    while read -r bench; do
+        local key="$BENCHMARKS_DIR/$bench/answer-key.json"
+        [[ -f "$key" ]] || continue
+
+        local bad
+        bad=$(jq -r '
+            [ (.expected_findings[]? | select(
+                  (.id? // "") == "" or (.file? // "") == "" or
+                  (.line_start? | type) != "number" or (.line_end? | type) != "number" or
+                  ((.keywords? // []) | length) == 0
+              ) | "expected finding \(.id // "<no id>")"),
+              (.false_positive_traps[]? | select(
+                  (.id? // "") == "" or (.file? // "") == "" or
+                  (.line_start? | type) != "number" or (.line_end? | type) != "number" or
+                  ((.trap_keywords? // []) | length) == 0
+              ) | "trap \(.id // "<no id>")")
+            ] | join(", ")
+        ' "$key")
+        [[ -z "$bad" ]] || problems+="$bench: incomplete entries: $bad"$'\n'
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: answer key line ranges run forwards" {
+    local problems=""
+    while read -r bench; do
+        local key="$BENCHMARKS_DIR/$bench/answer-key.json"
+        [[ -f "$key" ]] || continue
+
+        local bad
+        bad=$(jq -r '
+            [ (.expected_findings[]?, .false_positive_traps[]?)
+              | select((.line_start? | type) == "number" and (.line_end? | type) == "number")
+              | select(.line_start > .line_end)
+              | "\(.id): \(.line_start)-\(.line_end)"
+            ] | join(", ")
+        ' "$key")
+        [[ -z "$bad" ]] || problems+="$bench: reversed ranges: $bad"$'\n'
+    done < <(benchmark_paths)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}
+
+@test "eval benchmarks: no benchmark directory is missing from the registry" {
+    local problems=""
+    local registered
+    registered=$(benchmark_paths)
+
+    local dir
+    while read -r dir; do
+        local bench="${dir#"$BENCHMARKS_DIR"/}"
+        grep -qxF "$bench" <<< "$registered" ||
+            problems+="$bench: on disk but not in registry.json"$'\n'
+    done < <(find "$BENCHMARKS_DIR" -mindepth 2 -maxdepth 2 -type d | sort)
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}

--- a/tests/unit/test-eval-benchmarks.bats
+++ b/tests/unit/test-eval-benchmarks.bats
@@ -169,3 +169,22 @@ benchmark_paths() {
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
 }
+
+@test "eval benchmarks: the reviewing agent is never told the benchmark id" {
+    # run_crafted_benchmark hands the temp branch name to the review prompt and
+    # commits on that branch, and the skill reads both the branch name and the
+    # commit messages. An id like shadow-diff-duplication or unsafe-api would
+    # tell the reviewer what to look for before it reads any code.
+    local script="$PROJECT_ROOT/evals/scripts/run-eval.sh"
+    local problems=""
+
+    grep -qE 'tmp_branch="eval-tmp-\$\{bench_tag\}"' "$script" ||
+        problems+="temp branch name is not derived from the hashed bench_tag"$'\n'
+
+    local leaky
+    leaky=$(grep -nE 'commit -m "eval:[^"]*\$\{id\}' "$script" || true)
+    [[ -z "$leaky" ]] || problems+="eval commit message carries the id: $leaky"$'\n'
+
+    [[ -z "$problems" ]] || echo "$problems" >&2
+    [ -z "$problems" ]
+}

--- a/tests/unit/test-eval-benchmarks.bats
+++ b/tests/unit/test-eval-benchmarks.bats
@@ -15,11 +15,20 @@ setup() {
 
     REGISTRY="$BENCHMARKS_DIR/registry.json"
     export REGISTRY
-}
 
-# Print "<category>/<id>" for every registry entry.
-benchmark_paths() {
-    jq -r '.benchmarks[] | "\(.category)/\(.id)"' "$REGISTRY"
+    # Every loop below walks this list, and a `while read` over an empty list
+    # runs zero times and passes without asserting anything. Resolve it once
+    # here so an unreadable or empty registry fails every test in the file
+    # instead of leaving six of them reporting ok on nothing.
+    BENCH_PATHS=$(jq -r '.benchmarks[] | "\(.category)/\(.id)"' "$REGISTRY") || {
+        echo "setup: cannot read the benchmark list from $REGISTRY" >&2
+        return 1
+    }
+    if [[ -z "$BENCH_PATHS" ]]; then
+        echo "setup: the benchmark list from $REGISTRY is empty" >&2
+        return 1
+    fi
+    export BENCH_PATHS
 }
 
 @test "eval benchmarks: registry.json is valid JSON with a benchmarks array" {
@@ -46,7 +55,7 @@ benchmark_paths() {
         for required in metadata.json answer-key.json diff.patch; do
             [[ -f "$dir/$required" ]] || problems+="$bench: missing $required"$'\n'
         done
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -61,7 +70,7 @@ benchmark_paths() {
             [[ -f "$path" ]] || continue
             jq empty "$path" 2> /dev/null || problems+="$bench: $file is not valid JSON"$'\n'
         done
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -77,7 +86,7 @@ benchmark_paths() {
         metadata_id=$(jq -r '.id // ""' "$path")
         [[ "$metadata_id" == "$registry_id" ]] ||
             problems+="$bench: metadata id is '$metadata_id'"$'\n'
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -100,7 +109,7 @@ benchmark_paths() {
             problems+="$bench: expected_finding_count is $declared_findings, answer key has $actual_findings"$'\n'
         [[ "$declared_traps" == "$actual_traps" ]] ||
             problems+="$bench: false_positive_trap_count is $declared_traps, answer key has $actual_traps"$'\n'
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -127,7 +136,7 @@ benchmark_paths() {
             ] | join(", ")
         ' "$key")
         [[ -z "$bad" ]] || problems+="$bench: incomplete entries: $bad"$'\n'
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -148,7 +157,7 @@ benchmark_paths() {
             ] | join(", ")
         ' "$key")
         [[ -z "$bad" ]] || problems+="$bench: reversed ranges: $bad"$'\n'
-    done < <(benchmark_paths)
+    done <<< "$BENCH_PATHS"
 
     [[ -z "$problems" ]] || echo "$problems" >&2
     [ -z "$problems" ]
@@ -157,7 +166,7 @@ benchmark_paths() {
 @test "eval benchmarks: no benchmark directory is missing from the registry" {
     local problems=""
     local registered
-    registered=$(benchmark_paths)
+    registered="$BENCH_PATHS"
 
     local dir
     while read -r dir; do

--- a/tests/unit/test-setup.bats
+++ b/tests/unit/test-setup.bats
@@ -344,6 +344,10 @@ setup_function_body() {
         debug() { :; }
         warn() { :; }
         error() { :; }
+        # install_agents calls this whenever the codex CLI or config dir exists,
+        # so without the stub these tests pass or fail depending on whether the
+        # machine has Codex installed. They cover the PostHog Desktop loop.
+        install_codex_agents() { :; }
         HOME='${fake_home}'
         SCRIPT_DIR='$PROJECT_ROOT'
         CLAUDE_DIR='${fake_home}/.claude'
@@ -372,6 +376,10 @@ setup_function_body() {
         debug() { :; }
         warn() { :; }
         error() { :; }
+        # install_agents calls this whenever the codex CLI or config dir exists,
+        # so without the stub these tests pass or fail depending on whether the
+        # machine has Codex installed. They cover the PostHog Desktop loop.
+        install_codex_agents() { :; }
         HOME='${fake_home}'
         SCRIPT_DIR='$PROJECT_ROOT'
         CLAUDE_DIR='${fake_home}/.claude'


### PR DESCRIPTION
Findings that ask the author for nothing now get dropped, and two-copy duplication is judged by what the extraction costs rather than by a count.

## The no-ask rule

Every finding has to ask for a change, or a question only the author can answer. If the analysis lands on "leave it as it is", the agent records that in its Investigation Summary and never reports it. A trigger that hasn't happened yet gets the same treatment ("if a third caller is ever added"). Rewriting it as a `question:` or a `nit:` doesn't rescue it.

The rule lives in `briefing/shared-instructions.md`, which every reviewer reads, and again as a synthesis-time filter in `handlers/review.md`. Questions and nits stay exempt from the confidence filter, but not from this one.

## Two copies: ask, or stay silent

`code-reviewer-maintainability.md` drops the "3+ use cases" threshold. Two near-identical blocks are a finding when one shared function with a plain signature replaces both, and the comment has to carry that signature. When collapsing them needs generics, a trait, or a behavior flag threaded through several decision points, the finding is cleared. Describing the duplication and then declining to ask for the extraction is not an option; it leaves the author nothing to do.

`code-reviewer-architecture.md` had its own copy of the 3+ rule and now uses the same wording, so both agents that file consolidation findings give the same answer.

## Benchmarks, one per branch of the rule

`shadow-diff-duplication` (Rust) traps the false positive: two by-id diff functions whose consolidation would need generics and a trait, plus an index-shift bug and a divide-by-zero the reviewer should catch.

`analytics-emitter-batching` (TypeScript) expects the ask: `trackSignup` and `trackLogin` differ only by an event-name string. Two correctness bugs sit alongside them, and identical per-endpoint retry constants are the trap, since config that happens to match is not a consolidation ask.

## The benchmark id no longer reaches the reviewer

`run_crafted_benchmark` named its temp branch after the benchmark id and put the id in its commit messages. The branch name goes into the review prompt, and the skill reads commit messages into the agent briefing. A run of `shadow-diff-duplication` therefore told the reviewer to think about duplication before it read any code, and `unsafe-api` named its own bug class. Both now use a 12-character hash of the id, which stays unique per benchmark for cleanup and for concurrent runs. Console output still prints the readable id for the operator.

The baseline arm had the matching problem. `build_baseline_prompt` prepends `metadata.json`'s name and description to every benchmark's prompt, so those fields now describe the module instead of the answer key. The explicit "what this tests" wording moved to `registry.json`, which reaches no prompt.

## Tests

`tests/unit/test-eval-benchmarks.bats` checks every registry entry against its benchmark directory:

- the required files exist
- ids are unique and match `metadata.json`
- the two count fields match the answer key's list lengths
- findings and traps carry the fields the scorer reads
- line ranges run forwards
- no benchmark directory is missing from the registry
- the temp branch and eval commit messages don't carry the benchmark id

It caught `unsafe-api` declaring one false-positive trap while its answer key has two.

The two PostHog Desktop tests in `test-setup.bats` now stub `install_codex_agents`. `install_agents` calls it whenever the codex CLI is present, so those tests passed or failed depending on whether the developer had Codex installed rather than on the code.

## Test plan

- `bin/test` passes, including the ten new benchmark checks and the two repaired setup tests.
- `bin/lint` and `bin/fmt` are clean.
- `git apply --check` passes on both new fixture patches, and each `@@` header matches its line count.
- Ran the id hashing over all 11 registry ids: no word of any id survives into the branch name or the commit messages, and the 11 hashes are distinct.
- Reintroduced the id leak by hand and confirmed the new guard fails, then restored it.
- The two setup tests pass both with codex on PATH and with `CODEX_HOME` set.

https://claude.ai/code/session_01TxYJqbTFci72jrn9quaKfR
