### PR TITLE
Teach reviewers to verify externally-defined values

### DIFF
--- a/skills/review-code/briefing/shared-instructions.md
+++ b/skills/review-code/briefing/shared-instructions.md
@@ -29,7 +29,7 @@ When the answer is about file content (does X exist, what does Y do, where is Z 
 2. If `working_dir` is set, use Read/Grep on the PR's files at `git.working_dir`.
 3. If `file_ref` is set, fetch via `git show "$file_ref:<path>"`.
 4. If `pr.head_sha` is available, fetch via `gh api repos/<org>/<repo>/contents/<path>?ref=<sha>` and decode the base64 `content` field.
-5. If the answer lives in a different repo, name that repo and look there. Check a local clone if one is mapped in `repos.conf`, otherwise `gh api repos/<org>/<repo>/contents/<path>` (decode the base64 `content` field) or `gh search code`. For PostHog, deployment and runtime values live in `PostHog/charts`; the org context file lists the key paths.
+5. If the answer lives in a different repo, name that repo and look there. Check a local clone if one is mapped in `repos.conf`, otherwise `gh api repos/<org>/<repo>/contents/<path>` (decode the base64 `content` field; add `?ref=<sha-or-tag-or-branch>` when you know which ref to read) or `gh search code`. For PostHog, deployment and runtime values live in `PostHog/charts`; the org context file lists the key paths.
 
 **Values your finding depends on.**
 

--- a/skills/review-code/briefing/shared-instructions.md
+++ b/skills/review-code/briefing/shared-instructions.md
@@ -29,13 +29,11 @@ When the answer is about file content (does X exist, what does Y do, where is Z 
 2. If `working_dir` is set, use Read/Grep on the PR's files at `git.working_dir`.
 3. If `file_ref` is set, fetch via `git show "$file_ref:<path>"`.
 4. If `pr.head_sha` is available, fetch via `gh api repos/<org>/<repo>/contents/<path>?ref=<sha>` and decode the base64 `content` field.
-5. If the answer lives in a different repo, name that repo and look there. For PostHog, deployment and runtime values (grace periods, replica counts, resource limits, timeouts for deployed services) live in `PostHog/charts`; the org context file lists the key paths. Check a local clone if one is configured, otherwise `gh api repos/PostHog/charts/contents/<path>` (decode the base64 `content` field) or `gh search code`.
+5. If the answer lives in a different repo, name that repo and look there. Check a local clone if one is mapped in `repos.conf`, otherwise `gh api repos/<org>/<repo>/contents/<path>` (decode the base64 `content` field) or `gh search code`. For PostHog, deployment and runtime values live in `PostHog/charts`; the org context file lists the key paths.
 
 **Values your finding depends on.**
 
-If a finding's severity rests on a specific number — a timeout, grace period, batch size, quota, rollout percentage, retry count — the finding is only as good as the number. Read the value before asserting the consequence (ladder steps 1–5 cover values in other files and other repos). If you cannot read it, describe the coupling without asserting the outcome, and label the finding `question:` or note the unchecked value in the body.
-
-Arithmetic in the diff is verifiable from the diff and is a legitimate observation; the consequence of that arithmetic depends on a value and is not assertable without reading it. The shutdown-drain case: "the shutdown path now drains twice, 15s each, so up to 30s" is verifiable from the diff. "…which exceeds the grace period and triggers SIGKILL" is only a finding if you read `terminationGracePeriodSeconds` — otherwise the honest finding is "this timeout is now consumed twice, and the comment describing it still reads as a single budget."
+If a finding's severity rests on a specific number — a timeout, grace period, batch size, quota, rollout percentage, retry count — the finding is only as good as the number. Read the value before asserting the consequence. If you cannot read it, describe the coupling without asserting the outcome, and label the finding `question:`. Arithmetic in the diff is verifiable from the diff and fine to state (a shutdown path that now drains twice at 15s each is up to 30s); its consequence ("exceeds the grace period, triggers SIGKILL") is a finding only after you have read the value it is measured against.
 
 Only ask the author when the answer genuinely depends on context outside the code: their intent, a future plan, an incident the code is responding to, an external system's behavior. "What do you mean?" / "Does X exist?" / "Where is Y handled?" almost always have an answer in the repo, and asking the author for them wastes their time.
 

--- a/skills/review-code/briefing/shared-instructions.md
+++ b/skills/review-code/briefing/shared-instructions.md
@@ -29,6 +29,13 @@ When the answer is about file content (does X exist, what does Y do, where is Z 
 2. If `working_dir` is set, use Read/Grep on the PR's files at `git.working_dir`.
 3. If `file_ref` is set, fetch via `git show "$file_ref:<path>"`.
 4. If `pr.head_sha` is available, fetch via `gh api repos/<org>/<repo>/contents/<path>?ref=<sha>` and decode the base64 `content` field.
+5. If the answer lives in a different repo, name that repo and look there. For PostHog, deployment and runtime values (grace periods, replica counts, resource limits, timeouts for deployed services) live in `PostHog/charts`; the org context file lists the key paths. Check a local clone if one is configured, otherwise `gh api repos/PostHog/charts/contents/<path>` (decode the base64 `content` field) or `gh search code`.
+
+**Values your finding depends on.**
+
+If a finding's severity rests on a specific number — a timeout, grace period, batch size, quota, rollout percentage, retry count — the finding is only as good as the number. Read the value before asserting the consequence (ladder steps 1–5 cover values in other files and other repos). If you cannot read it, describe the coupling without asserting the outcome, and label the finding `question:` or note the unchecked value in the body.
+
+Arithmetic in the diff is verifiable from the diff and is a legitimate observation; the consequence of that arithmetic depends on a value and is not assertable without reading it. The shutdown-drain case: "the shutdown path now drains twice, 15s each, so up to 30s" is verifiable from the diff. "…which exceeds the grace period and triggers SIGKILL" is only a finding if you read `terminationGracePeriodSeconds` — otherwise the honest finding is "this timeout is now consumed twice, and the comment describing it still reads as a single budget."
 
 Only ask the author when the answer genuinely depends on context outside the code: their intent, a future plan, an incident the code is responding to, an external system's behavior. "What do you mean?" / "Does X exist?" / "Where is Y handled?" almost always have an answer in the repo, and asking the author for them wastes their time.
 

--- a/skills/review-code/context/orgs/posthog/org.md
+++ b/skills/review-code/context/orgs/posthog/org.md
@@ -38,7 +38,7 @@ When reviewing networking, IP handling, or infrastructure-related code, consult 
     - `argocd/contour/values/values.yaml` - num-trusted-hops config
     - `argocd/contour-ingress/values/values.prod-*.yaml` - routing and header policies
     - `docs/CONTOUR-GEOIP-README.md` - GeoIP and header handling
-    - `charts/posthog-rust/templates/deployment.yaml` - pod defaults for Rust services (grace period, resources; current values in the repo context file)
+    - `charts/posthog-rust/templates/deployment.yaml` - pod defaults for Rust services (grace period, resources; current values in `repos/charts.md`)
 
 ## Performance Guidelines
 

--- a/skills/review-code/context/orgs/posthog/org.md
+++ b/skills/review-code/context/orgs/posthog/org.md
@@ -38,8 +38,7 @@ When reviewing networking, IP handling, or infrastructure-related code, consult 
     - `argocd/contour/values/values.yaml` - num-trusted-hops config
     - `argocd/contour-ingress/values/values.prod-*.yaml` - routing and header policies
     - `docs/CONTOUR-GEOIP-README.md` - GeoIP and header handling
-    - `charts/posthog-rust/templates/deployment.yaml` - `terminationGracePeriodSeconds` (55s) and pod defaults for Rust services
-    - `argocd/posthog-rust/values/<service>/values*.yaml` - per-service overrides of the Rust deployment defaults
+    - `charts/posthog-rust/templates/deployment.yaml` - pod defaults for Rust services (grace period, resources; current values in the repo context file)
 
 ## Performance Guidelines
 

--- a/skills/review-code/context/orgs/posthog/org.md
+++ b/skills/review-code/context/orgs/posthog/org.md
@@ -33,11 +33,13 @@ When reviewing networking, IP handling, or infrastructure-related code, consult 
   - See: `README.md` for architecture diagram
 
 - **`~/dev/posthog/charts`** - Helm charts and K8s deployment configs
-  - Contains: Contour/Envoy configuration, ingress rules, header policies
+  - Contains: Contour/Envoy configuration, ingress rules, header policies, pod lifecycle values, resource limits
   - Key files:
     - `argocd/contour/values/values.yaml` - num-trusted-hops config
     - `argocd/contour-ingress/values/values.prod-*.yaml` - routing and header policies
     - `docs/CONTOUR-GEOIP-README.md` - GeoIP and header handling
+    - `charts/posthog-rust/templates/deployment.yaml` - `terminationGracePeriodSeconds` (55s) and pod defaults for Rust services
+    - `argocd/posthog-rust/values/<service>/values*.yaml` - per-service overrides of the Rust deployment defaults
 
 ## Performance Guidelines
 

--- a/skills/review-code/context/orgs/posthog/repos/charts.md
+++ b/skills/review-code/context/orgs/posthog/repos/charts.md
@@ -70,4 +70,5 @@ When reviewing changes:
 2. Check that service names reference actual deployed services
 3. Confirm environment variable additions are propagated to all relevant deployments
 4. Note any intentional per-environment differences (e.g., staged rollouts)
-5. A `posthog/posthog` change bounded by a deployment value (shutdown timeouts against the grace period, replica counts, resource limits) needs that value read from this repo before asserting what happens when it's exceeded.
+
+Deployment values in this repo bound `posthog/posthog` application timeouts (shutdown drains against `terminationGracePeriodSeconds`, connection counts against replica counts, memory use against resource limits), so application changes there assert consequences about values defined here.

--- a/skills/review-code/context/orgs/posthog/repos/charts.md
+++ b/skills/review-code/context/orgs/posthog/repos/charts.md
@@ -59,6 +59,10 @@ Services follow the naming pattern `posthog-<service-name>`. Examples:
 
 - `SERVICE_MODE` - Controls which routes a service registers (e.g., `"flags"` for flags-only mode)
 
+Pod lifecycle values:
+
+- `terminationGracePeriodSeconds` - `charts/posthog-rust/templates/deployment.yaml` defaults it to 55. Rust services (`posthog-feature-flags`, `posthog-feature-flags-definitions`) inherit it unless their `argocd/posthog-rust/values/<service>/values*.yaml` overrides it; as of this writing none of them does.
+
 ## Cross-Environment Consistency
 
 When reviewing changes:
@@ -66,3 +70,4 @@ When reviewing changes:
 2. Check that service names reference actual deployed services
 3. Confirm environment variable additions are propagated to all relevant deployments
 4. Note any intentional per-environment differences (e.g., staged rollouts)
+5. A `posthog/posthog` change bounded by a deployment value (shutdown timeouts against the grace period, replica counts, resource limits) needs that value read from this repo before asserting what happens when it's exceeded.

--- a/skills/review-code/context/orgs/posthog/repos/charts.md
+++ b/skills/review-code/context/orgs/posthog/repos/charts.md
@@ -71,4 +71,4 @@ When reviewing changes:
 3. Confirm environment variable additions are propagated to all relevant deployments
 4. Note any intentional per-environment differences (e.g., staged rollouts)
 
-Deployment values in this repo bound `posthog/posthog` application timeouts (shutdown drains against `terminationGracePeriodSeconds`, connection counts against replica counts, memory use against resource limits), so application changes there assert consequences about values defined here.
+Deployment values in this repo bind `posthog/posthog` application timeouts (shutdown drains against `terminationGracePeriodSeconds`, connection counts against replica counts, memory use against resource limits), so application changes there assert consequences about values defined here.


### PR DESCRIPTION
## Summary

Teaches the `/review-code` skill to check numbers that live outside the current repo before asserting consequences about them. Two changes work together:

1. **A new lookup step** in the briefing every review agent reads: when a finding depends on a value from another repo, the agent is instructed to fetch it (via a local clone in `repos.conf`, `gh api`, or `gh search code`) and to downgrade the finding to a question when the value can't be verified.

2. **The concrete PostHog facts** that make the rule actionable for the motivating case: `charts.md` now records that `terminationGracePeriodSeconds` defaults to 55 in `charts/posthog-rust/templates/deployment.yaml` and that the two Rust flags services currently inherit it without override (`argocd/posthog-rust/values/<service>/values*.yaml`). `org.md` points at `repos/charts.md` as the canonical home so the value lives in one place.

The change was motivated by a reviewer asserting "this 60s shutdown drain exceeds the pod's grace period" without checking what the grace period actually is.

## Review

Self-reviewed with `/review-code --fix`. Three findings: one auto-applied (the `org.md` pointer now names `repos/charts.md` directly), two skipped as low-confidence and listed in the review file at `.reviews/haacked/review-code/haacked-verify-external-values.md`. Correctness, security, testing, and architecture all came back clean; the correctness agent independently re-verified the `55` default and the no-override claim against a live `posthog/charts` clone.

---
*Created with [PostHog Desktop](https://posthog.com/desktop?ref=pr)*