### PR TITLE
Amend pending review comments without re-running the review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,8 @@ This repo contains the source files for the `/review-code` skill:
 
 The nine domain reviewers in `agents/` deliberately repeat four shared blocks instead of sourcing them from one file: "Before You Review", "Self-Challenge", the confidence rubric, and the finding format (a fenced ```text body plus the `Location: path:line | Confidence: NN%` trailer). Each subagent receives its own prompt exactly once, so deduplicating would save no runtime tokens; keep the four blocks in sync when editing one. The finding format is parsed by `parse-review-findings.sh` and the synthesis step in `handlers/review.md`; don't change its shape.
 
+A posted finding also carries the GitHub comment it produced, as an HTML comment on its heading: ``#### `path:42` <!-- pc:<id> <node_id> b:<digest> -->``. Three separate things depend on it sitting exactly there. `parse-review-findings.sh` never lets a heading line reach a finding's `description` and its header pattern is unanchored on the right, so the annotation changes nothing it parses. The annotation sits inside the finding's span, so `carry-forward-findings.sh` cuts it with the finding instead of orphaning it. And the digest is the body as of the last sync, which is the only thing that can say whether a later difference came from the notes or from someone editing the comment in the GitHub UI; without it `amend-pending-review.sh --push` cannot tell a clean push from one overwriting a hand edit. `review-comment-blocks.py` owns every read and write of these, and `tests/unit/test-review-comment-blocks.bats` asserts the parser cannot see them.
+
 ## Architecture
 
 **In the repository:**

--- a/skills/review-code/SKILL.md
+++ b/skills/review-code/SKILL.md
@@ -88,9 +88,9 @@ Examples:
 
 Uses session-based caching to run the orchestrator once and reuse data across bash invocations. This reduces token usage by ~60%.
 
-**Safety model:** GitHub review writes go only through the sanctioned scripts (`create-draft-review.sh`, `submit-review.sh`); a PreToolUse hook blocks direct `gh pr review` and review-API calls. Two rules the hook can't enforce:
+**Safety model:** GitHub review writes go only through the sanctioned scripts (`create-draft-review.sh`, `amend-pending-review.sh`, `submit-review.sh`); a PreToolUse hook blocks direct `gh pr review`, review-API calls, and review-comment mutations on either transport. Two rules the hook can't enforce:
 
-- Never submit a review on the user's behalf. Submitting requires their explicit instruction; if you can't amend a pending review, ask before doing anything that would submit it.
+- Never submit a review on the user's behalf. Submitting requires their explicit instruction. To correct a comment on a review already posted, amend it: `handlers/amend-pending-review.md` covers rewording and dropping without re-running the review. Submitting is never the way to fix a wrong comment.
 - When a step fails (session init, script error, API error), stop and report the failure instead of improvising a workaround. In particular, never post findings as a regular PR comment: that publishes immediately instead of staying pending.
 
 ### Step 1: Parse Arguments

--- a/skills/review-code/handlers/amend-pending-review.md
+++ b/skills/review-code/handlers/amend-pending-review.md
@@ -1,0 +1,73 @@
+## Amend a Pending Review
+
+Loaded on request, when a comment on a review you already posted needs rewording or removing. Nothing here runs as part of a review; a review that has just been posted is already correct as far as it knows.
+
+Use this when the author pushes back and they are right, when a finding turns out to be partly wrong, or when re-reading the posted comment shows the wording lands badly. Do not re-run the review to fix a comment: `--draft` only posts at the end of a review, so a re-run costs every agent again, gives every comment a new id, and discards anything edited by hand in the GitHub UI.
+
+**Never use a raw `gh api` call for this.** The PreToolUse hook blocks the review-comment endpoints on both REST and GraphQL, and the reason it blocks them is that they can delete a published comment, including someone else's. `amend-pending-review.sh` refuses any comment that is not in your own pending review.
+
+### The four steps
+
+Work in this order. Step 1 exists because the author may have edited a comment in the GitHub UI, and skipping it means overwriting their edit.
+
+**1. See where things stand.**
+
+```bash
+~/.agents/skills/review-code/scripts/amend-pending-review.sh <pr> --json
+```
+
+Each recorded comment comes back as one of:
+
+| State | Meaning |
+|---|---|
+| `in_sync` | The notes and GitHub agree |
+| `changed_on_github` | Someone edited the comment in the UI; the notes are stale |
+| `changed_in_notes` | You reworded it in the notes and have not pushed yet |
+| `diverged` | Both moved; the UI edit and your reword conflict |
+| `missing_on_github` | The comment is gone, but the finding is still live in the notes |
+| `unknown_baseline` | Posted before ids were recorded, so neither side can be trusted as the baseline |
+
+**2. Pull anything GitHub changed.**
+
+```bash
+~/.agents/skills/review-code/scripts/amend-pending-review.sh <pr> --pull
+```
+
+This copies GitHub's wording into the notes. Run it whenever anything reads `changed_on_github`, `diverged`, or `unknown_baseline`. `--push` refuses while any comment is in one of the first two states, and tells you so.
+
+**3. Reword in the review file.** Edit the ` ```text ` body of the finding block. Change only the body: the heading, its `<!-- pc:… -->` annotation, and the `*From: …*` line are how the two sides stay matched.
+
+Keep the voice rules that applied when the comment was written (see Inline Comment Voice in `review.md`), including the blank line at the seam between problem and recommendation.
+
+**4. Push it back.**
+
+```bash
+# Check first. This prints the full body of everything it would change.
+~/.agents/skills/review-code/scripts/amend-pending-review.sh <pr> --push --dry-run
+~/.agents/skills/review-code/scripts/amend-pending-review.sh <pr> --push
+```
+
+Add `--comment-id <id>` to push one comment when you reworded several and only want one to go.
+
+The comment keeps its id, so any reply thread on it survives, and the review stays `PENDING` throughout.
+
+### Dropping a finding outright
+
+When the finding is wrong rather than badly worded, take the comment off the PR and record why:
+
+```bash
+~/.agents/skills/review-code/scripts/amend-pending-review.sh <pr> \
+  --drop --comment-id <id> --reason "author showed environments are deprecated; confirmed in prod"
+```
+
+Deletion is irreversible and the body is not recoverable from GitHub afterwards, so run it with `--dry-run` first and read the body it echoes.
+
+This marks the finding withdrawn in the review file rather than deleting it. The block stays, so the argument that retired it stays on the record, and a later `--append` re-review will neither carry it forward nor repost it. Write a real reason: it is what a reader, and the learning pass, use to tell a false positive from a fix that landed.
+
+### What this cannot do
+
+- **A finding in the review body.** Comments that could not be mapped to a diff position are folded into the pending review's summary under `**Additional Notes:**` and have no comment id. Change those in the GitHub UI.
+- **A pending review this tooling did not post.** Without recorded ids there is nothing to match on. The status output says so rather than guessing.
+- **A submitted review.** Once submitted, its comments are public and out of scope here.
+
+If a step fails, stop and report it. Do not fall back to a raw API call, and do not submit the review: submitting is never the way to fix a wrong comment.

--- a/skills/review-code/handlers/amend-pending-review.md
+++ b/skills/review-code/handlers/amend-pending-review.md
@@ -37,7 +37,7 @@ This copies GitHub's wording into the notes. Run it whenever anything reads `cha
 
 **3. Reword in the review file.** Edit the ` ```text ` body of the finding block. Change only the body: the heading, its `<!-- pc:… -->` annotation, and the `*From: …*` line are how the two sides stay matched.
 
-Keep the voice rules that applied when the comment was written (see Inline Comment Voice in `review.md`), including the blank line at the seam between problem and recommendation.
+Keep the voice rules that applied when the comment was written (see Inline Comment Voice in `briefing/shared-instructions.md`), including the blank line at the seam between problem and recommendation.
 
 **4. Push it back.**
 

--- a/skills/review-code/handlers/learn.md
+++ b/skills/review-code/handlers/learn.md
@@ -41,6 +41,8 @@ For **"unaddressed" findings** (Claude found, file not modified after review), s
   3. "Correct but low priority": Valid but not worth changing
   4. "Skip": Don't record this learning
 
+For **"withdrawn" findings** (dropped from the review after it was posted), do not ask. The author already argued the finding down and `withdrawn_reason` carries what they said, so record it straight away as `type: "false_positive"`, `source: "claude"`, with the finding's `withdrawn_reason` as `user_feedback`. Report each one in a line so the user can see what was recorded on their behalf. Asking again would put the same question back to the person who already answered it, and "the file was not modified" is exactly what a withdrawn finding looks like.
+
 For **"missed" findings** (other reviewer found, Claude missed), show file, line, description, and author, then use AskUserQuestion:
 - Question: "Another reviewer found this issue that Claude missed. Should Claude learn to detect this?"
 - Options:

--- a/skills/review-code/handlers/review-pr-output.md
+++ b/skills/review-code/handlers/review-pr-output.md
@@ -58,7 +58,7 @@ When combining agent findings into the review document, add a "Suggested Comment
 
    Comment bodies already have their in-prose file:line citations rendered as GitHub permalinks (see "Link File References in Comment Bodies" above). Keep those links intact when writing the bodies into the review file.
 
-   Bodies must also already carry the seam structure (see "Break at the seam" under Inline Comment Voice in `review.md`) before they're written into the review file; preserve their paragraph breaks, never flatten a body into one block.
+   Bodies must also already carry the seam structure (see "Break at the seam" under Inline Comment Voice in `briefing/shared-instructions.md`) before they're written into the review file; preserve their paragraph breaks, never flatten a body into one block.
 
 2. **Check against existing comments**: For each finding, check if there are existing inline comments (from `$inline_comments`) that:
    - Are on the same file
@@ -86,7 +86,7 @@ For each finding that needs a new comment:
 #### `<file_path>:<line_number>`
 
 ```text
-<comment text: direct, specific, conversational (see Inline Comment Voice in review.md)>
+<comment text: direct, specific, conversational (see Inline Comment Voice in briefing/shared-instructions.md)>
 ```
 
 *From: <Agent Name> (<confidence>% confidence)*
@@ -168,7 +168,7 @@ If any condition fails, skip draft review creation.
 
    Keep any GitHub permalinks in the comment body intact (see "Link File References in Comment Bodies" above). They render as clickable links in the posted comment. The same applies to the `summary` field and `unmapped_comments` descriptions.
 
-   Bodies must already carry the seam structure (see "Break at the seam" under Inline Comment Voice in `review.md`); copy their blank lines into the draft payload verbatim.
+   Bodies must already carry the seam structure (see "Break at the seam" under Inline Comment Voice in `briefing/shared-instructions.md`); copy their blank lines into the draft payload verbatim.
 
    Look for this pattern in the review file:
    ```

--- a/skills/review-code/handlers/review-pr-output.md
+++ b/skills/review-code/handlers/review-pr-output.md
@@ -200,6 +200,7 @@ EOF
   "reviewer_username": "<reviewer from session>",
   "review_commit": "<pr.head_sha from session, if available>",
   "original_diff_path": "<diff_path>",
+  "review_file": "<review_file from session>",
   "summary": "<Short, conversational summary (see guidance below)>",
   "comments": [
     {"path": "file.ts", "line": 42, "side": "RIGHT", "body": "Clean comment text", "line_content": "    the_actual_code()"}

--- a/skills/review-code/handlers/review-pr-output.md
+++ b/skills/review-code/handlers/review-pr-output.md
@@ -164,6 +164,8 @@ If any condition fails, skip draft review creation.
 
 1. **Extract suggested comments from the review**: Parse the "Suggested Comments" section to get file path, line number, and comment body. Extract only the text inside the ` ```text ``` ` code block; the `*From: <Agent Name> (<confidence>% confidence)*` line is internal metadata and never goes to GitHub.
 
+   **Skip any block carrying a `*Withdrawn ...*` line or a `withdrawn:` mark on its heading.** Those findings were argued down by the author and taken off the PR; they stay in the document so the argument stays on the record. Reposting one would put back the exact comment someone already had removed.
+
    Keep any GitHub permalinks in the comment body intact (see "Link File References in Comment Bodies" above). They render as clickable links in the posted comment. The same applies to the `summary` field and `unmapped_comments` descriptions.
 
    Bodies must already carry the seam structure (see "Break at the seam" under Inline Comment Voice in `review.md`); copy their blank lines into the draft payload verbatim.
@@ -272,9 +274,11 @@ Summary:
 - Note: PR received new commits since review. Comments were adjusted to match current diff.
 
 The review is in PENDING state. Visit GitHub to:
-- Edit or remove any comments
 - Add additional comments
 - Submit with Approve/Request Changes/Comment
+
+To reword or drop a comment later, read
+~/.agents/skills/review-code/handlers/amend-pending-review.md.
 ```
 
 If failed, show the error and suggest using the review file manually.
@@ -289,6 +293,12 @@ If failed, show the error and suggest using the review file manually.
   3. Suggest: "You can copy comments from the review file and post them manually on GitHub."
   4. Clean up the session: `~/.agents/skills/review-code/scripts/review-status-handler.sh cleanup "<SESSION_ID>"`
   5. **Stop here.** Do not post the findings any other way: a regular PR comment or a direct `gh pr review` call publishes immediately instead of staying pending (and the PreToolUse hook blocks the direct calls regardless).
+
+### Amending a Draft After It Is Posted
+
+**Nothing in this section runs during a review.** It is here so the correction path sits next to the posting path; skip it unless the user is asking to change a comment on a review that is already on GitHub.
+
+A finding that gets argued down, or one whose wording turns out to be wrong, does not need a new review. Read `~/.agents/skills/review-code/handlers/amend-pending-review.md` and follow it. Never reach for a raw `gh api` call: the PreToolUse hook blocks those endpoints on both REST and GraphQL, and re-running the review to fix one sentence costs every agent again and renumbers every comment.
 
 ### Resolve Addressed Threads (--append, PR Mode Only)
 

--- a/skills/review-code/scripts/amend-pending-review.sh
+++ b/skills/review-code/scripts/amend-pending-review.sh
@@ -38,6 +38,8 @@
 # .../events, and every comment it touches must already belong to the caller's
 # own pending review.
 
+# shellcheck disable=SC2016  # jq and GraphQL documents throughout; the $vars
+# in single quotes are bound by --argjson/--arg/-f, not shell expansions.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,71 +48,11 @@ source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 # shellcheck source=helpers/gh-review-helpers.sh
 source "${SCRIPT_DIR}/helpers/gh-review-helpers.sh"
 
-# ── Logging ──────────────────────────────────────────────────────────────────
-# Log to stderr so stdout stays clean for JSON consumers.
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1" >&2; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+# shellcheck source=helpers/pr-target.sh
+source "${SCRIPT_DIR}/helpers/pr-target.sh"
 
 usage() {
     sed -n '2,39p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
-}
-
-# ── PR target resolution ─────────────────────────────────────────────────────
-# Vendored from resolve-review-threads.sh, which vendors it in turn. Keep the
-# three copies in step.
-
-parse_pr_url() {
-    local url="$1"
-    if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
-        OWNER="${BASH_REMATCH[1]}"
-        REPO_NAME="${BASH_REMATCH[2]}"
-        REPO="${OWNER}/${REPO_NAME}"
-        PR_NUMBER="${BASH_REMATCH[3]}"
-        return 0
-    fi
-    return 1
-}
-
-get_current_repo() {
-    gh repo view --json nameWithOwner -q '.nameWithOwner' 2> /dev/null || {
-        log_error "Could not determine repository. Run from inside a repo or pass a full PR URL."
-        exit 1
-    }
-}
-
-resolve_pr_target() {
-    local pr_arg="${1:-}"
-    if [[ -z "$pr_arg" ]]; then
-        local pr_url
-        pr_url=$(gh pr view --json url -q '.url' 2> /dev/null) || {
-            log_error "No PR found for the current branch. Specify a PR number or URL."
-            exit 1
-        }
-        if ! parse_pr_url "$pr_url"; then
-            log_error "Could not parse PR URL from current branch: ${pr_url}"
-            exit 1
-        fi
-    elif parse_pr_url "$pr_arg"; then
-        :
-    elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
-        PR_NUMBER="$pr_arg"
-        REPO=$(get_current_repo)
-        OWNER="${REPO%%/*}"
-        REPO_NAME="${REPO##*/}"
-    else
-        log_error "Invalid PR argument: ${pr_arg}"
-        log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
-        exit 1
-    fi
 }
 
 resolve_reviewer() {
@@ -123,7 +65,6 @@ resolve_reviewer() {
         exit 1
     fi
 }
-
 resolve_review_file() {
     if [[ -n "${REVIEW_FILE}" ]]; then
         return
@@ -154,6 +95,27 @@ echo_comment() {
         echo "${comment}" | jq -r '.notes_body // .live_body // ""'
         echo "────────────────────────────────────────────────────────────────────────"
     } >&2
+}
+
+# Emit JSON only when asked, and never let that decision become an exit status.
+# `[[ cond ]] && cmd` as a function's last statement returns 1 when cond is
+# false, which under set -euo pipefail kills the run silently, after the
+# mutation has already happened.
+# Pass data with --argjson, never by pipe: when JSON is off this returns
+# without reading stdin, so a piped producer takes SIGPIPE and set -euo
+# pipefail kills the run. That failure is a race on the pipe buffer, so it
+# hides on small payloads and surfaces under load.
+emit_json() {
+    [[ "${JSON_OUTPUT}" == "true" ]] || return 0
+    jq "$@"
+}
+
+# Show every comment a mode is about to touch, in full.
+echo_comments() {
+    local label="$1" targets="$2" comment
+    while IFS= read -r comment; do
+        echo_comment "${label}" "${comment}"
+    done < <(echo "${targets}" | jq -c '.[]')
 }
 
 display_status() {
@@ -200,8 +162,6 @@ validate_ids() {
 
 reword_comment() {
     local node_id="$1" body="$2"
-    # shellcheck disable=SC2016  # GraphQL document; $id and $body are GraphQL
-    # variables bound by --f, not shell expansions.
     gh api graphql \
         -f query='mutation($id: ID!, $body: String!) {
             updatePullRequestReviewComment(input: {pullRequestReviewCommentId: $id, body: $body}) {
@@ -224,9 +184,9 @@ main() {
     REVIEWER=""
     REASON=""
     local mode="status"
-    local dry_run=false
-    local json_output=false
-    local -a comment_ids=()
+    DRY_RUN=false
+    JSON_OUTPUT=false
+    COMMENT_IDS=()
 
     while (("$#")); do
         case "$1" in
@@ -259,7 +219,7 @@ main() {
                     log_error "--comment-id requires a numeric REST API comment ID, got: ${2:-}"
                     exit 1
                 }
-                comment_ids+=("$2")
+                COMMENT_IDS+=("$2")
                 shift 2
                 ;;
             --pull | --push | --drop)
@@ -271,11 +231,11 @@ main() {
                 shift
                 ;;
             --dry-run)
-                dry_run=true
+                DRY_RUN=true
                 shift
                 ;;
             --json)
-                json_output=true
+                JSON_OUTPUT=true
                 shift
                 ;;
             -h | --help)
@@ -299,7 +259,7 @@ main() {
         esac
     done
 
-    if [[ "${mode}" == "drop" && ${#comment_ids[@]} -eq 0 ]]; then
+    if [[ "${mode}" == "drop" && ${#COMMENT_IDS[@]} -eq 0 ]]; then
         log_error "--drop requires at least one --comment-id. Refusing to drop every comment."
         exit 1
     fi
@@ -307,7 +267,7 @@ main() {
         log_error "--reason only applies to --drop."
         exit 1
     fi
-    if [[ "${mode}" == "pull" && ${#comment_ids[@]} -gt 0 ]]; then
+    if [[ "${mode}" == "pull" && ${#COMMENT_IDS[@]} -gt 0 ]]; then
         log_error "--comment-id does not apply to --pull, which reconciles the whole review."
         exit 1
     fi
@@ -326,12 +286,14 @@ main() {
     if [[ "${pending}" == "null" ]]; then
         if [[ "${mode}" == "status" ]]; then
             log_info "No pending review by ${REVIEWER} on ${REPO}#${PR_NUMBER}."
-            [[ "${json_output}" == "true" ]] && jq -n '{comments: [], counts: {}, unrecorded: []}'
+            emit_json -n '{comments: [], counts: {}, unrecorded: []}'
             exit 0
         fi
         log_error "No pending review by ${REVIEWER} on ${REPO}#${PR_NUMBER}. Nothing to amend."
         exit 1
     fi
+
+    REVIEW_ID=$(echo "${pending}" | jq -r '.review_id')
 
     # One normalizer, in Python, so the shell never invents a second notion of
     # "changed" that disagrees with the one that wrote the digests.
@@ -340,10 +302,10 @@ main() {
         | "${SCRIPT_DIR}/review-comment-blocks.py" status --review-file "${REVIEW_FILE}")
 
     case "${mode}" in
-        status) do_status "${status_json}" "${json_output}" ;;
-        pull) do_pull "${status_json}" "${dry_run}" "${json_output}" ;;
-        push) do_push "${status_json}" "${dry_run}" "${json_output}" "${comment_ids[@]+"${comment_ids[@]}"}" ;;
-        drop) do_drop "${pending}" "${status_json}" "${dry_run}" "${json_output}" "${comment_ids[@]}" ;;
+        status) do_status "${status_json}" ;;
+        pull) do_pull "${status_json}" ;;
+        push) do_push "${status_json}" ;;
+        drop) do_drop "${pending}" ;;
         *)
             log_error "Unhandled mode '${mode}'."
             exit 1
@@ -352,37 +314,34 @@ main() {
 }
 
 do_status() {
-    local status_json="$1" json_output="$2"
-    if [[ "${json_output}" == "true" ]]; then
-        echo "${status_json}" | jq '{review_id, counts, unrecorded,
-            comments: [.comments[] | {id, node_id, path, line, position, state}]}'
+    local status_json="$1"
+    if [[ "${JSON_OUTPUT}" == "true" ]]; then
+        emit_json -n --argjson s "${status_json}" '{review_id: $s.review_id,
+            counts: $s.counts, unrecorded: $s.unrecorded,
+            comments: [$s.comments[] | {id, node_id, path, line, position, state}]}'
     else
         display_status "${status_json}"
     fi
 }
 
 do_pull() {
-    local status_json="$1" dry_run="$2" json_output="$3"
-    local targets
+    local status_json="$1"
+    local targets count
     targets=$(echo "${status_json}" | jq -c '[.comments[]
         | select(.state == "changed_on_github" or .state == "diverged" or .state == "unknown_baseline")]')
-    local count
     count=$(echo "${targets}" | jq 'length')
 
     if [[ "${count}" -eq 0 ]]; then
         log_info "Notes already match GitHub; nothing to pull."
-        [[ "${json_output}" == "true" ]] && echo "${status_json}" | jq '{pulled: 0, dryRun: false}'
+        emit_json -n '{pulled: 0, dryRun: false}'
         return 0
     fi
 
-    local comment
-    while IFS= read -r comment; do
-        echo_comment "Replacing notes body for comment" "${comment}"
-    done < <(echo "${targets}" | jq -c '.[]')
+    echo_comments "Replacing notes body for comment" "${targets}"
 
-    if [[ "${dry_run}" == "true" ]]; then
+    if [[ "${DRY_RUN}" == "true" ]]; then
         log_info "Dry run: would update ${count} block(s) in ${REVIEW_FILE}."
-        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pulled: 0, dryRun: true, comments: [.[] | {id, state}]}'
+        emit_json -n --argjson t "${targets}" '{pulled: 0, dryRun: true, comments: [$t[] | {id, state}]}'
         return 0
     fi
 
@@ -390,26 +349,24 @@ do_pull() {
         | "${SCRIPT_DIR}/review-comment-blocks.py" set-body --review-file "${REVIEW_FILE}" > /dev/null
     refresh_digests
     log_success "Pulled ${count} comment(s) from GitHub into ${REVIEW_FILE}."
-    [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pulled: length, dryRun: false, comments: [.[] | {id, state}]}'
+    emit_json -n --argjson t "${targets}" '{pulled: ($t | length), dryRun: false, comments: [$t[] | {id, state}]}'
     return 0
 }
 
 do_push() {
-    local status_json="$1" dry_run="$2" json_output="$3"
-    shift 3
-    local -a wanted=("$@")
+    local status_json="$1"
+    local targets blocked count
 
-    local targets
     targets=$(echo "${status_json}" | jq -c '[.comments[] | select(.state == "changed_in_notes")]')
-    if [[ ${#wanted[@]} -gt 0 ]]; then
+    if [[ ${#COMMENT_IDS[@]} -gt 0 ]]; then
         local ids_json
-        ids_json=$(printf '%s\n' "${wanted[@]}" | jq -s 'map(tonumber)')
-        targets=$(echo "${targets}" | jq -c --argjson ids "${ids_json}" '[.[] | select(.id as $i | $ids | index($i) != null)]')
+        ids_json=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
+        targets=$(echo "${targets}" | jq -c --argjson ids "${ids_json}" \
+            '[.[] | select(.id as $i | $ids | index($i) != null)]')
     fi
 
     # Refuse rather than clobber. A body that moved on GitHub is someone's hand
     # edit, and overwriting it silently is the failure this tool exists to stop.
-    local blocked
     blocked=$(echo "${status_json}" | jq -c '[.comments[]
         | select(.state == "changed_on_github" or .state == "diverged")]')
     if [[ "$(echo "${blocked}" | jq 'length')" -gt 0 ]]; then
@@ -419,39 +376,36 @@ do_push() {
         exit 1
     fi
 
-    local count
     count=$(echo "${targets}" | jq 'length')
     if [[ "${count}" -eq 0 ]]; then
         log_info "No reworded comments to push."
-        [[ "${json_output}" == "true" ]] && jq -n '{pushed: 0, failed: 0, dryRun: false}'
+        emit_json -n '{pushed: 0, failed: 0, dryRun: false}'
         return 0
     fi
 
-    local comment
-    while IFS= read -r comment; do
-        echo_comment "Rewording comment" "${comment}"
-    done < <(echo "${targets}" | jq -c '.[]')
+    echo_comments "Rewording comment" "${targets}"
 
-    if [[ "${dry_run}" == "true" ]]; then
+    if [[ "${DRY_RUN}" == "true" ]]; then
         log_info "Dry run: would reword ${count} comment(s) on ${REPO}#${PR_NUMBER}."
-        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pushed: 0, failed: 0, dryRun: true, comments: [.[] | {id}]}'
+        emit_json -n --argjson t "${targets}" '{pushed: 0, failed: 0, dryRun: true, comments: [$t[] | {id}]}'
         return 0
     fi
 
-    local pushed=0 failed=0 id node_id body
-    while IFS=$'\t' read -r id node_id; do
-        body=$(echo "${targets}" | jq -r --argjson id "${id}" '.[] | select(.id == $id) | .notes_body')
-        if reword_comment "${node_id}" "${body}"; then
+    local pushed=0 failed=0 id node_id body_b64
+    # One jq pass carries the body along, so the loop does not re-parse the
+    # whole target list once per comment. base64 keeps newlines out of the TSV.
+    while IFS=$'\t' read -r id node_id body_b64; do
+        if reword_comment "${node_id}" "$(printf '%s' "${body_b64}" | base64 --decode)"; then
             log_success "Reworded ${id}"
             pushed=$((pushed + 1))
         else
             log_warn "Failed to reword ${id}"
             failed=$((failed + 1))
         fi
-    done < <(echo "${targets}" | jq -r '.[] | [.id, .node_id] | @tsv')
+    done < <(echo "${targets}" | jq -r '.[] | [.id, .node_id, (.notes_body | @base64)] | @tsv')
 
     refresh_digests
-    [[ "${json_output}" == "true" ]] && jq -n --argjson pushed "${pushed}" --argjson failed "${failed}" \
+    emit_json -n --argjson pushed "${pushed}" --argjson failed "${failed}" \
         '{pushed: $pushed, failed: $failed, dryRun: false}'
     if [[ "${failed}" -gt 0 ]]; then
         log_error "${failed} comment(s) failed to reword."
@@ -461,38 +415,29 @@ do_push() {
 }
 
 do_drop() {
-    local pending="$1" status_json="$2" dry_run="$3" json_output="$4"
-    shift 4
-    local -a wanted=("$@")
+    local pending="$1"
 
-    validate_ids "${pending}" "${wanted[@]}"
+    validate_ids "${pending}" "${COMMENT_IDS[@]}"
 
+    # Built from the pending review, not from the notes: validate_ids has just
+    # proved every id is in there, and the body GitHub holds is the one the
+    # operator should read before an irreversible delete.
     local ids_json targets
-    ids_json=$(printf '%s\n' "${wanted[@]}" | jq -s 'map(tonumber)')
-    targets=$(echo "${status_json}" | jq -c --argjson ids "${ids_json}" \
-        '[.comments[] | select(.id as $i | $ids | index($i) != null)]')
+    ids_json=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
+    targets=$(echo "${pending}" | jq -c --argjson ids "${ids_json}" \
+        '[.comments[] | select(.id as $i | $ids | index($i) != null)
+          | {id, path, line, position, live_body: .body}]')
 
-    # An id can be in the pending review but absent from the notes, so fall
-    # back to the live comment rather than skipping it.
-    if [[ "$(echo "${targets}" | jq 'length')" -lt ${#wanted[@]} ]]; then
-        targets=$(echo "${pending}" | jq -c --argjson ids "${ids_json}" \
-            '[.comments[] | select(.id as $i | $ids | index($i) != null)
-              | {id, node_id, path, line, position, live_body: .body}]')
-    fi
+    echo_comments "Dropping comment" "${targets}"
 
-    local comment
-    while IFS= read -r comment; do
-        echo_comment "Dropping comment" "${comment}"
-    done < <(echo "${targets}" | jq -c '.[]')
-
-    if [[ "${dry_run}" == "true" ]]; then
-        log_info "Dry run: would drop ${#wanted[@]} comment(s) from ${REPO}#${PR_NUMBER}."
-        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{dropped: 0, failed: 0, dryRun: true, comments: [.[] | {id, path}]}'
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "Dry run: would drop ${#COMMENT_IDS[@]} comment(s) from ${REPO}#${PR_NUMBER}."
+        emit_json -n --argjson t "${targets}" '{dropped: 0, failed: 0, dryRun: true, comments: [$t[] | {id, path}]}'
         return 0
     fi
 
     local dropped=0 failed=0 id
-    for id in "${wanted[@]}"; do
+    for id in "${COMMENT_IDS[@]}"; do
         if drop_comment "${id}"; then
             log_success "Dropped ${id}"
             dropped=$((dropped + 1))
@@ -505,7 +450,7 @@ do_drop() {
     # Retire the finding in the notes, so carry-forward does not re-propose it
     # and a later --draft does not repost it. Only the ids that actually went.
     if [[ "${dropped}" -gt 0 ]]; then
-        printf '%s\n' "${wanted[@]}" \
+        printf '%s\n' "${COMMENT_IDS[@]}" \
             | jq -R --arg reason "${REASON}" -s 'split("\n") | map(select(length > 0))
                 | map({id: tonumber, reason: $reason})' \
             | "${SCRIPT_DIR}/review-comment-blocks.py" withdraw \
@@ -516,31 +461,34 @@ do_drop() {
         }
     fi
 
+    # Read back rather than subtract, so the count reflects what GitHub kept.
     local remaining
-    remaining=$(gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews/$(echo "${pending}" | jq -r '.review_id')/comments" \
-        --paginate 2> /dev/null | jq 'length' 2> /dev/null || echo "?")
+    remaining=$(pending_comments | jq 'length' 2> /dev/null || echo "?")
     log_info "${remaining} comment(s) remain in the pending review."
     if [[ "${remaining}" == "0" ]]; then
         log_warn "That was the last inline comment. The pending review still exists with its summary body."
     fi
 
-    [[ "${json_output}" == "true" ]] && jq -n --argjson dropped "${dropped}" --argjson failed "${failed}" \
-        --arg remaining "${remaining}" '{dropped: $dropped, failed: $failed, remaining: $remaining, dryRun: false}'
+    emit_json -n --argjson dropped "${dropped}" --argjson failed "${failed}" \
+        --arg remaining "${remaining}" \
+        '{dropped: $dropped, failed: $failed, remaining: $remaining, dryRun: false}'
     if [[ "${failed}" -gt 0 ]]; then
         return 1
     fi
     return 0
 }
 
+# The pending review's comments, from the id this run already resolved.
+pending_comments() {
+    gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews/${REVIEW_ID}/comments" \
+        --paginate 2> /dev/null || echo "[]"
+}
+
 # Re-stamp the last-synced digests so the next run can still tell which side
-# moved. Best effort: a stale digest makes the next push refuse and --pull
-# re-syncs, which is the safe direction to fail in.
+# moved. Best effort, and safe to fail: classify() settles identical bodies as
+# in sync before it consults a digest, so a stale one cannot wedge the tool.
 refresh_digests() {
-    local live
-    live=$(gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews/$(
-        get_existing_pending_review "${OWNER}" "${REPO_NAME}" "${PR_NUMBER}" "${REVIEWER}" | jq -r '.review_id'
-    )/comments" --paginate 2> /dev/null || echo "[]")
-    echo "${live}" | "${SCRIPT_DIR}/review-comment-blocks.py" annotate \
+    pending_comments | "${SCRIPT_DIR}/review-comment-blocks.py" annotate \
         --review-file "${REVIEW_FILE}" > /dev/null 2>&1 || true
 }
 

--- a/skills/review-code/scripts/amend-pending-review.sh
+++ b/skills/review-code/scripts/amend-pending-review.sh
@@ -1,0 +1,549 @@
+#!/usr/bin/env bash
+# amend-pending-review.sh - Reword or drop single comments in your pending review
+#
+# Correcting one comment used to cost a whole re-review: create-draft-review.sh
+# replaces a pending review wholesale, and --draft only runs at the end of a
+# review, so changing a sentence meant re-running every agent, renumbering every
+# comment, and discarding anything edited by hand on GitHub. This amends the
+# review that is already there.
+#
+# Usage: amend-pending-review.sh [PR] [OPTIONS]
+#
+# PR can be:
+#   (none)              Infer from the current branch
+#   NUMBER              PR number in the current repo
+#   GITHUB_PR_URL       Full PR URL
+#
+# Options:
+#   --review-file PATH   Review notes to compare against (default: resolved from the PR)
+#   --pull               Copy changed bodies from GitHub into the notes
+#   --push               Send changed bodies from the notes to GitHub
+#   --drop               Delete the named comments from the pending review
+#   --comment-id ID      Restrict --push or --drop to this comment (repeatable)
+#   --reason TEXT        Why a dropped finding was withdrawn, recorded in the notes
+#   --reviewer LOGIN     Whose pending review to amend (default: gh api user)
+#   --dry-run            Show what would change without calling the API
+#   --json               Output as JSON
+#   -h, --help           Show this help message
+#
+# With no --pull/--push/--drop, reports each recorded comment as in sync,
+# changed on GitHub, changed in the notes, diverged, or missing.
+#
+# Rewording goes through the GraphQL updatePullRequestReviewComment mutation.
+# The REST endpoint cannot do it: GET and PATCH on /pulls/comments/{id} both
+# 404 for a comment that is still pending, though DELETE on that same path
+# works, which is why dropping is REST and rewording is GraphQL.
+#
+# This script cannot submit a review. It never calls POST .../reviews or
+# .../events, and every comment it touches must already belong to the caller's
+# own pending review.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/gh-wrapper.sh
+source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
+# shellcheck source=helpers/gh-review-helpers.sh
+source "${SCRIPT_DIR}/helpers/gh-review-helpers.sh"
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+# Log to stderr so stdout stays clean for JSON consumers.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+usage() {
+    sed -n '2,39p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+# ── PR target resolution ─────────────────────────────────────────────────────
+# Vendored from resolve-review-threads.sh, which vendors it in turn. Keep the
+# three copies in step.
+
+parse_pr_url() {
+    local url="$1"
+    if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        OWNER="${BASH_REMATCH[1]}"
+        REPO_NAME="${BASH_REMATCH[2]}"
+        REPO="${OWNER}/${REPO_NAME}"
+        PR_NUMBER="${BASH_REMATCH[3]}"
+        return 0
+    fi
+    return 1
+}
+
+get_current_repo() {
+    gh repo view --json nameWithOwner -q '.nameWithOwner' 2> /dev/null || {
+        log_error "Could not determine repository. Run from inside a repo or pass a full PR URL."
+        exit 1
+    }
+}
+
+resolve_pr_target() {
+    local pr_arg="${1:-}"
+    if [[ -z "$pr_arg" ]]; then
+        local pr_url
+        pr_url=$(gh pr view --json url -q '.url' 2> /dev/null) || {
+            log_error "No PR found for the current branch. Specify a PR number or URL."
+            exit 1
+        }
+        if ! parse_pr_url "$pr_url"; then
+            log_error "Could not parse PR URL from current branch: ${pr_url}"
+            exit 1
+        fi
+    elif parse_pr_url "$pr_arg"; then
+        :
+    elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="$pr_arg"
+        REPO=$(get_current_repo)
+        OWNER="${REPO%%/*}"
+        REPO_NAME="${REPO##*/}"
+    else
+        log_error "Invalid PR argument: ${pr_arg}"
+        log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
+        exit 1
+    fi
+}
+
+resolve_reviewer() {
+    if [[ -n "${REVIEWER}" ]]; then
+        return
+    fi
+    REVIEWER=$(gh api user --jq '.login' 2> /dev/null || true)
+    if [[ -z "${REVIEWER}" ]]; then
+        log_error "Could not determine your GitHub login. Pass --reviewer LOGIN."
+        exit 1
+    fi
+}
+
+resolve_review_file() {
+    if [[ -n "${REVIEW_FILE}" ]]; then
+        return
+    fi
+    REVIEW_FILE=$("${SCRIPT_DIR}/review-file-path.sh" --org "${OWNER}" --repo "${REPO_NAME}" \
+        "pr-${PR_NUMBER}" 2> /dev/null | jq -r '.file_path // ""')
+    if [[ -z "${REVIEW_FILE}" ]]; then
+        log_error "Could not resolve a review file for ${REPO}#${PR_NUMBER}. Pass --review-file PATH."
+        exit 1
+    fi
+}
+
+# ── Rendering ────────────────────────────────────────────────────────────────
+
+# Show a comment in full before changing or deleting it. Pending comments carry
+# no line number of their own (the API returns line and original_line null and
+# only sets position), so the line shown is the one the notes recorded.
+echo_comment() {
+    local label="$1" comment="$2"
+    local id path line position
+    read -r id path line position < <(
+        echo "${comment}" | jq -r '[.id, .path, (.line // "-"), (.position // "-")] | @tsv'
+    )
+    {
+        echo
+        echo "${label} ${id}: ${path}:${line} (diff position ${position})"
+        echo "────────────────────────────────────────────────────────────────────────"
+        echo "${comment}" | jq -r '.notes_body // .live_body // ""'
+        echo "────────────────────────────────────────────────────────────────────────"
+    } >&2
+}
+
+display_status() {
+    local status_json="$1"
+    local total
+    total=$(echo "${status_json}" | jq '.comments | length')
+    log_info "${REPO}#${PR_NUMBER}: ${total} recorded comment(s) in ${REVIEW_FILE}"
+    echo "${status_json}" | jq -r '
+        .comments[]
+        | "  \(.id)  \(.state)  \(.path):\(.line)"
+    ' >&2
+    local unrecorded
+    unrecorded=$(echo "${status_json}" | jq '.unrecorded | length')
+    if [[ "${unrecorded}" -gt 0 ]]; then
+        log_warn "${unrecorded} comment(s) on GitHub are not recorded in the notes; they are left alone."
+    fi
+}
+
+# ── Safety ───────────────────────────────────────────────────────────────────
+
+# The membership check is the whole safety argument, not a nicety. DELETE on
+# /pulls/comments/{id} will happily remove a published comment, including a
+# teammate's, given permissions. Scoping every id to the caller's own pending
+# review is the only thing standing between a reword and someone else's review.
+# Refuse the entire run rather than mutating a prefix of it.
+validate_ids() {
+    local pending="$1"
+    shift
+    local bad=()
+    local id
+    for id in "$@"; do
+        if [[ "$(echo "${pending}" | jq --argjson id "${id}" '[.comments[] | select(.id == $id)] | length')" -eq 0 ]]; then
+            bad+=("${id}")
+        fi
+    done
+    if [[ ${#bad[@]} -gt 0 ]]; then
+        log_error "Not in your pending review on ${REPO}#${PR_NUMBER}: ${bad[*]}"
+        log_error "Run without --push/--drop to list the comments you can amend."
+        exit 1
+    fi
+}
+
+# ── Mutations ────────────────────────────────────────────────────────────────
+
+reword_comment() {
+    local node_id="$1" body="$2"
+    # shellcheck disable=SC2016  # GraphQL document; $id and $body are GraphQL
+    # variables bound by --f, not shell expansions.
+    gh api graphql \
+        -f query='mutation($id: ID!, $body: String!) {
+            updatePullRequestReviewComment(input: {pullRequestReviewCommentId: $id, body: $body}) {
+                pullRequestReviewComment { databaseId }
+            }
+        }' \
+        -f id="${node_id}" -f body="${body}" > /dev/null
+}
+
+drop_comment() {
+    local id="$1"
+    gh api --method DELETE "repos/${OWNER}/${REPO_NAME}/pulls/comments/${id}" > /dev/null
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main() {
+    local pr_arg=""
+    REVIEW_FILE=""
+    REVIEWER=""
+    REASON=""
+    local mode="status"
+    local dry_run=false
+    local json_output=false
+    local -a comment_ids=()
+
+    while (("$#")); do
+        case "$1" in
+            --review-file)
+                [[ -n "${2:-}" ]] || {
+                    log_error "--review-file requires a path"
+                    exit 1
+                }
+                REVIEW_FILE="$2"
+                shift 2
+                ;;
+            --reason)
+                [[ -n "${2:-}" ]] || {
+                    log_error "--reason requires text"
+                    exit 1
+                }
+                REASON="$2"
+                shift 2
+                ;;
+            --reviewer)
+                [[ -n "${2:-}" ]] || {
+                    log_error "--reviewer requires a login"
+                    exit 1
+                }
+                REVIEWER="$2"
+                shift 2
+                ;;
+            --comment-id)
+                [[ "${2:-}" =~ ^[0-9]+$ ]] || {
+                    log_error "--comment-id requires a numeric REST API comment ID, got: ${2:-}"
+                    exit 1
+                }
+                comment_ids+=("$2")
+                shift 2
+                ;;
+            --pull | --push | --drop)
+                if [[ "${mode}" != "status" ]]; then
+                    log_error "Choose one of --pull, --push, or --drop; they are separate runs."
+                    exit 1
+                fi
+                mode="${1#--}"
+                shift
+                ;;
+            --dry-run)
+                dry_run=true
+                shift
+                ;;
+            --json)
+                json_output=true
+                shift
+                ;;
+            -h | --help)
+                usage
+                exit 0
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage >&2
+                exit 1
+                ;;
+            *)
+                if [[ -n "${pr_arg}" ]]; then
+                    log_error "Unexpected argument: $1"
+                    usage >&2
+                    exit 1
+                fi
+                pr_arg="$1"
+                shift
+                ;;
+        esac
+    done
+
+    if [[ "${mode}" == "drop" && ${#comment_ids[@]} -eq 0 ]]; then
+        log_error "--drop requires at least one --comment-id. Refusing to drop every comment."
+        exit 1
+    fi
+    if [[ -n "${REASON}" && "${mode}" != "drop" ]]; then
+        log_error "--reason only applies to --drop."
+        exit 1
+    fi
+    if [[ "${mode}" == "pull" && ${#comment_ids[@]} -gt 0 ]]; then
+        log_error "--comment-id does not apply to --pull, which reconciles the whole review."
+        exit 1
+    fi
+
+    resolve_pr_target "${pr_arg}"
+    resolve_reviewer
+    resolve_review_file
+
+    if [[ ! -f "${REVIEW_FILE}" ]]; then
+        log_error "Review file not found: ${REVIEW_FILE}"
+        exit 1
+    fi
+
+    local pending
+    pending=$(get_existing_pending_review "${OWNER}" "${REPO_NAME}" "${PR_NUMBER}" "${REVIEWER}")
+    if [[ "${pending}" == "null" ]]; then
+        if [[ "${mode}" == "status" ]]; then
+            log_info "No pending review by ${REVIEWER} on ${REPO}#${PR_NUMBER}."
+            [[ "${json_output}" == "true" ]] && jq -n '{comments: [], counts: {}, unrecorded: []}'
+            exit 0
+        fi
+        log_error "No pending review by ${REVIEWER} on ${REPO}#${PR_NUMBER}. Nothing to amend."
+        exit 1
+    fi
+
+    # One normalizer, in Python, so the shell never invents a second notion of
+    # "changed" that disagrees with the one that wrote the digests.
+    local status_json
+    status_json=$(echo "${pending}" | jq -c '.comments' \
+        | "${SCRIPT_DIR}/review-comment-blocks.py" status --review-file "${REVIEW_FILE}")
+
+    case "${mode}" in
+        status) do_status "${status_json}" "${json_output}" ;;
+        pull) do_pull "${status_json}" "${dry_run}" "${json_output}" ;;
+        push) do_push "${status_json}" "${dry_run}" "${json_output}" "${comment_ids[@]+"${comment_ids[@]}"}" ;;
+        drop) do_drop "${pending}" "${status_json}" "${dry_run}" "${json_output}" "${comment_ids[@]}" ;;
+        *)
+            log_error "Unhandled mode '${mode}'."
+            exit 1
+            ;;
+    esac
+}
+
+do_status() {
+    local status_json="$1" json_output="$2"
+    if [[ "${json_output}" == "true" ]]; then
+        echo "${status_json}" | jq '{review_id, counts, unrecorded,
+            comments: [.comments[] | {id, node_id, path, line, position, state}]}'
+    else
+        display_status "${status_json}"
+    fi
+}
+
+do_pull() {
+    local status_json="$1" dry_run="$2" json_output="$3"
+    local targets
+    targets=$(echo "${status_json}" | jq -c '[.comments[]
+        | select(.state == "changed_on_github" or .state == "diverged" or .state == "unknown_baseline")]')
+    local count
+    count=$(echo "${targets}" | jq 'length')
+
+    if [[ "${count}" -eq 0 ]]; then
+        log_info "Notes already match GitHub; nothing to pull."
+        [[ "${json_output}" == "true" ]] && echo "${status_json}" | jq '{pulled: 0, dryRun: false}'
+        return 0
+    fi
+
+    local comment
+    while IFS= read -r comment; do
+        echo_comment "Replacing notes body for comment" "${comment}"
+    done < <(echo "${targets}" | jq -c '.[]')
+
+    if [[ "${dry_run}" == "true" ]]; then
+        log_info "Dry run: would update ${count} block(s) in ${REVIEW_FILE}."
+        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pulled: 0, dryRun: true, comments: [.[] | {id, state}]}'
+        return 0
+    fi
+
+    echo "${targets}" | jq -c '[.[] | {id, body: .live_body}]' \
+        | "${SCRIPT_DIR}/review-comment-blocks.py" set-body --review-file "${REVIEW_FILE}" > /dev/null
+    refresh_digests
+    log_success "Pulled ${count} comment(s) from GitHub into ${REVIEW_FILE}."
+    [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pulled: length, dryRun: false, comments: [.[] | {id, state}]}'
+    return 0
+}
+
+do_push() {
+    local status_json="$1" dry_run="$2" json_output="$3"
+    shift 3
+    local -a wanted=("$@")
+
+    local targets
+    targets=$(echo "${status_json}" | jq -c '[.comments[] | select(.state == "changed_in_notes")]')
+    if [[ ${#wanted[@]} -gt 0 ]]; then
+        local ids_json
+        ids_json=$(printf '%s\n' "${wanted[@]}" | jq -s 'map(tonumber)')
+        targets=$(echo "${targets}" | jq -c --argjson ids "${ids_json}" '[.[] | select(.id as $i | $ids | index($i) != null)]')
+    fi
+
+    # Refuse rather than clobber. A body that moved on GitHub is someone's hand
+    # edit, and overwriting it silently is the failure this tool exists to stop.
+    local blocked
+    blocked=$(echo "${status_json}" | jq -c '[.comments[]
+        | select(.state == "changed_on_github" or .state == "diverged")]')
+    if [[ "$(echo "${blocked}" | jq 'length')" -gt 0 ]]; then
+        log_error "These comments changed on GitHub since the notes were written:"
+        echo "${blocked}" | jq -r '.[] | "  \(.id)  \(.path):\(.line)  (\(.state))"' >&2
+        log_error "Run --pull first to bring those edits into the notes, then reword and push."
+        exit 1
+    fi
+
+    local count
+    count=$(echo "${targets}" | jq 'length')
+    if [[ "${count}" -eq 0 ]]; then
+        log_info "No reworded comments to push."
+        [[ "${json_output}" == "true" ]] && jq -n '{pushed: 0, failed: 0, dryRun: false}'
+        return 0
+    fi
+
+    local comment
+    while IFS= read -r comment; do
+        echo_comment "Rewording comment" "${comment}"
+    done < <(echo "${targets}" | jq -c '.[]')
+
+    if [[ "${dry_run}" == "true" ]]; then
+        log_info "Dry run: would reword ${count} comment(s) on ${REPO}#${PR_NUMBER}."
+        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{pushed: 0, failed: 0, dryRun: true, comments: [.[] | {id}]}'
+        return 0
+    fi
+
+    local pushed=0 failed=0 id node_id body
+    while IFS=$'\t' read -r id node_id; do
+        body=$(echo "${targets}" | jq -r --argjson id "${id}" '.[] | select(.id == $id) | .notes_body')
+        if reword_comment "${node_id}" "${body}"; then
+            log_success "Reworded ${id}"
+            pushed=$((pushed + 1))
+        else
+            log_warn "Failed to reword ${id}"
+            failed=$((failed + 1))
+        fi
+    done < <(echo "${targets}" | jq -r '.[] | [.id, .node_id] | @tsv')
+
+    refresh_digests
+    [[ "${json_output}" == "true" ]] && jq -n --argjson pushed "${pushed}" --argjson failed "${failed}" \
+        '{pushed: $pushed, failed: $failed, dryRun: false}'
+    if [[ "${failed}" -gt 0 ]]; then
+        log_error "${failed} comment(s) failed to reword."
+        return 1
+    fi
+    return 0
+}
+
+do_drop() {
+    local pending="$1" status_json="$2" dry_run="$3" json_output="$4"
+    shift 4
+    local -a wanted=("$@")
+
+    validate_ids "${pending}" "${wanted[@]}"
+
+    local ids_json targets
+    ids_json=$(printf '%s\n' "${wanted[@]}" | jq -s 'map(tonumber)')
+    targets=$(echo "${status_json}" | jq -c --argjson ids "${ids_json}" \
+        '[.comments[] | select(.id as $i | $ids | index($i) != null)]')
+
+    # An id can be in the pending review but absent from the notes, so fall
+    # back to the live comment rather than skipping it.
+    if [[ "$(echo "${targets}" | jq 'length')" -lt ${#wanted[@]} ]]; then
+        targets=$(echo "${pending}" | jq -c --argjson ids "${ids_json}" \
+            '[.comments[] | select(.id as $i | $ids | index($i) != null)
+              | {id, node_id, path, line, position, live_body: .body}]')
+    fi
+
+    local comment
+    while IFS= read -r comment; do
+        echo_comment "Dropping comment" "${comment}"
+    done < <(echo "${targets}" | jq -c '.[]')
+
+    if [[ "${dry_run}" == "true" ]]; then
+        log_info "Dry run: would drop ${#wanted[@]} comment(s) from ${REPO}#${PR_NUMBER}."
+        [[ "${json_output}" == "true" ]] && echo "${targets}" | jq '{dropped: 0, failed: 0, dryRun: true, comments: [.[] | {id, path}]}'
+        return 0
+    fi
+
+    local dropped=0 failed=0 id
+    for id in "${wanted[@]}"; do
+        if drop_comment "${id}"; then
+            log_success "Dropped ${id}"
+            dropped=$((dropped + 1))
+        else
+            log_warn "Failed to drop ${id}"
+            failed=$((failed + 1))
+        fi
+    done
+
+    # Retire the finding in the notes, so carry-forward does not re-propose it
+    # and a later --draft does not repost it. Only the ids that actually went.
+    if [[ "${dropped}" -gt 0 ]]; then
+        printf '%s\n' "${wanted[@]}" \
+            | jq -R --arg reason "${REASON}" -s 'split("\n") | map(select(length > 0))
+                | map({id: tonumber, reason: $reason})' \
+            | "${SCRIPT_DIR}/review-comment-blocks.py" withdraw \
+                --review-file "${REVIEW_FILE}" \
+                --date "$(date -u +%Y-%m-%d)" > /dev/null || {
+            log_warn "Dropped on GitHub, but could not mark the finding withdrawn in ${REVIEW_FILE}."
+            log_warn "Mark it by hand, or a later re-review may re-propose it."
+        }
+    fi
+
+    local remaining
+    remaining=$(gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews/$(echo "${pending}" | jq -r '.review_id')/comments" \
+        --paginate 2> /dev/null | jq 'length' 2> /dev/null || echo "?")
+    log_info "${remaining} comment(s) remain in the pending review."
+    if [[ "${remaining}" == "0" ]]; then
+        log_warn "That was the last inline comment. The pending review still exists with its summary body."
+    fi
+
+    [[ "${json_output}" == "true" ]] && jq -n --argjson dropped "${dropped}" --argjson failed "${failed}" \
+        --arg remaining "${remaining}" '{dropped: $dropped, failed: $failed, remaining: $remaining, dryRun: false}'
+    if [[ "${failed}" -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Re-stamp the last-synced digests so the next run can still tell which side
+# moved. Best effort: a stale digest makes the next push refuse and --pull
+# re-syncs, which is the safe direction to fail in.
+refresh_digests() {
+    local live
+    live=$(gh api "repos/${OWNER}/${REPO_NAME}/pulls/${PR_NUMBER}/reviews/$(
+        get_existing_pending_review "${OWNER}" "${REPO_NAME}" "${PR_NUMBER}" "${REVIEWER}" | jq -r '.review_id'
+    )/comments" --paginate 2> /dev/null || echo "[]")
+    echo "${live}" | "${SCRIPT_DIR}/review-comment-blocks.py" annotate \
+        --review-file "${REVIEW_FILE}" > /dev/null 2>&1 || true
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/skills/review-code/scripts/amend-pending-review.sh
+++ b/skills/review-code/scripts/amend-pending-review.sh
@@ -295,8 +295,22 @@ main() {
 
     REVIEW_ID=$(echo "${pending}" | jq -r '.review_id')
 
+    # Every mode that takes --comment-id checks membership here, so a mistyped
+    # id is refused by name rather than quietly narrowing a target set to
+    # nothing. --push used to filter by id without checking, so a typo printed
+    # "No reworded comments to push" and exited 0, which reads as "the reword
+    # never registered" and sends you looking in the wrong file.
+    if [[ ${#COMMENT_IDS[@]} -gt 0 ]]; then
+        validate_ids "${pending}" "${COMMENT_IDS[@]}"
+    fi
+
     # One normalizer, in Python, so the shell never invents a second notion of
     # "changed" that disagrees with the one that wrote the digests.
+    # --drop does not read status_json, and computing it costs a Python start
+    # plus a full parse of the review file. It runs for every mode on purpose:
+    # status exits non-zero on a review file it cannot parse, and that has to
+    # happen before the DELETE rather than after, because the delete cannot be
+    # undone and the withdrawal that records it would then have nowhere to go.
     local status_json
     status_json=$(echo "${pending}" | jq -c '.comments' \
         | "${SCRIPT_DIR}/review-comment-blocks.py" status --review-file "${REVIEW_FILE}")
@@ -378,7 +392,15 @@ do_push() {
 
     count=$(echo "${targets}" | jq 'length')
     if [[ "${count}" -eq 0 ]]; then
-        log_info "No reworded comments to push."
+        # main has already refused any id that is not in the pending review, so
+        # reaching here with ids named means they are real and nothing in the
+        # notes was reworded for them. Say which, so this is not confused with
+        # having named the wrong comment.
+        if [[ ${#COMMENT_IDS[@]} -gt 0 ]]; then
+            log_info "No reword recorded in ${REVIEW_FILE} for: ${COMMENT_IDS[*]}. Nothing pushed."
+        else
+            log_info "No reworded comments to push."
+        fi
         emit_json -n '{pushed: 0, failed: 0, dryRun: false}'
         return 0
     fi
@@ -417,10 +439,8 @@ do_push() {
 do_drop() {
     local pending="$1"
 
-    validate_ids "${pending}" "${COMMENT_IDS[@]}"
-
-    # Built from the pending review, not from the notes: validate_ids has just
-    # proved every id is in there, and the body GitHub holds is the one the
+    # Built from the pending review, not from the notes: validate_ids in main
+    # has proved every id is in there, and the body GitHub holds is the one the
     # operator should read before an irreversible delete.
     local ids_json targets
     ids_json=$(printf '%s\n' "${COMMENT_IDS[@]}" | jq -s 'map(tonumber)')
@@ -437,9 +457,11 @@ do_drop() {
     fi
 
     local dropped=0 failed=0 id
+    local dropped_ids=()
     for id in "${COMMENT_IDS[@]}"; do
         if drop_comment "${id}"; then
             log_success "Dropped ${id}"
+            dropped_ids+=("${id}")
             dropped=$((dropped + 1))
         else
             log_warn "Failed to drop ${id}"
@@ -448,17 +470,26 @@ do_drop() {
     done
 
     # Retire the finding in the notes, so carry-forward does not re-propose it
-    # and a later --draft does not repost it. Only the ids that actually went.
-    if [[ "${dropped}" -gt 0 ]]; then
-        printf '%s\n' "${COMMENT_IDS[@]}" \
+    # and a later --draft does not repost it. Only the ids whose DELETE returned
+    # success: withdrawing one whose delete failed would retire a finding whose
+    # comment is still on the PR, and withdrawn blocks are invisible to status,
+    # --push and set-body afterwards, so the file is the only way back.
+    if [[ ${#dropped_ids[@]} -gt 0 ]]; then
+        local withdraw_result marked
+        withdraw_result=$(printf '%s\n' "${dropped_ids[@]}" \
             | jq -R --arg reason "${REASON}" -s 'split("\n") | map(select(length > 0))
                 | map({id: tonumber, reason: $reason})' \
             | "${SCRIPT_DIR}/review-comment-blocks.py" withdraw \
                 --review-file "${REVIEW_FILE}" \
-                --date "$(date -u +%Y-%m-%d)" > /dev/null || {
-            log_warn "Dropped on GitHub, but could not mark the finding withdrawn in ${REVIEW_FILE}."
-            log_warn "Mark it by hand, or a later re-review may re-propose it."
-        }
+                --date "$(date -u +%Y-%m-%d)") || withdraw_result=""
+        # withdraw exits 0 and reports the ids it could not find, so a count
+        # short of the deletes means no finding carries that id: the comment is
+        # gone from GitHub and the notes still offer it to the next re-review.
+        marked=$(echo "${withdraw_result}" | jq -r '.withdrawn // 0' 2> /dev/null || echo 0)
+        if [[ "${marked}" -lt "${dropped}" ]]; then
+            log_warn "Dropped on GitHub, but ${REVIEW_FILE} records no finding for $((dropped - marked)) of them."
+            log_warn "Mark the finding withdrawn by hand, or a later re-review will propose it again."
+        fi
     fi
 
     # Read back rather than subtract, so the count reflects what GitHub kept.

--- a/skills/review-code/scripts/build-agent-briefing.sh
+++ b/skills/review-code/scripts/build-agent-briefing.sh
@@ -219,6 +219,9 @@ if [[ -n "${PREVIOUS_REVIEW}" && -f "${PREVIOUS_REVIEW}" ]]; then
     emit "- Update status if code changed"
     emit "- Mark findings as resolved if fixed"
     emit ""
+    emit "Do NOT re-raise a finding marked \`*Withdrawn ...*\`. Those were argued"
+    emit "down by the author after the review was posted and taken off the PR."
+    emit ""
 fi
 
 # ------------------------------------------------------ shared instructions

--- a/skills/review-code/scripts/carry-forward-findings.sh
+++ b/skills/review-code/scripts/carry-forward-findings.sh
@@ -205,7 +205,11 @@ else
         }
     ' "${REVIEW_FILE}" > "${PRUNED_FILE}"
 
-    ACTUAL=$("${SCRIPT_DIR}/parse-review-findings.sh" "${PRUNED_FILE}" | identity)
+    # --with-spans on both sides, because only the plain mode truncates a
+    # description at 500 bytes. Parsing the two sides differently made the
+    # comparison fail on every review with a finding body past that length,
+    # which is most of them, so the cut was always abandoned.
+    ACTUAL=$("${SCRIPT_DIR}/parse-review-findings.sh" --with-spans "${PRUNED_FILE}" | identity)
     if [[ "${ACTUAL}" == "${EXPECTED}" ]]; then
         PRUNED=true
     else

--- a/skills/review-code/scripts/create-draft-review.sh
+++ b/skills/review-code/scripts/create-draft-review.sh
@@ -19,6 +19,9 @@ set -euo pipefail
 #     "review_commit": "abc123...",           (optional: enables drift detection)
 #     "original_diff": "diff --git ...",      (optional: original diff for content matching)
 #     "original_diff_path": "/path/diff.patch",  (optional: same diff as a file, preferred)
+#     "review_file": "/path/pr-123.md",       (optional: records each posted comment's
+#                                              id in that file, so a later session can
+#                                              reword one comment instead of re-reviewing)
 #     "comments": [
 #       {"path": "src/auth.ts", "line": 42, "side": "RIGHT", "body": "Consider...", "line_content": "    some_code()"},
 #       {"path": "src/utils.ts", "line": 15, "side": "RIGHT", "body": "This could..."}
@@ -36,7 +39,8 @@ set -euo pipefail
 #     "inline_count": 5,
 #     "summary_count": 2,
 #     "replaced_existing": true,
-#     "drift_detected": false
+#     "drift_detected": false,
+#     "annotated_count": 5                    (comments whose id was recorded in review_file)
 #   }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,53 +50,8 @@ source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 source "${SCRIPT_DIR}/helpers/json-helpers.sh"
 # shellcheck source=lib/helpers/gh-wrapper.sh
 source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
-
-# Fetch existing pending review and its comments
-# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = reviewer_username
-# Output: JSON with review_id and comments, or null if no pending review
-get_existing_pending_review() {
-    local owner="$1"
-    local repo="$2"
-    local pr_number="$3"
-    local reviewer="$4"
-
-    # Get all reviews for this PR
-    local reviews
-    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2> /dev/null || echo "[]")
-
-    # Find pending review from this user
-    local pending_review
-    pending_review=$(echo "${reviews}" | jq -r --arg user "${reviewer}" \
-        '[.[] | select(.state == "PENDING" and .user.login == $user)] | first // null')
-
-    if [[ "${pending_review}" == "null" ]]; then
-        echo "null"
-        return
-    fi
-
-    local review_id
-    review_id=$(echo "${pending_review}" | jq -r '.id')
-
-    # Fetch comments for this pending review
-    local comments
-    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2> /dev/null || echo "[]")
-
-    # Return review info with comments
-    jq -n \
-        --argjson review "${pending_review}" \
-        --argjson comments "${comments}" \
-        '{
-            review_id: $review.id,
-            body: $review.body,
-            comments: [$comments[] | {
-                id: .id,
-                path: .path,
-                line: (.line // .original_line // .position),
-                position: .position,
-                body: .body
-            }]
-        }'
-}
+# shellcheck source=helpers/gh-review-helpers.sh
+source "${SCRIPT_DIR}/helpers/gh-review-helpers.sh"
 
 # Delete a pending review
 # Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = review_id
@@ -155,13 +114,14 @@ main() {
     validate_json "${input}" || exit 1
 
     # Extract fields
-    local owner repo pr_number reviewer summary comments unmapped_comments review_commit
+    local owner repo pr_number reviewer summary comments unmapped_comments review_commit review_file
     owner=$(echo "${input}" | jq -r '.owner')
     repo=$(echo "${input}" | jq -r '.repo')
     pr_number=$(echo "${input}" | jq -r '.pr_number')
     reviewer=$(echo "${input}" | jq -r '.reviewer_username')
     summary=$(echo "${input}" | jq -r '.summary // ""')
     review_commit=$(echo "${input}" | jq -r '.review_commit // ""')
+    review_file=$(echo "${input}" | jq -r '.review_file // ""')
     comments=$(echo "${input}" | jq -c '.comments // []')
     unmapped_comments=$(echo "${input}" | jq -c '.unmapped_comments // []')
 
@@ -276,9 +236,31 @@ main() {
     local inline_count
     inline_count=$(echo "${comments}" | jq 'length')
 
+    # Record which comment each finding produced, so a later session can reword
+    # one without re-running the review. The POST returns only the review, so
+    # the ids come from a follow-up read. Annotation failures are reported but
+    # never fail the run: the review is already posted by this point, and a
+    # missing id costs a reword, not the review.
+    local annotated_count=0
+    if [[ -n "${review_file}" && -f "${review_file}" ]]; then
+        local posted_comments annotate_result
+        posted_comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2> /dev/null || echo "[]")
+        annotate_result=$(echo "${posted_comments}" | "${SCRIPT_DIR}/review-comment-blocks.py" annotate \
+            --review-file "${review_file}" \
+            --review-id "${review_id}" \
+            --posted-at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" 2> /dev/null || echo '{}')
+        annotated_count=$(echo "${annotate_result}" | jq -r '.annotated // 0')
+        local annotate_error
+        annotate_error=$(echo "${annotate_result}" | jq -r '.error // ""')
+        if [[ -n "${annotate_error}" ]]; then
+            warning "Could not record comment ids in ${review_file}: ${annotate_error}"
+        fi
+    fi
+
     # Return success result
     jq -n \
         --argjson success true \
+        --argjson annotated_count "${annotated_count}" \
         --argjson review_id "${review_id}" \
         --arg review_url "${review_url}" \
         --argjson inline_count "${inline_count}" \
@@ -292,7 +274,8 @@ main() {
             inline_count: $inline_count,
             summary_count: $summary_count,
             replaced_existing: $replaced_existing,
-            drift_detected: $drift_detected
+            drift_detected: $drift_detected,
+            annotated_count: $annotated_count
         }'
 }
 

--- a/skills/review-code/scripts/get-review-diff.sh
+++ b/skills/review-code/scripts/get-review-diff.sh
@@ -50,19 +50,27 @@ if [[ "${BASH_SOURCE[0]:-}" = "${0}" ]]; then
     mode="$1"
     shift
 
-    # Extract file pattern from remaining args if present
-    # It should be the last argument
+    # The file pattern is optional and always last, so what marks it is the
+    # argument count: each mode takes a fixed number of refs, and anything past
+    # that is the pattern.
+    #
+    # Telling the two apart by shape does not work, because a pathspec and a ref
+    # are not distinguishable that way. The old test read "contains a dot after a
+    # slash" as a path, which is also the shape of origin/main..HEAD and of a
+    # base branch like origin/release-1.0. Either one was taken as a pattern and
+    # removed from "$@", and the mode below then read a positional that was no
+    # longer there, so the script died on an unbound variable instead of
+    # diffing. A bare main..HEAD survived only because it carries no slash.
+    case "${mode}" in
+        "local") mode_args=0 ;;
+        "branch" | "branch-plus-uncommitted") mode_args=2 ;;
+        *) mode_args=1 ;;
+    esac
+
     file_pattern=""
-    if [[ $# -gt 0 ]]; then
-        # Check if last arg looks like a file pattern (not a branch/commit)
-        last_arg="${*: -1}"
-        # If it contains glob (*) or looks like a path pattern (contains / or common extensions)
-        # But exclude git ranges (contains ..)
-        if [[ "${last_arg}" == *"*"* ]] || [[ "${last_arg}" == *"/"*.* ]]; then
-            file_pattern="${last_arg}"
-            # Remove last arg from positional parameters
-            set -- "${@:1:$(($# - 1))}"
-        fi
+    if [[ $# -gt ${mode_args} ]]; then
+        file_pattern="${*: -1}"
+        set -- "${@:1:$(($# - 1))}"
     fi
 
     # Use pattern_arg to handle empty file_pattern

--- a/skills/review-code/scripts/helpers/gh-review-helpers.sh
+++ b/skills/review-code/scripts/helpers/gh-review-helpers.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# gh-review-helpers.sh - Read a user's pending PR review and its comments.
+#
+# Sourced by create-draft-review.sh, which uses it to decide whether to replace
+# an existing pending review, and by amend-pending-review.sh, which uses it to
+# scope every reword and drop to the caller's own pending review.
+#
+# Everything here is read-only. Callers that mutate keep their own delete and
+# update functions, so a script that must not create or destroy a review can
+# source this without gaining the ability to.
+
+# Guard against being sourced more than once per process.
+[[ -n "${_GH_REVIEW_HELPERS_SOURCED:-}" ]] && return
+_GH_REVIEW_HELPERS_SOURCED=1
+
+_GH_REVIEW_HELPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/gh-wrapper.sh
+source "${_GH_REVIEW_HELPERS_DIR}/gh-wrapper.sh"
+
+# Fetch a user's pending review and its inline comments.
+# Args: $1 = owner, $2 = repo, $3 = pr_number, $4 = reviewer_username
+# Output: JSON with review_id and comments, or the string "null" if the user
+#         has no pending review on this PR.
+#
+# GitHub allows one pending review per user per PR, so `first` is the only one.
+# Pending comments are absent from GET /pulls/{n}/comments and from
+# GET /pulls/comments/{id} (both 404), so this endpoint is the only way to read
+# them. They also come back with line and original_line null, carrying only
+# position, which is why position is reported separately rather than folded
+# into line.
+get_existing_pending_review() {
+    local owner="$1"
+    local repo="$2"
+    local pr_number="$3"
+    local reviewer="$4"
+
+    # Get all reviews for this PR
+    local reviews
+    reviews=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews" --paginate 2> /dev/null || echo "[]")
+
+    # Find pending review from this user
+    local pending_review
+    pending_review=$(echo "${reviews}" | jq -r --arg user "${reviewer}" \
+        '[.[] | select(.state == "PENDING" and .user.login == $user)] | first // null')
+
+    if [[ "${pending_review}" == "null" ]]; then
+        echo "null"
+        return
+    fi
+
+    local review_id
+    review_id=$(echo "${pending_review}" | jq -r '.id')
+
+    # Fetch comments for this pending review
+    local comments
+    comments=$(gh api "repos/${owner}/${repo}/pulls/${pr_number}/reviews/${review_id}/comments" --paginate 2> /dev/null || echo "[]")
+
+    # Return review info with comments. node_id is what the GraphQL reword
+    # mutation addresses; id is the REST id a delete needs.
+    jq -n \
+        --argjson review "${pending_review}" \
+        --argjson comments "${comments}" \
+        '{
+            review_id: $review.id,
+            body: $review.body,
+            comments: [$comments[] | {
+                id: .id,
+                node_id: .node_id,
+                path: .path,
+                line: (.line // .original_line),
+                position: .position,
+                body: .body
+            }]
+        }'
+}

--- a/skills/review-code/scripts/helpers/pr-target.sh
+++ b/skills/review-code/scripts/helpers/pr-target.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034  # OWNER/REPO_NAME/REPO/PR_NUMBER are this file's
+# output contract; they are read by the scripts that source it, not here.
+# pr-target.sh - Resolve a PR argument into OWNER/REPO_NAME/REPO/PR_NUMBER,
+# plus the stderr logging the resolution reports through.
+#
+# Sourced by resolve-review-threads.sh and amend-pending-review.sh. Both take a
+# PR the same three ways (inferred from the branch, a bare number, a full URL)
+# and both keep stdout clean for JSON consumers, so the logging travels with
+# the resolution rather than living apart from it.
+#
+# Sets: OWNER, REPO_NAME, REPO, PR_NUMBER.
+
+# Guard against being sourced more than once per process.
+[[ -n "${_PR_TARGET_SOURCED:-}" ]] && return
+_PR_TARGET_SOURCED=1
+
+_PR_TARGET_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=helpers/gh-wrapper.sh
+source "${_PR_TARGET_DIR}/gh-wrapper.sh"
+
+# ── Logging ──────────────────────────────────────────────────────────────────
+# Log to stderr so stdout stays clean for JSON consumers.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
+log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1" >&2; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+# ── PR target resolution ─────────────────────────────────────────────────────
+
+# Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, and PR_NUMBER.
+parse_pr_url() {
+    local url="$1"
+    if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
+        OWNER="${BASH_REMATCH[1]}"
+        REPO_NAME="${BASH_REMATCH[2]}"
+        REPO="${OWNER}/${REPO_NAME}"
+        PR_NUMBER="${BASH_REMATCH[3]}"
+        return 0
+    fi
+    return 1
+}
+
+get_current_repo() {
+    gh repo view --json nameWithOwner -q '.nameWithOwner' 2> /dev/null || {
+        log_error "Could not determine repository. Run from inside a repo or pass a full PR URL."
+        exit 1
+    }
+}
+
+# Resolve a PR argument (URL, number, or empty) into OWNER/REPO_NAME/REPO/PR_NUMBER.
+resolve_pr_target() {
+    local pr_arg="${1:-}"
+    if [[ -z "$pr_arg" ]]; then
+        local pr_url
+        pr_url=$(gh pr view --json url -q '.url' 2> /dev/null) || {
+            log_error "No PR found for the current branch. Specify a PR number or URL."
+            exit 1
+        }
+        if ! parse_pr_url "$pr_url"; then
+            log_error "Could not parse PR URL from current branch: ${pr_url}"
+            exit 1
+        fi
+    elif parse_pr_url "$pr_arg"; then
+        :
+    elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
+        PR_NUMBER="$pr_arg"
+        REPO=$(get_current_repo)
+        OWNER="${REPO%%/*}"
+        REPO_NAME="${REPO##*/}"
+    else
+        log_error "Invalid PR argument: ${pr_arg}"
+        log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
+        exit 1
+    fi
+}

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -224,8 +224,14 @@ main() {
         --argjson claude "${claude_results}" \
         --argjson other "${other_findings}" \
         '
+        # A withdrawn finding was argued down after the review was posted, and
+        # the reason is on the record, so it is not put back to the user as an
+        # open question. Its file is the one nobody touched afterwards, so
+        # without this it lands in "unaddressed" and gets asked about again.
+        [$claude[] | select(.withdrawn == true) | {type: "withdrawn", finding: .}]
+        +
         # Claude findings that were not addressed - ask if false positive
-        [$claude[] | select(.addressed == "not_modified") | {type: "unaddressed", finding: .}]
+        [$claude[] | select(.addressed == "not_modified" and (.withdrawn | not)) | {type: "unaddressed", finding: .}]
         +
         # Other reviewer findings that Claude missed - ask if should learn
         [$other[] | select(.claude_caught == false and .addressed == "likely") | {type: "missed", finding: .}]

--- a/skills/review-code/scripts/learn-from-pr.sh
+++ b/skills/review-code/scripts/learn-from-pr.sh
@@ -100,9 +100,11 @@ main() {
         exit 1
     fi
 
-    # Parse Claude's findings from review file
+    # Parse Claude's findings from review file. Withdrawn findings are asked
+    # for here and nowhere else: a finding the author argued down is the
+    # clearest false positive there is, and it is exactly what learning wants.
     local claude_findings
-    claude_findings=$("${SCRIPT_DIR}/parse-review-findings.sh" "${review_file}")
+    claude_findings=$("${SCRIPT_DIR}/parse-review-findings.sh" --include-withdrawn "${review_file}")
 
     # Fetch PR data from GitHub
     local pr_data

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -3,7 +3,7 @@
 # parse-review-findings.sh - Extract structured findings from review markdown files
 #
 # Usage:
-#   parse-review-findings.sh [--with-spans] <review-file-path>
+#   parse-review-findings.sh [--with-spans] [--include-withdrawn] <review-file-path>
 #
 # Description:
 #   Parses a code review markdown file and extracts structured findings.
@@ -13,6 +13,9 @@
 #   - Agent section headers: ## Security Review, ## Performance Review
 #
 # Options:
+#   --include-withdrawn  Include findings retired after the review was posted.
+#                 Skipped by default so a re-review neither carries one forward
+#                 nor reposts it; each carries "withdrawn": true.
 #   --with-spans  Add the line range each finding occupies in the file, plus
 #                 whether that range is safe to cut. carry-forward-findings.sh
 #                 uses it to prune a review in place without the document
@@ -26,7 +29,8 @@
 #       "confidence": 85,
 #       "file": "auth.py",
 #       "line": 45,
-#       "description": "SQL injection risk"
+#       "description": "SQL injection risk",
+#       "withdrawn": false
 #     }
 #   ]
 #
@@ -49,7 +53,7 @@ INCLUDE_WITHDRAWN=false
 
 # Append a finding as a single JSONL line.
 # Args: $1=agent, $2=confidence, $3=file, $4=line, $5=description,
-#       $6=start_line, $7=end_line, $8=deletable
+#       $6=start_line, $7=end_line, $8=deletable, $9=withdrawn
 # Uses: findings_jsonl variable (must be in scope)
 # Modifies: findings_jsonl variable
 save_finding() {
@@ -61,6 +65,7 @@ save_finding() {
     local start="$6"
     local end="$7"
     local deletable="$8"
+    local withdrawn="$9"
 
     # Truncated for the orchestrator, which only needs enough to identify a
     # finding. Not under --with-spans: carry-forward-findings.sh compares whole
@@ -70,8 +75,6 @@ save_finding() {
     if [[ "${WITH_SPANS}" != "true" ]]; then
         desc=$(echo "${desc}" | head -c 500)
     fi
-    local withdrawn="$9"
-
     # A withdrawn finding was argued down after the review was posted. It stays
     # in the document so the argument stays on the record, but it is not a live
     # finding: carry-forward must not re-propose it and the draft payload must
@@ -283,7 +286,7 @@ main() {
             begin_finding
             # A drop stamps the heading's comment-id annotation rather than the
             # body, so the flag costs the description nothing.
-            if [[ "${line}" =~ withdrawn: ]]; then
+            if [[ "${line}" =~ \<!--[[:space:]]*pc:[^\>]*withdrawn: ]]; then
                 finding_withdrawn=true
             fi
             continue

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -53,7 +53,8 @@ INCLUDE_WITHDRAWN=false
 
 # Append a finding as a single JSONL line.
 # Args: $1=agent, $2=confidence, $3=file, $4=line, $5=description,
-#       $6=start_line, $7=end_line, $8=deletable, $9=withdrawn
+#       $6=start_line, $7=end_line, $8=deletable, $9=withdrawn,
+#       ${10}=withdrawn_reason
 # Uses: findings_jsonl variable (must be in scope)
 # Modifies: findings_jsonl variable
 save_finding() {
@@ -66,6 +67,7 @@ save_finding() {
     local end="$7"
     local deletable="$8"
     local withdrawn="$9"
+    local withdrawn_reason="${10:-}"
 
     # Truncated for the orchestrator, which only needs enough to identify a
     # finding. Not under --with-spans: carry-forward-findings.sh compares whole
@@ -95,13 +97,15 @@ save_finding() {
         --argjson deletable "${deletable}" \
         --argjson spans "${WITH_SPANS}" \
         --argjson withdrawn "${withdrawn}" \
+        --arg withdrawn_reason "${withdrawn_reason}" \
         '{
             agent: $agent,
             confidence: ($conf | tonumber),
             file: $file,
             line: ($line | tonumber),
             description: $desc,
-            withdrawn: $withdrawn
+            withdrawn: $withdrawn,
+            withdrawn_reason: $withdrawn_reason
         }
         + (if $spans then {
             start_line: $start,
@@ -120,6 +124,7 @@ begin_finding() {
     finding_end=0
     finding_deletable="${1:-true}"
     finding_withdrawn=false
+    finding_withdrawn_reason=""
 }
 
 # Append one body line to the pending finding's description. Both the in-fence
@@ -127,6 +132,13 @@ begin_finding() {
 # Once the span has ended the finding is over, so nothing more is taken.
 append_description() {
     [[ "${finding_end}" -eq 0 ]] || return 0
+    # The withdrawal marker says something about the finding rather than being
+    # part of it, and it travels as withdrawn_reason instead. Left in the
+    # description it reads as the tail of the finding text, and a consumer that
+    # wants the reason has to go looking for it in prose.
+    if [[ "$1" =~ ^\*Withdrawn ]]; then
+        return 0
+    fi
     finding_description="${finding_description:+${finding_description} }$1"
 }
 
@@ -141,7 +153,8 @@ flush_pending_finding() {
             end="${prev_nonblank}"
         fi
         save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file:-}" "${finding_line:-0}" "${finding_description}" \
-            "${finding_start}" "${end}" "${finding_deletable}" "${finding_withdrawn:-false}"
+            "${finding_start}" "${end}" "${finding_deletable}" "${finding_withdrawn:-false}" \
+            "${finding_withdrawn_reason:-}"
     fi
 }
 
@@ -258,6 +271,11 @@ main() {
         # outside fences only: a body quoting this line is quoting, not marking.
         if [[ "${in_finding}" == true ]] && [[ "${line}" =~ ^\*Withdrawn ]]; then
             finding_withdrawn=true
+            # "*Withdrawn <date>: <reason>*". A marker with no reason after the
+            # date leaves the field empty rather than storing the date twice.
+            if [[ "${line}" =~ ^\*Withdrawn[[:space:]]+[^:*]*:[[:space:]]*(.+)\*$ ]]; then
+                finding_withdrawn_reason="${BASH_REMATCH[1]}"
+            fi
         fi
 
         # Detect agent section headers (## Security Review, ## Performance Review, etc.)

--- a/skills/review-code/scripts/parse-review-findings.sh
+++ b/skills/review-code/scripts/parse-review-findings.sh
@@ -45,6 +45,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/helpers/error-helpers.sh"
 
 WITH_SPANS=false
+INCLUDE_WITHDRAWN=false
 
 # Append a finding as a single JSONL line.
 # Args: $1=agent, $2=confidence, $3=file, $4=line, $5=description,
@@ -69,6 +70,17 @@ save_finding() {
     if [[ "${WITH_SPANS}" != "true" ]]; then
         desc=$(echo "${desc}" | head -c 500)
     fi
+    local withdrawn="$9"
+
+    # A withdrawn finding was argued down after the review was posted. It stays
+    # in the document so the argument stays on the record, but it is not a live
+    # finding: carry-forward must not re-propose it and the draft payload must
+    # not repost it. The learning path asks for them explicitly, since a
+    # finding the author successfully rebutted is exactly what it wants to see.
+    if [[ "${withdrawn}" == "true" && "${INCLUDE_WITHDRAWN}" != "true" ]]; then
+        return 0
+    fi
+
     local entry
     entry=$(jq -nc --arg agent "${agent}" \
         --arg conf "${conf}" \
@@ -79,12 +91,14 @@ save_finding() {
         --argjson end "${end}" \
         --argjson deletable "${deletable}" \
         --argjson spans "${WITH_SPANS}" \
+        --argjson withdrawn "${withdrawn}" \
         '{
             agent: $agent,
             confidence: ($conf | tonumber),
             file: $file,
             line: ($line | tonumber),
-            description: $desc
+            description: $desc,
+            withdrawn: $withdrawn
         }
         + (if $spans then {
             start_line: $start,
@@ -102,6 +116,7 @@ begin_finding() {
     finding_start="${lineno}"
     finding_end=0
     finding_deletable="${1:-true}"
+    finding_withdrawn=false
 }
 
 # Append one body line to the pending finding's description. Both the in-fence
@@ -123,7 +138,7 @@ flush_pending_finding() {
             end="${prev_nonblank}"
         fi
         save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file:-}" "${finding_line:-0}" "${finding_description}" \
-            "${finding_start}" "${end}" "${finding_deletable}"
+            "${finding_start}" "${end}" "${finding_deletable}" "${finding_withdrawn:-false}"
     fi
 }
 
@@ -136,6 +151,10 @@ main() {
                 WITH_SPANS=true
                 shift
                 ;;
+            --include-withdrawn)
+                INCLUDE_WITHDRAWN=true
+                shift
+                ;;
             *)
                 review_file="$1"
                 shift
@@ -144,7 +163,7 @@ main() {
     done
 
     if [[ -z "${review_file}" ]]; then
-        error "Usage: parse-review-findings.sh [--with-spans] <review-file-path>"
+        error "Usage: parse-review-findings.sh [--with-spans] [--include-withdrawn] <review-file-path>"
         exit 1
     fi
 
@@ -231,6 +250,13 @@ main() {
             continue
         fi
 
+        # A finding marked withdrawn by hand, in a review that was never posted
+        # as a draft and so carries no heading annotation to stamp. Checked
+        # outside fences only: a body quoting this line is quoting, not marking.
+        if [[ "${in_finding}" == true ]] && [[ "${line}" =~ ^\*Withdrawn ]]; then
+            finding_withdrawn=true
+        fi
+
         # Detect agent section headers (## Security Review, ## Performance Review, etc.)
         if [[ "${line}" =~ ^##[[:space:]]+(Security|Performance|Correctness|Maintainability|Testing|Compatibility|Architecture|Frontend)[[:space:]]+Review ]]; then
             flush_pending_finding
@@ -255,6 +281,11 @@ main() {
             finding_description=""
             current_confidence=""
             begin_finding
+            # A drop stamps the heading's comment-id annotation rather than the
+            # body, so the flag costs the description nothing.
+            if [[ "${line}" =~ withdrawn: ]]; then
+                finding_withdrawn=true
+            fi
             continue
         fi
 
@@ -324,7 +355,7 @@ main() {
 
             # This pattern includes the description inline, so save it immediately
             save_finding "${current_agent:-unknown}" "${current_confidence:-0}" "${finding_file}" "${finding_line}" "${finding_description}" \
-                "${lineno}" "${lineno}" true
+                "${lineno}" "${lineno}" true false
 
             finding_file=""
             finding_line=""
@@ -359,7 +390,7 @@ main() {
 
             # Save this finding immediately (inline pattern)
             save_finding "${agent_name}" "${current_confidence}" "${finding_file}" "${finding_line}" "${finding_description}" \
-                "${lineno}" "${lineno}" true
+                "${lineno}" "${lineno}" true false
 
             finding_file=""
             finding_line=""

--- a/skills/review-code/scripts/resolve-review-threads.sh
+++ b/skills/review-code/scripts/resolve-review-threads.sh
@@ -33,68 +33,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=helpers/gh-wrapper.sh
 source "${SCRIPT_DIR}/helpers/gh-wrapper.sh"
 
-# ── Logging ──────────────────────────────────────────────────────────────────
-# Log to stderr so stdout stays clean for JSON consumers.
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
-
-log_info() { echo -e "${BLUE}[INFO]${NC} $1" >&2; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1" >&2; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
-
-# ── PR target resolution ─────────────────────────────────────────────────────
-
-# Parse a GitHub PR URL into OWNER, REPO_NAME, REPO, and PR_NUMBER.
-parse_pr_url() {
-    local url="$1"
-    if [[ "$url" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+) ]]; then
-        OWNER="${BASH_REMATCH[1]}"
-        REPO_NAME="${BASH_REMATCH[2]}"
-        REPO="${OWNER}/${REPO_NAME}"
-        PR_NUMBER="${BASH_REMATCH[3]}"
-        return 0
-    fi
-    return 1
-}
-
-get_current_repo() {
-    gh repo view --json nameWithOwner -q '.nameWithOwner' 2> /dev/null || {
-        log_error "Could not determine repository. Run from inside a repo or pass a full PR URL."
-        exit 1
-    }
-}
-
-# Resolve a PR argument (URL, number, or empty) into OWNER/REPO_NAME/REPO/PR_NUMBER.
-resolve_pr_target() {
-    local pr_arg="${1:-}"
-    if [[ -z "$pr_arg" ]]; then
-        local pr_url
-        pr_url=$(gh pr view --json url -q '.url' 2> /dev/null) || {
-            log_error "No PR found for the current branch. Specify a PR number or URL."
-            exit 1
-        }
-        if ! parse_pr_url "$pr_url"; then
-            log_error "Could not parse PR URL from current branch: ${pr_url}"
-            exit 1
-        fi
-    elif parse_pr_url "$pr_arg"; then
-        :
-    elif [[ "$pr_arg" =~ ^[0-9]+$ ]]; then
-        PR_NUMBER="$pr_arg"
-        REPO=$(get_current_repo)
-        OWNER="${REPO%%/*}"
-        REPO_NAME="${REPO##*/}"
-    else
-        log_error "Invalid PR argument: ${pr_arg}"
-        log_error "Expected a PR number or URL (https://github.com/owner/repo/pull/123)."
-        exit 1
-    fi
-}
+# shellcheck source=helpers/pr-target.sh
+source "${SCRIPT_DIR}/helpers/pr-target.sh"
 
 # ── Thread fetching ──────────────────────────────────────────────────────────
 

--- a/skills/review-code/scripts/review-comment-blocks.py
+++ b/skills/review-code/scripts/review-comment-blocks.py
@@ -199,12 +199,54 @@ def prose_withdrawal(lines: list[str], start: int) -> str | None:
     return None
 
 
+def copies_of(blocks: list[dict], taken: set, anchor: dict) -> list[dict]:
+    """Every block that is the same finding written out again.
+
+    A composed review carries each finding twice, once in its agent section and
+    once under Suggested Comments. Same path, same line and the same body text
+    is what marks a copy, rather than a different finding that happens to sit on
+    the same line. A block with no body cannot be told apart that way, so it
+    stands alone.
+    """
+    body = normalize(anchor["body"])
+    if not body:
+        return [anchor]
+    return [
+        block
+        for block in blocks
+        if block["index"] not in taken
+        and block["path"] == anchor["path"]
+        and block["line"] == anchor["line"]
+        and normalize(block["body"]) == body
+    ]
+
+
+def one_per_id(blocks: list[dict]) -> list[dict]:
+    """Collapse a finding's copies to the one that was posted.
+
+    Both copies carry the id, so reporting each separately would invent a second
+    comment: status would pair the live comment with one and mark the other
+    missing_on_github, which is enough to make --push refuse. The later block is
+    the copy under Suggested Comments, and that is the text that was posted.
+    """
+    by_id: dict[int, dict] = {}
+    for block in blocks:
+        by_id[block["id"]] = block
+    return list(by_id.values())
+
+
 def match_comments(blocks: list[dict], comments: list[dict]) -> tuple[dict, list]:
-    """Pair each posted comment with the block that produced it.
+    """Pair each posted comment with every block that carries its text.
 
     Body is the primary key, not path:line. Drift remapping can move a comment
     to a different line than the heading records, and two findings can share a
     line, so the text is the only thing that reliably identifies the block.
+
+    Every copy is paired, not just the first. Only the copy under Suggested
+    Comments was posted, but the agent-section copy comes first in the document,
+    so annotating one and leaving the other meant a withdrawal landed on a copy
+    nothing reads: the posted finding stayed live and the next re-review offered
+    the comment again. status and read collapse the copies back to one entry.
     """
     taken: set[int] = set()
     pairs: dict[int, dict] = {}
@@ -213,34 +255,68 @@ def match_comments(blocks: list[dict], comments: list[dict]) -> tuple[dict, list
     for comment in comments:
         path = (comment.get("path") or "").strip()
         body = normalize(comment.get("body") or "")
-        chosen = None
-        for block in blocks:
-            if block["index"] in taken or block["path"] != path:
-                continue
-            if body and normalize(block["body"]) == body:
-                chosen = block
-                break
-        if chosen is None:
-            for block in blocks:
-                if block["index"] in taken or block["path"] != path:
-                    continue
-                if block["line"] == comment.get("line"):
-                    chosen = block
-                    break
-        if chosen is None:
+        anchor = None
+        if body:
+            anchor = next(
+                (
+                    block
+                    for block in blocks
+                    if block["index"] not in taken
+                    and block["path"] == path
+                    and normalize(block["body"]) == body
+                ),
+                None,
+            )
+        if anchor is None:
+            anchor = next(
+                (
+                    block
+                    for block in blocks
+                    if block["index"] not in taken
+                    and block["path"] == path
+                    and block["line"] == comment.get("line")
+                ),
+                None,
+            )
+        if anchor is None:
             unmatched.append({"id": comment.get("id"), "path": path})
             continue
-        taken.add(chosen["index"])
-        pairs[chosen["index"]] = comment
+        for block in copies_of(blocks, taken, anchor):
+            taken.add(block["index"])
+            pairs[block["index"]] = comment
     return pairs, unmatched
 
 
-def annotate_heading(line: str, comment: dict) -> str:
+def heading_tokens(line: str) -> list[str]:
+    """The annotation tokens a heading already carries."""
+    match = HEADING.match(line)
+    if not match:
+        return []
+    annotation = ANNOTATION.search(match.group("rest"))
+    return annotation.group("ids").split() if annotation else []
+
+
+def rewrite_annotation(line: str, tokens: list[str]) -> str:
+    """Put this token list on the heading, replacing any annotation there.
+
+    The heading's shape is the contract CLAUDE.md documents and three readers
+    depend on, so it is rebuilt here and nowhere else. What differs between
+    callers is which tokens belong on it, so each one says that for itself
+    rather than the rule living inside two near-identical rebuild bodies.
+    """
     match = HEADING.match(line)
     if not match:
         return line
     rest = ANNOTATION.sub("", match.group("rest")).rstrip()
-    ids = " ".join(
+    head = (
+        f"{match.group('open')}{match.group('path')}:{match.group('line')}"
+        f"{match.group('close')}{rest}"
+    )
+    return f"{head} <!-- pc:{' '.join(tokens)} -->" if tokens else head
+
+
+def annotate_heading(line: str, comment: dict) -> str:
+    tokens = [
         str(v)
         for v in (
             comment.get("id"),
@@ -248,11 +324,12 @@ def annotate_heading(line: str, comment: dict) -> str:
             BODY_HASH_PREFIX + body_hash(comment.get("body") or ""),
         )
         if v
-    )
-    return (
-        f"{match.group('open')}{match.group('path')}:{match.group('line')}"
-        f"{match.group('close')}{rest} <!-- pc:{ids} -->"
-    )
+    ]
+    # A withdrawal already on the heading survives re-annotation. These tokens
+    # are built from the comment, so anything not rebuilt from it has to be
+    # carried over deliberately or it is dropped.
+    tokens += [t for t in heading_tokens(line) if t.startswith(WITHDRAWN_PREFIX)]
+    return rewrite_annotation(line, tokens)
 
 
 def stamp_withdrawn(line: str, date: str) -> str:
@@ -262,18 +339,9 @@ def stamp_withdrawn(line: str, date: str) -> str:
     on the withdrawal rather than on a missing id, which keeps "never posted"
     and "posted then withdrawn" distinguishable.
     """
-    match = HEADING.match(line)
-    if not match:
-        return line
-    annotation = ANNOTATION.search(match.group("rest"))
-    tokens = annotation.group("ids").split() if annotation else []
-    tokens = [t for t in tokens if not t.startswith(WITHDRAWN_PREFIX)]
+    tokens = [t for t in heading_tokens(line) if not t.startswith(WITHDRAWN_PREFIX)]
     tokens.append(f"{WITHDRAWN_PREFIX}{date}")
-    rest = ANNOTATION.sub("", match.group("rest")).rstrip()
-    return (
-        f"{match.group('open')}{match.group('path')}:{match.group('line')}"
-        f"{match.group('close')}{rest} <!-- pc:{' '.join(tokens)} -->"
-    )
+    return rewrite_annotation(line, tokens)
 
 
 def header_span(lines: list[str]) -> tuple[int | None, int | None]:
@@ -392,9 +460,9 @@ def classify(notes: str, live: str, recorded: str | None) -> str:
 
 def cmd_status(args, lines: list[str], path: Path) -> dict:
     live_by_id = {int(c["id"]): c for c in load_stdin_list() if c.get("id") is not None}
-    blocks = [
-        b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]
-    ]
+    blocks = one_per_id(
+        [b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]]
+    )
 
     comments = []
     for block in blocks:
@@ -467,9 +535,9 @@ def cmd_withdraw(args, lines: list[str], path: Path) -> dict:
 
 
 def cmd_read(args, lines: list[str], path: Path) -> dict:
-    blocks = [
-        b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]
-    ]
+    blocks = one_per_id(
+        [b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]]
+    )
     return {
         "review_id": header_field(lines, "review_id"),
         "posted_at": header_field(lines, "posted_at"),

--- a/skills/review-code/scripts/review-comment-blocks.py
+++ b/skills/review-code/scripts/review-comment-blocks.py
@@ -448,9 +448,14 @@ def cmd_withdraw(args, lines: list[str], path: Path) -> dict:
     for block in sorted(blocks, key=lambda b: b["index"], reverse=True):
         reason = wanted[block["id"]]
         note = f"*Withdrawn {date}{': ' + reason if reason else ''}*"
-        if block["body_end"] is not None:
-            lines.insert(block["body_end"] + 1, "")
-            lines.insert(block["body_end"] + 2, note)
+        # Under the fenced body, or straight under the heading when there is no
+        # fence to sit below. A block with no body reaches here: annotate's
+        # path-and-line fallback matches one even though body matching cannot,
+        # and stamping the heading while skipping the note would retire the
+        # finding with the reason written down nowhere.
+        anchor = block["index"] if block["body_end"] is None else block["body_end"]
+        lines.insert(anchor + 1, "")
+        lines.insert(anchor + 2, note)
         lines[block["index"]] = stamp_withdrawn(lines[block["index"]], date)
 
     if blocks:

--- a/skills/review-code/scripts/review-comment-blocks.py
+++ b/skills/review-code/scripts/review-comment-blocks.py
@@ -33,9 +33,10 @@ Subcommands:
              an internal failure is reported and exits 0 rather than turning a
              successful post into a script error.
 
-  read       Emit the recorded blocks as JSON. Fails loud, because a silent
-             empty result is indistinguishable from "nothing was ever recorded"
-             and would let an amend run act on the wrong thing.
+  read       Emit the recorded blocks as JSON. Nothing in the pipeline calls
+             this; it is the way to inspect what a review file has recorded,
+             by hand or from a test. Fails loud so an unreadable file is not
+             mistaken for a file with nothing recorded in it.
 
   set-body   Replace the fenced body of the blocks named on stdin, as
              [{"id": N, "body": "..."}]. Fails loud, for the same reason.
@@ -134,12 +135,16 @@ def find_blocks(lines: list[str]) -> list[dict]:
         match = HEADING.match(line)
         if match:
             body_start, body_end = body_span(lines, index + 1)
+            annotation = parse_annotation(match.group("rest"))
+            annotation["withdrawn"] = annotation["withdrawn"] or prose_withdrawal(
+                lines, body_end if body_end is not None else index
+            )
             blocks.append(
                 {
                     "index": index,
                     "path": match.group("path").strip().strip("`"),
                     "line": int(match.group("line")),
-                    **parse_annotation(match.group("rest")),
+                    **annotation,
                     "body_start": body_start,
                     "body_end": body_end,
                     "body": (
@@ -174,6 +179,24 @@ def body_span(lines: list[str], start: int) -> tuple[int | None, int | None]:
         if marker and token.startswith(fence) and not line[marker.end() :].strip():
             return open_at, offset
     return None, None
+
+
+def prose_withdrawal(lines: list[str], start: int) -> str | None:
+    """Find a `*Withdrawn ...*` line in the block's tail, if there is one.
+
+    parse-review-findings.sh accepts this marker as well as the heading token,
+    so a review that was never posted as a draft can still retire a finding.
+    Reading only the token here would leave such a block looking live, and the
+    annotate filter would then let a new finding at the same path and line
+    claim it. Bounded by the next heading or thematic break so it cannot reach
+    into the following finding.
+    """
+    for line in lines[start + 1 :]:
+        if line.startswith("#") or line.strip().startswith("---"):
+            return None
+        if line.startswith("*Withdrawn"):
+            return line.strip().strip("*") or "yes"
+    return None
 
 
 def match_comments(blocks: list[dict], comments: list[dict]) -> tuple[dict, list]:
@@ -346,10 +369,16 @@ def cmd_annotate(args, lines: list[str], path: Path) -> dict:
 # at the last sync, so it is the only thing that distinguishes an edit made on
 # GitHub from one made in the notes.
 def classify(notes: str, live: str, recorded: str | None) -> str:
+    # Settle the agreeing case before consulting the digest. A digest that went
+    # stale (a dropped network call during a refresh, say) would otherwise read
+    # as `diverged` on two identical bodies, which accuses someone of a UI edit
+    # they did not make and leaves --push refusing with nothing to reconcile.
+    if normalize(notes) == normalize(live):
+        return "in_sync"
     if recorded is None:
-        # Annotated before digests existed, or hand-edited. Two values can only
-        # report disagreement, never attribute it.
-        return "in_sync" if body_hash(notes) == body_hash(live) else "unknown_baseline"
+        # Annotated before digests existed, or hand-edited. Two differing
+        # values can report disagreement but never attribute it.
+        return "unknown_baseline"
     notes_moved = body_hash(notes) != recorded
     live_moved = body_hash(live) != recorded
     if notes_moved and live_moved:
@@ -507,12 +536,9 @@ def main() -> int:
         result.update(COMMANDS[args.command](args, lines, path))
     except Exception as exc:  # noqa: BLE001 - see FAIL_OPEN
         result["error"] = str(exc)
-        if args.command not in FAIL_OPEN:
-            print(json.dumps(result))
-            return 1
 
     print(json.dumps(result))
-    return 0
+    return 1 if result["error"] and args.command not in FAIL_OPEN else 0
 
 
 if __name__ == "__main__":

--- a/skills/review-code/scripts/review-comment-blocks.py
+++ b/skills/review-code/scripts/review-comment-blocks.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Read and rewrite the finding blocks a review file posted as PR comments.
+
+A pending review comment cannot be found again from the review document alone:
+the document holds a path, a line and a body, and none of those survive as a
+stable key once the author edits the comment on GitHub or the PR takes new
+commits. Recording the comment's id in the document at post time is what lets a
+later session reconcile the two and reword one comment instead of re-running
+the whole review.
+
+The id rides on the finding's heading, inside an HTML comment:
+
+    #### `posthog/feature_flags.py:784` <!-- pc:3846146537 PRRC_kwDO…lP4np b:3f9a2c1e -->
+
+The third token is a digest of the body as of the last sync. Without it, notes
+and GitHub give two values that can only say *that* they differ, never which
+side moved, so a reword pushed over someone's hand edit would be
+indistinguishable from a clean push. With it, the three-way comparison names
+the side that changed and `--push` can refuse when GitHub is the one that did.
+
+That position is deliberate. parse-review-findings.sh never lets a heading line
+reach a finding's `description` and its header pattern is unanchored on the
+right, so the annotation changes nothing it parses; the annotation still sits
+inside the finding's span, so carry-forward-findings.sh cuts it along with the
+finding rather than leaving it orphaned; and both linters skip the Suggested
+Comments section entirely.
+
+Subcommands:
+
+  annotate   Record ids after a draft post. Reads the posted comments as JSON on
+             stdin (as GET /pulls/{n}/reviews/{id}/comments returns them).
+             Fails open: the review is already posted by the time this runs, so
+             an internal failure is reported and exits 0 rather than turning a
+             successful post into a script error.
+
+  read       Emit the recorded blocks as JSON. Fails loud, because a silent
+             empty result is indistinguishable from "nothing was ever recorded"
+             and would let an amend run act on the wrong thing.
+
+  set-body   Replace the fenced body of the blocks named on stdin, as
+             [{"id": N, "body": "..."}]. Fails loud, for the same reason.
+
+  withdraw   Mark blocks as withdrawn, from [{"id": N, "reason": "..."}] on
+             stdin. The block stays where it is so the argument that retired it
+             stays on the record; it simply stops counting as a live finding.
+
+  status     Classify each recorded block against the live pending review, read
+             as JSON on stdin. Comparison lives here rather than in the calling
+             shell so there is one normalizer: a second one would drift, and
+             drift invents "changed" states the push guard exists to catch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+
+# Mirrors finding_header_re in parse-review-findings.sh, plus a trailing group
+# so an annotation already present is replaced instead of doubled.
+HEADING = re.compile(
+    r"^(?P<open>#{3,4}[ \t]+(?:\d+\.[ \t]+)?`?)"
+    r"(?P<path>[^:`]+):(?P<line>\d+)"
+    r"(?P<close>`?)"
+    r"(?P<rest>.*)$"
+)
+
+ANNOTATION = re.compile(r"\s*<!--\s*pc:(?P<ids>.*?)-->")
+
+BODY_HASH_PREFIX = "b:"
+WITHDRAWN_PREFIX = "withdrawn:"
+
+METADATA_OPEN = re.compile(r"^<!--\s*review-metadata\b")
+
+
+def normalize(text: str) -> str:
+    """Compare bodies ignoring differences GitHub does not preserve."""
+    return "\n".join(line.rstrip() for line in text.strip().splitlines()).strip()
+
+
+def body_hash(text: str) -> str:
+    """Digest a body so a later run can tell which side of a sync moved."""
+    return hashlib.sha256(normalize(text).encode("utf-8")).hexdigest()[:8]
+
+
+def parse_annotation(rest: str) -> dict:
+    """Pull the comment id, node id, last-synced digest and withdrawal off a heading."""
+    match = ANNOTATION.search(rest)
+    parsed: dict = {
+        "id": None,
+        "node_id": None,
+        "body_hash": None,
+        "withdrawn": None,
+    }
+    if not match:
+        return parsed
+    for token in match.group("ids").split():
+        if token.startswith(BODY_HASH_PREFIX):
+            parsed["body_hash"] = token[len(BODY_HASH_PREFIX) :]
+        elif token.startswith(WITHDRAWN_PREFIX):
+            parsed["withdrawn"] = token[len(WITHDRAWN_PREFIX) :]
+        elif token.isdigit():
+            parsed["id"] = int(token)
+        else:
+            parsed["node_id"] = token
+    return parsed
+
+
+def find_blocks(lines: list[str]) -> list[dict]:
+    """Locate every finding heading and the fenced body beneath it.
+
+    The fence walk matters: a finding body can quote markdown that contains
+    something heading-shaped, and treating that as a new finding would attach
+    the wrong comment id to it.
+    """
+    blocks: list[dict] = []
+    fence = ""
+    for index, line in enumerate(lines):
+        marker = FENCE.match(line)
+        token = marker.group(1) if marker else ""
+        if fence:
+            if marker and token.startswith(fence) and not line[marker.end() :].strip():
+                fence = ""
+            continue
+        if token:
+            fence = token
+            continue
+        match = HEADING.match(line)
+        if match:
+            body_start, body_end = body_span(lines, index + 1)
+            blocks.append(
+                {
+                    "index": index,
+                    "path": match.group("path").strip().strip("`"),
+                    "line": int(match.group("line")),
+                    **parse_annotation(match.group("rest")),
+                    "body_start": body_start,
+                    "body_end": body_end,
+                    "body": (
+                        "\n".join(lines[body_start:body_end])
+                        if body_start is not None
+                        else ""
+                    ),
+                }
+            )
+    return blocks
+
+
+def body_span(lines: list[str], start: int) -> tuple[int | None, int | None]:
+    """Return the line range of the first fenced block after a heading.
+
+    That fence is the comment text. A heading or thematic break reached before
+    any fence means the finding has no comment body.
+    """
+    fence = ""
+    open_at = None
+    for offset, line in enumerate(lines[start:], start=start):
+        marker = FENCE.match(line)
+        token = marker.group(1) if marker else ""
+        if not fence:
+            if token:
+                fence = token
+                open_at = offset + 1
+                continue
+            if line.startswith("#") or line.strip().startswith("---"):
+                return None, None
+            continue
+        if marker and token.startswith(fence) and not line[marker.end() :].strip():
+            return open_at, offset
+    return None, None
+
+
+def match_comments(blocks: list[dict], comments: list[dict]) -> tuple[dict, list]:
+    """Pair each posted comment with the block that produced it.
+
+    Body is the primary key, not path:line. Drift remapping can move a comment
+    to a different line than the heading records, and two findings can share a
+    line, so the text is the only thing that reliably identifies the block.
+    """
+    taken: set[int] = set()
+    pairs: dict[int, dict] = {}
+    unmatched: list[dict] = []
+
+    for comment in comments:
+        path = (comment.get("path") or "").strip()
+        body = normalize(comment.get("body") or "")
+        chosen = None
+        for block in blocks:
+            if block["index"] in taken or block["path"] != path:
+                continue
+            if body and normalize(block["body"]) == body:
+                chosen = block
+                break
+        if chosen is None:
+            for block in blocks:
+                if block["index"] in taken or block["path"] != path:
+                    continue
+                if block["line"] == comment.get("line"):
+                    chosen = block
+                    break
+        if chosen is None:
+            unmatched.append({"id": comment.get("id"), "path": path})
+            continue
+        taken.add(chosen["index"])
+        pairs[chosen["index"]] = comment
+    return pairs, unmatched
+
+
+def annotate_heading(line: str, comment: dict) -> str:
+    match = HEADING.match(line)
+    if not match:
+        return line
+    rest = ANNOTATION.sub("", match.group("rest")).rstrip()
+    ids = " ".join(
+        str(v)
+        for v in (
+            comment.get("id"),
+            comment.get("node_id"),
+            BODY_HASH_PREFIX + body_hash(comment.get("body") or ""),
+        )
+        if v
+    )
+    return (
+        f"{match.group('open')}{match.group('path')}:{match.group('line')}"
+        f"{match.group('close')}{rest} <!-- pc:{ids} -->"
+    )
+
+
+def stamp_withdrawn(line: str, date: str) -> str:
+    """Add the withdrawal to the heading annotation, keeping the ids.
+
+    The ids stay so the record shows which comment was retired. Readers filter
+    on the withdrawal rather than on a missing id, which keeps "never posted"
+    and "posted then withdrawn" distinguishable.
+    """
+    match = HEADING.match(line)
+    if not match:
+        return line
+    annotation = ANNOTATION.search(match.group("rest"))
+    tokens = annotation.group("ids").split() if annotation else []
+    tokens = [t for t in tokens if not t.startswith(WITHDRAWN_PREFIX)]
+    tokens.append(f"{WITHDRAWN_PREFIX}{date}")
+    rest = ANNOTATION.sub("", match.group("rest")).rstrip()
+    return (
+        f"{match.group('open')}{match.group('path')}:{match.group('line')}"
+        f"{match.group('close')}{rest} <!-- pc:{' '.join(tokens)} -->"
+    )
+
+
+def header_span(lines: list[str]) -> tuple[int | None, int | None]:
+    """Locate the first review-metadata block.
+
+    Only the first: review files on disk sometimes carry a second one from an
+    earlier append, and the first is the one every other reader takes.
+    """
+    start = next((i for i, line in enumerate(lines) if METADATA_OPEN.match(line)), None)
+    if start is None:
+        return None, None
+    end = next(
+        (i for i in range(start + 1, len(lines)) if lines[i].strip().startswith("-->")),
+        None,
+    )
+    return (start, end) if end is not None else (None, None)
+
+
+def header_field(lines: list[str], key: str) -> str | None:
+    start, end = header_span(lines)
+    if start is None:
+        return None
+    for line in lines[start + 1 : end]:
+        head, _, value = line.partition(":")
+        if head.strip() == key:
+            return value.strip()
+    return None
+
+
+def update_header(lines: list[str], review_id, posted_at) -> bool:
+    if review_id is None:
+        return False
+    start, end = header_span(lines)
+    if start is None:
+        return False
+
+    fields = {"review_id": str(review_id)}
+    if posted_at:
+        fields["posted_at"] = posted_at
+
+    kept = [
+        line
+        for line in lines[start + 1 : end]
+        if line.split(":", 1)[0].strip() not in fields
+    ]
+    # Sit above the nested blocks so the scalars stay together and nothing
+    # reads as if it belonged to scope: or token_usage:.
+    insert = next(
+        (i for i, line in enumerate(kept) if line.rstrip().endswith(":")), len(kept)
+    )
+    added = [f"{key}: {value}" for key, value in fields.items()]
+    lines[start + 1 : end] = kept[:insert] + added + kept[insert:]
+    return True
+
+
+def write_atomic(path: Path, lines: list[str], suffix: str) -> None:
+    """Replace the file in one step.
+
+    write_text truncates first, so a write that failed part-way would leave the
+    review a partial file, and a fail-open caller would report that as a clean
+    skip.
+    """
+    tmp = path.with_name(f".{path.name}.{suffix}")
+    try:
+        tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        os.replace(tmp, path)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def cmd_annotate(args, lines: list[str], path: Path) -> dict:
+    comments = load_stdin_list()
+    # A withdrawn block is never a candidate. Its finding was retired and its
+    # text was not reposted, so body matching cannot reach it, but the
+    # path-and-line fallback would: a new finding at the same location would
+    # take the retired block's annotation, wiping the withdrawal and bringing
+    # the finding back to life while the real new block got nothing.
+    live = [b for b in find_blocks(lines) if not b["withdrawn"]]
+    pairs, unmatched = match_comments(live, comments)
+    for index, comment in pairs.items():
+        lines[index] = annotate_heading(lines[index], comment)
+    header_updated = update_header(lines, args.review_id, args.posted_at)
+    if pairs or header_updated:
+        write_atomic(path, lines, "pc-ids")
+    return {
+        "annotated": len(pairs),
+        "unmatched": unmatched,
+        "header_updated": header_updated,
+    }
+
+
+# What the three bodies say about who moved. `recorded` is the digest written
+# at the last sync, so it is the only thing that distinguishes an edit made on
+# GitHub from one made in the notes.
+def classify(notes: str, live: str, recorded: str | None) -> str:
+    if recorded is None:
+        # Annotated before digests existed, or hand-edited. Two values can only
+        # report disagreement, never attribute it.
+        return "in_sync" if body_hash(notes) == body_hash(live) else "unknown_baseline"
+    notes_moved = body_hash(notes) != recorded
+    live_moved = body_hash(live) != recorded
+    if notes_moved and live_moved:
+        return "diverged"
+    if live_moved:
+        return "changed_on_github"
+    if notes_moved:
+        return "changed_in_notes"
+    return "in_sync"
+
+
+def cmd_status(args, lines: list[str], path: Path) -> dict:
+    live_by_id = {int(c["id"]): c for c in load_stdin_list() if c.get("id") is not None}
+    blocks = [
+        b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]
+    ]
+
+    comments = []
+    for block in blocks:
+        live = live_by_id.pop(block["id"], None)
+        if live is None:
+            state, live_body = "missing_on_github", None
+        else:
+            live_body = live.get("body") or ""
+            state = classify(block["body"], live_body, block["body_hash"])
+        comments.append(
+            {
+                "id": block["id"],
+                "node_id": block["node_id"] or (live or {}).get("node_id"),
+                "path": block["path"],
+                "line": block["line"],
+                "position": (live or {}).get("position"),
+                "state": state,
+                "notes_body": block["body"],
+                "live_body": live_body,
+            }
+        )
+
+    counts: dict[str, int] = {}
+    for comment in comments:
+        counts[comment["state"]] = counts.get(comment["state"], 0) + 1
+
+    return {
+        "review_id": header_field(lines, "review_id"),
+        "comments": comments,
+        "counts": counts,
+        # Live comments with no block: posted by hand, or by a review whose
+        # notes were overwritten. Never acted on, only reported.
+        "unrecorded": [
+            {"id": c.get("id"), "path": c.get("path")} for c in live_by_id.values()
+        ],
+    }
+
+
+def cmd_withdraw(args, lines: list[str], path: Path) -> dict:
+    wanted = {int(item["id"]): (item.get("reason") or "") for item in load_stdin_list()}
+    date = args.date or "unknown date"
+    blocks = [b for b in find_blocks(lines) if b["id"] in wanted and not b["withdrawn"]]
+
+    # Bottom-up, so inserting a line never shifts a span still to be edited.
+    for block in sorted(blocks, key=lambda b: b["index"], reverse=True):
+        reason = wanted[block["id"]]
+        note = f"*Withdrawn {date}{': ' + reason if reason else ''}*"
+        if block["body_end"] is not None:
+            lines.insert(block["body_end"] + 1, "")
+            lines.insert(block["body_end"] + 2, note)
+        lines[block["index"]] = stamp_withdrawn(lines[block["index"]], date)
+
+    if blocks:
+        write_atomic(path, lines, "pc-withdraw")
+    return {
+        "withdrawn": len(blocks),
+        "missing": sorted(set(wanted) - {b["id"] for b in blocks}),
+    }
+
+
+def cmd_read(args, lines: list[str], path: Path) -> dict:
+    blocks = [
+        b for b in find_blocks(lines) if b["id"] is not None and not b["withdrawn"]
+    ]
+    return {
+        "review_id": header_field(lines, "review_id"),
+        "posted_at": header_field(lines, "posted_at"),
+        "comments": [
+            {
+                "id": b["id"],
+                "node_id": b["node_id"],
+                "path": b["path"],
+                "line": b["line"],
+                "body": b["body"],
+                "body_hash": b["body_hash"],
+            }
+            for b in blocks
+        ],
+    }
+
+
+def cmd_set_body(args, lines: list[str], path: Path) -> dict:
+    wanted = {int(item["id"]): item["body"] for item in load_stdin_list()}
+    # Rewriting a retired finding's body is never right; it is kept as the
+    # record of what was argued, not as something still in play.
+    blocks = [b for b in find_blocks(lines) if b["id"] in wanted and not b["withdrawn"]]
+    found = {b["id"] for b in blocks}
+
+    # Rewrite from the bottom so earlier spans keep their indices.
+    updated = 0
+    for block in sorted(blocks, key=lambda b: b["index"], reverse=True):
+        if block["body_start"] is None:
+            continue
+        body = wanted[block["id"]].splitlines() or [""]
+        lines[block["body_start"] : block["body_end"]] = body
+        updated += 1
+    if updated:
+        write_atomic(path, lines, "pc-body")
+    return {
+        "updated": updated,
+        "missing": sorted(set(wanted) - found),
+    }
+
+
+def load_stdin_list() -> list[dict]:
+    payload = json.load(sys.stdin)
+    if not isinstance(payload, list):
+        raise ValueError("expected a JSON array")
+    return payload
+
+
+COMMANDS = {
+    "annotate": cmd_annotate,
+    "read": cmd_read,
+    "set-body": cmd_set_body,
+    "status": cmd_status,
+    "withdraw": cmd_withdraw,
+}
+
+# annotate runs after the review is already on GitHub, where a hard failure
+# would misreport a successful post. read and set-body drive an amend, where a
+# silent empty result would let the caller act on the wrong thing.
+FAIL_OPEN = {"annotate"}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=sorted(COMMANDS))
+    parser.add_argument("--review-file", required=True)
+    parser.add_argument("--review-id")
+    parser.add_argument("--posted-at")
+    parser.add_argument("--date")
+    args = parser.parse_args()
+
+    result: dict = {"error": None}
+    try:
+        path = Path(args.review_file)
+        lines = path.read_text(encoding="utf-8").splitlines()
+        result.update(COMMANDS[args.command](args, lines, path))
+    except Exception as exc:  # noqa: BLE001 - see FAIL_OPEN
+        result["error"] = str(exc)
+        if args.command not in FAIL_OPEN:
+            print(json.dumps(result))
+            return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/review-code/scripts/review-comment-blocks.py
+++ b/skills/review-code/scripts/review-comment-blocks.py
@@ -407,7 +407,13 @@ def cmd_status(args, lines: list[str], path: Path) -> dict:
         comments.append(
             {
                 "id": block["id"],
-                "node_id": block["node_id"] or (live or {}).get("node_id"),
+                # GitHub's node id wins over the one on the heading. The numeric
+                # id is checked against the pending review, but the node id is
+                # what the reword mutation actually addresses, and it is read
+                # from a file anyone can edit; taking the live one keeps the
+                # header's claim that every comment touched is the caller's own.
+                # The recorded one still covers a live comment with none.
+                "node_id": (live or {}).get("node_id") or block["node_id"],
                 "path": block["path"],
                 "line": block["line"],
                 "position": (live or {}).get("position"),

--- a/skills/review-code/scripts/review-safety-hook.sh
+++ b/skills/review-code/scripts/review-safety-hook.sh
@@ -7,13 +7,26 @@
 # duplicate review detection, etc.).
 #
 # Blocked patterns:
-#   - gh pr review    (submits/creates reviews directly)
-#   - gh api with review endpoints (bypasses create-draft-review.sh)
+#   - gh pr review                          (submits/creates reviews directly)
+#   - gh api on a PR's reviews endpoints    (bypasses create-draft-review.sh)
+#   - gh api on a single review comment     (can delete a published comment)
+#   - GraphQL review-comment mutations      (the other transport for the same)
 #
 # Input: JSON on stdin (Claude Code PreToolUse hook format)
 # Output: JSON with permissionDecision (deny or allow)
 
 set -euo pipefail
+
+deny() {
+    jq -n --arg reason "$1" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }'
+    exit 0
+}
 
 input=$(cat)
 command=$(echo "$input" | jq -r '.tool_input.command // ""')
@@ -25,26 +38,12 @@ fi
 
 # Block direct gh pr review commands
 if echo "$command" | grep -qE '\bgh\s+pr\s+review\b'; then
-    jq -n '{
-        hookSpecificOutput: {
-            hookEventName: "PreToolUse",
-            permissionDecision: "deny",
-            permissionDecisionReason: "Direct gh pr review is blocked during code review. Use create-draft-review.sh instead, which ensures reviews stay in PENDING state and handles duplicate detection."
-        }
-    }'
-    exit 0
+    deny "Direct gh pr review is blocked during code review. Use create-draft-review.sh instead, which ensures reviews stay in PENDING state and handles duplicate detection."
 fi
 
 # Block direct gh api calls to review endpoints
 if echo "$command" | grep -qE '\bgh\s+api\b.*\brepos/[^/]+/[^/]+/pulls/[0-9]+/reviews\b'; then
-    jq -n '{
-        hookSpecificOutput: {
-            hookEventName: "PreToolUse",
-            permissionDecision: "deny",
-            permissionDecisionReason: "Direct GitHub API calls to review endpoints are blocked during code review. Use create-draft-review.sh instead."
-        }
-    }'
-    exit 0
+    deny "Direct GitHub API calls to review endpoints are blocked during code review. Use create-draft-review.sh instead."
 fi
 
 # Block direct calls to the single-review-comment endpoints, whatever the
@@ -56,14 +55,7 @@ fi
 # literal number. It does not match pulls/<n>/comments or the reply endpoint
 # pulls/<n>/comments/<id>/replies, neither of which contains "pulls/comments/".
 if echo "$command" | grep -qE '\bgh\s+api\b.*\brepos/[^/]+/[^/]+/pulls/comments/'; then
-    jq -n '{
-        hookSpecificOutput: {
-            hookEventName: "PreToolUse",
-            permissionDecision: "deny",
-            permissionDecisionReason: "Direct GitHub API calls to review comment endpoints are blocked during code review. Use amend-pending-review.sh to list, reword, or drop comments in your pending review."
-        }
-    }'
-    exit 0
+    deny "Direct GitHub API calls to review comment endpoints are blocked during code review. Use amend-pending-review.sh to list, reword, or drop comments in your pending review."
 fi
 
 # Rewording a pending comment only works over GraphQL, so the REST pattern above
@@ -71,14 +63,7 @@ fi
 # resolveReviewThread is deliberately absent: resolve-review-threads.sh is the
 # sanctioned path for that and agents are not the ones calling it directly.
 if echo "$command" | grep -qE '\bgh\s+api\b.*\bgraphql\b.*(updatePullRequestReviewComment|addPullRequestReviewThread|deletePullRequestReviewComment)'; then
-    jq -n '{
-        hookSpecificOutput: {
-            hookEventName: "PreToolUse",
-            permissionDecision: "deny",
-            permissionDecisionReason: "Direct GraphQL mutations on review comments are blocked during code review. Use amend-pending-review.sh to reword or drop comments in your pending review."
-        }
-    }'
-    exit 0
+    deny "Direct GraphQL mutations on review comments are blocked during code review. Use amend-pending-review.sh to reword or drop comments in your pending review."
 fi
 
 # Allow everything else

--- a/skills/review-code/scripts/review-safety-hook.sh
+++ b/skills/review-code/scripts/review-safety-hook.sh
@@ -29,7 +29,13 @@ deny() {
 }
 
 input=$(cat)
-command=$(echo "$input" | jq -r '.tool_input.command // ""')
+# Newlines are flattened to spaces before any matching below. Every check greps
+# the command, and grep tests one line at a time, so a mutation split across
+# lines would put "gh api" and the endpoint on different lines and match none of
+# the patterns. Both spellings that get written by hand are multi-line: a
+# GraphQL query in a quoted heredoc-style string, and a REST call continued with
+# a trailing backslash.
+command=$(echo "$input" | jq -r '.tool_input.command // ""' | tr '\n' ' ')
 
 # Allow empty commands (shouldn't happen, but be safe)
 if [[ -z "$command" ]]; then
@@ -60,10 +66,14 @@ fi
 
 # Rewording a pending comment only works over GraphQL, so the REST pattern above
 # would miss it entirely and the hole would simply move to the new transport.
+# submitPullRequestReview and addPullRequestReview publish every pending comment
+# at once and cannot be undone; the REST pattern above already denies the same
+# action on /pulls/<n>/reviews, so leaving them out here enforced "never submit
+# on the user's behalf" on one transport only.
 # resolveReviewThread is deliberately absent: resolve-review-threads.sh is the
 # sanctioned path for that and agents are not the ones calling it directly.
-if echo "$command" | grep -qE '\bgh\s+api\b.*\bgraphql\b.*(updatePullRequestReviewComment|addPullRequestReviewThread|deletePullRequestReviewComment)'; then
-    deny "Direct GraphQL mutations on review comments are blocked during code review. Use amend-pending-review.sh to reword or drop comments in your pending review."
+if echo "$command" | grep -qE '\bgh\s+api\b.*\bgraphql\b.*(updatePullRequestReviewComment|addPullRequestReviewThread|deletePullRequestReviewComment|submitPullRequestReview|addPullRequestReview)'; then
+    deny "Direct GraphQL mutations on reviews and review comments are blocked during code review. Use amend-pending-review.sh to reword or drop comments in your pending review. Never submit a review; that is the user's call."
 fi
 
 # Allow everything else

--- a/skills/review-code/scripts/review-safety-hook.sh
+++ b/skills/review-code/scripts/review-safety-hook.sh
@@ -47,5 +47,39 @@ if echo "$command" | grep -qE '\bgh\s+api\b.*\brepos/[^/]+/[^/]+/pulls/[0-9]+/re
     exit 0
 fi
 
+# Block direct calls to the single-review-comment endpoints, whatever the
+# method. Matching the verb is not worth attempting: -X DELETE, --method DELETE,
+# flag order and a shell variable in place of the verb all defeat it. Blocking
+# reads too costs nothing, because GET on a pending comment 404s anyway and
+# amend-pending-review.sh is the sanctioned way to list them. The pattern has no
+# trailing id class on purpose, so pulls/comments/$id is caught as well as a
+# literal number. It does not match pulls/<n>/comments or the reply endpoint
+# pulls/<n>/comments/<id>/replies, neither of which contains "pulls/comments/".
+if echo "$command" | grep -qE '\bgh\s+api\b.*\brepos/[^/]+/[^/]+/pulls/comments/'; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: "Direct GitHub API calls to review comment endpoints are blocked during code review. Use amend-pending-review.sh to list, reword, or drop comments in your pending review."
+        }
+    }'
+    exit 0
+fi
+
+# Rewording a pending comment only works over GraphQL, so the REST pattern above
+# would miss it entirely and the hole would simply move to the new transport.
+# resolveReviewThread is deliberately absent: resolve-review-threads.sh is the
+# sanctioned path for that and agents are not the ones calling it directly.
+if echo "$command" | grep -qE '\bgh\s+api\b.*\bgraphql\b.*(updatePullRequestReviewComment|addPullRequestReviewThread|deletePullRequestReviewComment)'; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: "Direct GraphQL mutations on review comments are blocked during code review. Use amend-pending-review.sh to reword or drop comments in your pending review."
+        }
+    }'
+    exit 0
+fi
+
 # Allow everything else
 exit 0

--- a/tests/unit/test-amend-pending-review.bats
+++ b/tests/unit/test-amend-pending-review.bats
@@ -69,6 +69,7 @@ create_mock_gh() {
 #!/usr/bin/env bash
 args="$*"
 body777="${LIVE_BODY_777:-Validate the token first.}"
+[[ -n "${GH_CALL_LOG:-}" ]] && echo "$args" >> "$GH_CALL_LOG"
 
 if [[ "$args" == *"repo view"* ]]; then echo "org/test"; exit 0; fi
 if [[ "$args" == *"api user"* ]]; then echo "testuser"; exit 0; fi
@@ -116,6 +117,11 @@ annotate() {
       {id:777, node_id:"PRRC_aaa", path:"src/auth.ts", line:42, body:"Validate the token first."},
       {id:888, node_id:"PRRC_bbb", path:"src/db.py", line:12, body:"N+1 query here."}
     ]' | python3 "$BLOCKS" annotate --review-file "$REVIEW" --review-id 99 > /dev/null
+}
+
+# Same shape as tests/unit/test-lint-review-narrative.bats:24.
+checksum() {
+    md5 -q "$1" 2> /dev/null || md5sum "$1" | cut -d' ' -f1
 }
 
 amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
@@ -238,10 +244,10 @@ amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
 
 @test "amend: pull --dry-run leaves the notes alone" {
     annotate
-    before=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    before=$(checksum "$REVIEW")
     LIVE_BODY_777="Edited in the UI." run amend --pull --dry-run
     [ "$status" -eq 0 ]
-    after=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    after=$(checksum "$REVIEW")
     [ "$before" = "$after" ]
 }
 
@@ -355,4 +361,46 @@ amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
     amend --pull > /dev/null 2>&1 || true
     amend --drop --comment-id 888 --reason "x" > /dev/null 2>&1 || true
     ! grep -q "UNEXPECTED-URL" "$MUTATIONS"
+}
+
+# =============================================================================
+# Invariants the /simplify pass established
+# =============================================================================
+
+# `[[ cond ]] && cmd` as a function's last statement returns 1 when cond is
+# false, which under set -euo pipefail kills the run silently after the
+# mutation has already landed. Every mode must exit 0 without --json.
+@test "amend: every mode exits zero without --json" {
+    annotate
+    amend > /dev/null
+    amend --pull > /dev/null
+    amend --push > /dev/null
+    jq -n '[{id: 777, body: "Reworded."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    amend --push > /dev/null
+    amend --drop --comment-id 888 --reason "x" > /dev/null
+}
+
+@test "amend: a push makes no redundant pending-review lookups" {
+    annotate
+    jq -n '[{id: 777, body: "Reworded."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    : > "$TEST_DIR/calls.log"
+    GH_CALL_LOG="$TEST_DIR/calls.log" amend --push > /dev/null
+    # The reviews list is read once. Re-reading it to recover an id this run
+    # already holds is what the refresh path used to do.
+    [ "$(grep -c 'reviews --paginate' "$TEST_DIR/calls.log")" -eq 1 ]
+}
+
+# emit_json returns without reading stdin when --json is off. Anything piped
+# into it takes SIGPIPE, and set -euo pipefail turns that into a silent death
+# mid-run. It is a race on the pipe buffer, so only a large payload makes it
+# deterministic; a small one hides the bug.
+@test "amend: a large payload does not kill a non-JSON run" {
+    annotate
+    big=$(head -c 200000 /dev/zero | tr '\0' 'x')
+    LIVE_BODY_777="$big" run amend --pull --dry-run
+    [ "$status" -eq 0 ]
+    LIVE_BODY_777="$big" run amend --json
+    [ "$status" -eq 0 ]
 }

--- a/tests/unit/test-amend-pending-review.bats
+++ b/tests/unit/test-amend-pending-review.bats
@@ -68,7 +68,16 @@ create_mock_gh() {
     cat > "$MOCK_DIR/gh" << 'EOF'
 #!/usr/bin/env bash
 args="$*"
+# A reword that landed is the body GitHub holds from then on, the same way a
+# deleted comment stays deleted below. Without this the mock keeps reporting the
+# pre-reword body, every later push reads as still-pending, and the digest
+# re-stamp after a successful push has nothing asserting it. The body is kept in
+# its own file rather than parsed back out of the mutation log, because the log
+# holds the whole GraphQL query and that spans lines.
 body777="${LIVE_BODY_777:-Validate the token first.}"
+if [[ -z "${LIVE_BODY_777:-}" && -s "$MUTATIONS.body.PRRC_aaa" ]]; then
+    body777=$(cat "$MUTATIONS.body.PRRC_aaa")
+fi
 [[ -n "${GH_CALL_LOG:-}" ]] && echo "$args" >> "$GH_CALL_LOG"
 
 if [[ "$args" == *"repo view"* ]]; then echo "org/test"; exit 0; fi
@@ -76,6 +85,8 @@ if [[ "$args" == *"api user"* ]]; then echo "testuser"; exit 0; fi
 
 if [[ "$args" == *"graphql"* ]]; then
     echo "GRAPHQL $args" >> "$MUTATIONS"
+    node="${args##*-f id=}"; node="${node%% *}"
+    printf '%s' "${args#*-f body=}" > "$MUTATIONS.body.$node"
     echo '{"data":{"updatePullRequestReviewComment":{"pullRequestReviewComment":{"databaseId":777}}}}'
     exit 0
 fi
@@ -403,4 +414,114 @@ amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
     [ "$status" -eq 0 ]
     LIVE_BODY_777="$big" run amend --json
     [ "$status" -eq 0 ]
+}
+
+# =============================================================================
+# Drop: what reaches the notes when GitHub does not take every id
+# =============================================================================
+
+# The mock deletes 777 and refuses 888, so the run ends with one comment gone
+# and one still on the PR.
+fail_delete_888() {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/usr/bin/env bash
+args="$*"
+[[ -n "${GH_CALL_LOG:-}" ]] && echo "$args" >> "$GH_CALL_LOG"
+if [[ "$args" == *"repo view"* ]]; then echo "org/test"; exit 0; fi
+if [[ "$args" == *"api user"* ]]; then echo "testuser"; exit 0; fi
+if [[ "$args" == *"--method DELETE"* ]]; then
+    if [[ "$args" == *"pulls/comments/888"* ]]; then
+        echo '{"message":"Server Error"}'; exit 1
+    fi
+    echo "DELETE $args" >> "$MUTATIONS"; exit 0
+fi
+if [[ "$args" == *"repos/org/test/pulls/1/reviews/99/comments"* ]]; then
+    dropped=$(grep -oE 'pulls/comments/[0-9]+' "$MUTATIONS" 2> /dev/null \
+        | grep -oE '[0-9]+$' | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')
+    jq -n --argjson dropped "${dropped:-[]}" '[
+      {id:777, node_id:"PRRC_aaa", path:"src/auth.ts", line:null, position:3, body:"Validate the token first."},
+      {id:888, node_id:"PRRC_bbb", path:"src/db.py", line:null, position:7, body:"N+1 query here."}
+    ] | map(select(.id as $i | $dropped | index($i) == null))'
+    exit 0
+fi
+if [[ "$args" == *"repos/org/test/pulls/1/reviews"* ]]; then
+    echo '[{"id":99,"state":"PENDING","user":{"login":"testuser"},"body":"summary"}]'
+    exit 0
+fi
+echo '{"message":"Not Found"}'; exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+@test "amend: a failed delete leaves its finding live in the notes" {
+    annotate
+    fail_delete_888
+    run amend --drop --comment-id 777 --comment-id 888 --reason "not real"
+    # 888 is still on the PR, so its finding must still be proposable.
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$REVIEW"
+    [ "$(echo "$output" | jq '[.[] | select(.file == "src/db.py")] | length')" -eq 1 ]
+}
+
+@test "amend: a failed delete does not stamp its heading withdrawn" {
+    annotate
+    fail_delete_888
+    amend --drop --comment-id 777 --comment-id 888 --reason "not real" || true
+    # One withdrawal, for 777, not two.
+    [ "$(grep -c '^\*Withdrawn ' "$REVIEW")" -eq 1 ]
+}
+
+@test "amend: dropping an id the notes never recorded warns instead of passing silently" {
+    # No annotate call, so no finding carries an id. Every draft posted before
+    # the payload set review_file is in exactly this state.
+    run amend --drop --comment-id 777 --reason "not real"
+    [[ "$output" == *"records no finding"* ]]
+}
+
+@test "amend: an unrecorded drop leaves the finding live rather than losing it" {
+    PARSER="$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh"
+    before=$("$PARSER" "$REVIEW" | jq 'length')
+    amend --drop --comment-id 777 --reason "not real" || true
+    after=$("$PARSER" "$REVIEW" | jq 'length')
+    [ "$after" -eq "$before" ]
+}
+
+@test "amend: push refuses an id that is not in the pending review" {
+    annotate
+    run amend --push --comment-id 4242
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Not in your pending review"* ]]
+}
+
+@test "amend: push names the id when the notes hold no reword for it" {
+    annotate
+    run amend --push --comment-id 888
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"No reword recorded"* ]]
+    [[ "$output" == *"888"* ]]
+}
+
+@test "amend: a second reword pushes after the first one landed" {
+    annotate
+    jq -n '[{id:777, body:"First reword."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    run amend --push
+    [ "$status" -eq 0 ]
+
+    # GitHub now holds "First reword." The digest re-stamp after that push is
+    # what keeps this second one from reading as someone's edit in the UI.
+    jq -n '[{id:777, body:"Second reword."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    run amend --push
+    [ "$status" -eq 0 ]
+    [ "$(grep -c GRAPHQL "$MUTATIONS")" -eq 2 ]
+    grep -q 'Second reword.' "$MUTATIONS"
+}
+
+@test "amend: a pushed reword is in sync on the next status" {
+    annotate
+    jq -n '[{id:777, body:"Reworded once."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    amend --push
+    run amend --json
+    [ "$(echo "$output" | jq -r '.comments[] | select(.id == 777) | .state')" = "in_sync" ]
 }

--- a/tests/unit/test-amend-pending-review.bats
+++ b/tests/unit/test-amend-pending-review.bats
@@ -407,9 +407,15 @@ amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
 # into it takes SIGPIPE, and set -euo pipefail turns that into a silent death
 # mid-run. It is a race on the pipe buffer, so only a large payload makes it
 # deterministic; a small one hides the bug.
+#
+# The size has a floor and a ceiling. It has to clear the 64KiB pipe buffer, or
+# the write succeeds and the bug hides. It also has to stay under the 128KiB
+# Linux puts on any single argv or environment string (PAGE_SIZE * 32), because
+# the body reaches the script through the environment: at 200000 execve failed
+# with E2BIG before the script ran, which passes on macOS and fails on Linux.
 @test "amend: a large payload does not kill a non-JSON run" {
     annotate
-    big=$(head -c 200000 /dev/zero | tr '\0' 'x')
+    big=$(head -c 100000 /dev/zero | tr '\0' 'x')
     LIVE_BODY_777="$big" run amend --pull --dry-run
     [ "$status" -eq 0 ]
     LIVE_BODY_777="$big" run amend --json

--- a/tests/unit/test-amend-pending-review.bats
+++ b/tests/unit/test-amend-pending-review.bats
@@ -1,0 +1,358 @@
+#!/usr/bin/env bats
+# Tests for amend-pending-review.sh
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/amend-pending-review.sh"
+    BLOCKS="$PROJECT_ROOT/skills/review-code/scripts/review-comment-blocks.py"
+
+    TEST_DIR=$(mktemp -d)
+    REVIEW="$TEST_DIR/pr-1.md"
+    MOCK_DIR="$TEST_DIR/bin"
+    mkdir -p "$MOCK_DIR"
+    export PATH="$MOCK_DIR:$PATH"
+    MUTATIONS="$TEST_DIR/mutations.log"
+    : > "$MUTATIONS"
+    export MUTATIONS
+
+    write_review
+    create_mock_gh
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+write_review() {
+    cat > "$REVIEW" << 'EOF'
+<!-- review-metadata
+reviewed_at: 2026-08-25T00:00:00Z
+mode: pr
+pr_number: 1
+org: org
+repo: test
+-->
+
+# Pull Request Review: #1
+
+## Suggested Comments
+
+### New Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*From: Security (85% confidence)*
+
+---
+
+#### `src/db.py:12`
+
+```text
+N+1 query here.
+```
+
+*From: Performance (70% confidence)*
+
+---
+EOF
+}
+
+# Live pending review with two comments. LIVE_BODY_777 lets a test change what
+# GitHub reports without rewriting the mock.
+create_mock_gh() {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/usr/bin/env bash
+args="$*"
+body777="${LIVE_BODY_777:-Validate the token first.}"
+
+if [[ "$args" == *"repo view"* ]]; then echo "org/test"; exit 0; fi
+if [[ "$args" == *"api user"* ]]; then echo "testuser"; exit 0; fi
+
+if [[ "$args" == *"graphql"* ]]; then
+    echo "GRAPHQL $args" >> "$MUTATIONS"
+    echo '{"data":{"updatePullRequestReviewComment":{"pullRequestReviewComment":{"databaseId":777}}}}'
+    exit 0
+fi
+if [[ "$args" == *"--method DELETE"* ]]; then
+    echo "DELETE $args" >> "$MUTATIONS"; exit 0
+fi
+if [[ "$args" == *"--method POST"* ]]; then
+    echo "POST $args" >> "$MUTATIONS"; exit 0
+fi
+# Match the real endpoint shapes exactly. A permissive *"/comments"* match
+# would answer a malformed URL just as happily as a correct one, which is how
+# a missing PR number reached a live run once already.
+if [[ "$args" == *"repos/org/test/pulls/1/reviews/99/comments"* ]]; then
+    # Comments already deleted this run really are gone, so the mock reads its
+    # own mutation log rather than taking a hint from the test. A stateless
+    # mock would hide an id before the delete and break membership validation.
+    dropped=$(grep -oE 'pulls/comments/[0-9]+' "$MUTATIONS" 2> /dev/null \
+        | grep -oE '[0-9]+$' | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')
+    jq -n --arg b "$body777" --argjson dropped "${dropped:-[]}" '[
+      {id:777, node_id:"PRRC_aaa", path:"src/auth.ts", line:null, position:3, body:$b},
+      {id:888, node_id:"PRRC_bbb", path:"src/db.py", line:null, position:7, body:"N+1 query here."}
+    ] | map(select(.id as $i | $dropped | index($i) == null))'
+    exit 0
+fi
+if [[ "$args" == *"repos/org/test/pulls/1/reviews"* ]]; then
+    echo '[{"id":99,"state":"PENDING","user":{"login":"testuser"},"body":"summary"}]'
+    exit 0
+fi
+echo "UNEXPECTED-URL $args" >> "$MUTATIONS"
+echo '{"message":"Not Found"}'
+exit 1
+EOF
+    chmod +x "$MOCK_DIR/gh"
+}
+
+# Record the ids, as a --draft post would.
+annotate() {
+    jq -n '[
+      {id:777, node_id:"PRRC_aaa", path:"src/auth.ts", line:42, body:"Validate the token first."},
+      {id:888, node_id:"PRRC_bbb", path:"src/db.py", line:12, body:"N+1 query here."}
+    ]' | python3 "$BLOCKS" annotate --review-file "$REVIEW" --review-id 99 > /dev/null
+}
+
+amend() { "$SCRIPT" 1 --review-file "$REVIEW" "$@"; }
+
+# =============================================================================
+# Argument validation, before any network call
+# =============================================================================
+
+@test "amend: --drop without --comment-id is refused" {
+    run amend --drop
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"requires at least one --comment-id"* ]]
+}
+
+@test "amend: --pull and --push cannot be combined" {
+    run amend --pull --push
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"separate runs"* ]]
+}
+
+@test "amend: --comment-id must be numeric" {
+    run amend --comment-id abc
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"numeric REST API comment ID"* ]]
+}
+
+@test "amend: --help exits zero and describes the script" {
+    run amend --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"amend-pending-review.sh"* ]]
+}
+
+# =============================================================================
+# status
+# =============================================================================
+
+@test "amend: status reports both comments in sync and mutates nothing" {
+    annotate
+    run amend --json
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.counts.in_sync')" = "2" ]
+    [ ! -s "$MUTATIONS" ]
+}
+
+@test "amend: status names GitHub as the side that changed" {
+    annotate
+    LIVE_BODY_777="Edited in the UI." run amend --json
+    [ "$(echo "$output" | jq -r '.comments[] | select(.id==777) | .state')" = "changed_on_github" ]
+}
+
+@test "amend: status reports position, since a pending comment has no line" {
+    annotate
+    run amend --json
+    [ "$(echo "$output" | jq -r '.comments[] | select(.id==777) | .position')" = "3" ]
+}
+
+# =============================================================================
+# push
+# =============================================================================
+
+@test "amend: push rewords only the comment changed in the notes" {
+    annotate
+    jq -n '[{id:777, body:"Reworded in the notes."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    run amend --push
+    [ "$status" -eq 0 ]
+    [ "$(grep -c GRAPHQL "$MUTATIONS")" -eq 1 ]
+    grep -q "PRRC_aaa" "$MUTATIONS"
+    ! grep -q "PRRC_bbb" "$MUTATIONS"
+}
+
+@test "amend: push refuses when GitHub moved, and names --pull" {
+    annotate
+    jq -n '[{id:777, body:"Reworded in the notes."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    LIVE_BODY_777="Edited in the UI." run amend --push
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"--pull"* ]]
+    [ ! -s "$MUTATIONS" ]
+}
+
+@test "amend: push with nothing reworded makes no call" {
+    annotate
+    run amend --push
+    [ "$status" -eq 0 ]
+    [ ! -s "$MUTATIONS" ]
+}
+
+@test "amend: push --dry-run shows the body and calls nothing" {
+    annotate
+    jq -n '[{id:777, body:"Reworded in the notes."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    run amend --push --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Reworded in the notes."* ]]
+    [ ! -s "$MUTATIONS" ]
+}
+
+@test "amend: push --comment-id narrows to one comment" {
+    annotate
+    jq -n '[{id:777, body:"A."},{id:888, body:"B."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    run amend --push --comment-id 888
+    [ "$status" -eq 0 ]
+    [ "$(grep -c GRAPHQL "$MUTATIONS")" -eq 1 ]
+    grep -q "PRRC_bbb" "$MUTATIONS"
+}
+
+# =============================================================================
+# pull
+# =============================================================================
+
+@test "amend: pull copies the GitHub body into the notes" {
+    annotate
+    LIVE_BODY_777="Edited in the UI." run amend --pull
+    [ "$status" -eq 0 ]
+    body=$(python3 "$BLOCKS" read --review-file "$REVIEW" | jq -r '.comments[] | select(.id==777) | .body')
+    [ "$body" = "Edited in the UI." ]
+}
+
+@test "amend: pull --dry-run leaves the notes alone" {
+    annotate
+    before=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    LIVE_BODY_777="Edited in the UI." run amend --pull --dry-run
+    [ "$status" -eq 0 ]
+    after=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    [ "$before" = "$after" ]
+}
+
+@test "amend: pull then push is allowed, since the notes are current again" {
+    annotate
+    LIVE_BODY_777="Edited in the UI." amend --pull
+    jq -n '[{id:777, body:"Reworded after pulling."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    LIVE_BODY_777="Edited in the UI." run amend --push
+    [ "$status" -eq 0 ]
+    [ "$(grep -c GRAPHQL "$MUTATIONS")" -eq 1 ]
+}
+
+# =============================================================================
+# drop
+# =============================================================================
+
+@test "amend: drop deletes exactly the named comment" {
+    annotate
+    run amend --drop --comment-id 777
+    [ "$status" -eq 0 ]
+    [ "$(grep -c DELETE "$MUTATIONS")" -eq 1 ]
+    grep -q "pulls/comments/777" "$MUTATIONS"
+}
+
+@test "amend: drop refuses an id that is not in the pending review" {
+    annotate
+    run amend --drop --comment-id 4242
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Not in your pending review"* ]]
+    [ ! -s "$MUTATIONS" ]
+}
+
+@test "amend: drop echoes the body before deleting" {
+    annotate
+    run amend --drop --comment-id 777
+    [[ "$output" == *"Validate the token first."* ]]
+}
+
+@test "amend: drop --dry-run deletes nothing" {
+    annotate
+    run amend --drop --comment-id 777 --dry-run
+    [ "$status" -eq 0 ]
+    [ ! -s "$MUTATIONS" ]
+}
+
+# =============================================================================
+# It must never be able to submit
+# =============================================================================
+
+@test "amend: no mode ever posts a review or an event" {
+    annotate
+    jq -n '[{id:777, body:"Reworded."}]' \
+        | python3 "$BLOCKS" set-body --review-file "$REVIEW" > /dev/null
+    amend --json > /dev/null || true
+    amend --push || true
+    amend --drop --comment-id 888 || true
+    ! grep -q "POST" "$MUTATIONS"
+    ! grep -q "events" "$MUTATIONS"
+}
+
+# =============================================================================
+# A drop retires the finding in the notes
+# =============================================================================
+
+@test "amend: drop marks the finding withdrawn, with the reason" {
+    annotate
+    run amend --drop --comment-id 777 --reason "author showed environments are deprecated"
+    [ "$status" -eq 0 ]
+    grep -q 'withdrawn:' "$REVIEW"
+    grep -q '^\*Withdrawn .*author showed environments are deprecated\*$' "$REVIEW"
+}
+
+@test "amend: a dropped finding stops being a live finding" {
+    PARSER="$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh"
+    annotate
+    before=$("$PARSER" "$REVIEW" | jq 'length')
+    amend --drop --comment-id 777 --reason "not a real issue"
+    after=$("$PARSER" "$REVIEW" | jq 'length')
+    [ "$after" -eq $((before - 1)) ]
+}
+
+@test "amend: a dropped finding keeps its body for the record" {
+    annotate
+    amend --drop --comment-id 777 --reason "not a real issue"
+    grep -q "Validate the token first." "$REVIEW"
+}
+
+@test "amend: --dry-run drop marks nothing" {
+    annotate
+    amend --drop --comment-id 777 --reason "x" --dry-run
+    ! grep -q 'withdrawn:' "$REVIEW"
+}
+
+@test "amend: --reason is refused outside --drop" {
+    run amend --push --reason "x"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"only applies to --drop"* ]]
+}
+
+@test "amend: drop reports how many comments remain" {
+    annotate
+    run amend --drop --comment-id 777 --reason "x"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"1 comment(s) remain"* ]]
+}
+
+@test "amend: every gh call uses a real endpoint shape" {
+    annotate
+    amend --json > /dev/null
+    amend --pull > /dev/null 2>&1 || true
+    amend --drop --comment-id 888 --reason "x" > /dev/null 2>&1 || true
+    ! grep -q "UNEXPECTED-URL" "$MUTATIONS"
+}

--- a/tests/unit/test-carry-forward-findings.bats
+++ b/tests/unit/test-carry-forward-findings.bats
@@ -284,3 +284,54 @@ EOF
     ! grep -q "constant time" "$TEST_DIR/review.md"
     grep -q "Missing input validation" "$TEST_DIR/review.md"
 }
+
+# =============================================================================
+# Withdrawn findings
+# =============================================================================
+
+# A finding the author argued down must not come back on the next re-review,
+# and its text must survive so the argument stays on the record.
+@test "carry-forward-findings.sh: does not carry a withdrawn finding forward as live" {
+    # Retire the finding on a file the delta does not touch, so the only thing
+    # that can keep it out of the carried set is the withdrawal marker.
+    python3 - "$TEST_DIR/review.md" << 'PY'
+import sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+for i, line in enumerate(lines):
+    if line.startswith("#### `src/untouched.py"):
+        lines.insert(i + 1, "")
+        lines.insert(i + 2, "*Withdrawn 2026-08-25: author showed the header is validated upstream*")
+        break
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    carried_before=$("$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" \
+        --include-withdrawn "$TEST_DIR/review.md" | jq '[.[] | select(.withdrawn)] | length')
+    [ "$carried_before" -eq 1 ]
+
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+
+    # Still in the document, but no longer a finding anything will act on.
+    grep -q "Missing input validation on the forwarded header." "$TEST_DIR/review.md"
+    live=$("$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md" \
+        | jq '[.[] | select(.file == "src/untouched.py")] | length')
+    [ "$live" -eq 0 ]
+}
+
+@test "carry-forward-findings.sh: prune-safety still passes with a withdrawal marker present" {
+    python3 - "$TEST_DIR/review.md" << 'PY'
+import sys
+path = sys.argv[1]
+lines = open(path).read().splitlines()
+for i, line in enumerate(lines):
+    if line.startswith("#### `src/untouched.py"):
+        lines.insert(i + 1, "")
+        lines.insert(i + 2, "*Withdrawn 2026-08-25: not a real issue*")
+        break
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+    run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.pruned == true' > /dev/null
+}

--- a/tests/unit/test-carry-forward-findings.bats
+++ b/tests/unit/test-carry-forward-findings.bats
@@ -330,3 +330,53 @@ PY
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.pruned == true' > /dev/null
 }
+
+# =============================================================================
+# Prune safety across long finding bodies
+# =============================================================================
+
+# The check that guards the cut compares the expected survivors against a
+# re-parse of the pruned file. Both sides have to be parsed the same way: the
+# plain mode truncates a description at 500 bytes and the --with-spans mode does
+# not, so on any review with a finding body past that length the two can never
+# match and the cut is abandoned every time. Real reviews run to thousands of
+# characters per finding, so this is the normal case, not an edge one.
+@test "carry-forward-findings.sh: prunes a review whose findings exceed the truncation limit" {
+    local long_body
+    long_body=$(printf 'The token comparison leaks timing information. %.0s' {1..20})
+    [ "${#long_body}" -gt 500 ]
+
+    cat > "$TEST_DIR/long.md" << EOF
+<!-- review-metadata
+reviewed_at: 2026-08-01T10:00:00Z
+mode: pr
+pr_number: 42
+review_commit: aaaaaaa
+-->
+
+# Pull Request Review: #42
+
+## Security Review
+
+#### \`src/auth.py:45\`
+
+${long_body}
+
+---
+
+#### \`src/untouched.py:10\`
+
+${long_body}
+
+---
+EOF
+
+    run "$SCRIPT" --review-file "$TEST_DIR/long.md" --delta-diff "$TEST_DIR/delta.patch"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.pruned == true' > /dev/null
+    echo "$output" | jq -e '.dropped == 1' > /dev/null
+    echo "$output" | jq -e '.carried == 1' > /dev/null
+    # The delta touched src/auth.py, so that finding goes and the other stays.
+    ! grep -q 'src/auth.py:45' "$TEST_DIR/long.md"
+    grep -q 'src/untouched.py:10' "$TEST_DIR/long.md"
+}

--- a/tests/unit/test-carry-forward-findings.bats
+++ b/tests/unit/test-carry-forward-findings.bats
@@ -285,6 +285,21 @@ EOF
     grep -q "Missing input validation" "$TEST_DIR/review.md"
 }
 
+# The withdrawal marker's literal form is the contract parse-review-findings.sh
+# matches on, so it lives in one place here rather than in each test.
+withdraw_untouched_finding() {
+    python3 - "$TEST_DIR/review.md" "$1" << 'PY'
+import sys
+path, reason = sys.argv[1], sys.argv[2]
+lines = open(path).read().splitlines()
+for i, line in enumerate(lines):
+    if line.startswith("#### `src/untouched.py"):
+        lines[i + 1:i + 1] = ["", f"*Withdrawn 2026-08-25: {reason}*"]
+        break
+open(path, "w").write("\n".join(lines) + "\n")
+PY
+}
+
 # =============================================================================
 # Withdrawn findings
 # =============================================================================
@@ -294,17 +309,7 @@ EOF
 @test "carry-forward-findings.sh: does not carry a withdrawn finding forward as live" {
     # Retire the finding on a file the delta does not touch, so the only thing
     # that can keep it out of the carried set is the withdrawal marker.
-    python3 - "$TEST_DIR/review.md" << 'PY'
-import sys
-path = sys.argv[1]
-lines = open(path).read().splitlines()
-for i, line in enumerate(lines):
-    if line.startswith("#### `src/untouched.py"):
-        lines.insert(i + 1, "")
-        lines.insert(i + 2, "*Withdrawn 2026-08-25: author showed the header is validated upstream*")
-        break
-open(path, "w").write("\n".join(lines) + "\n")
-PY
+    withdraw_untouched_finding "author showed the header is validated upstream"
     carried_before=$("$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" \
         --include-withdrawn "$TEST_DIR/review.md" | jq '[.[] | select(.withdrawn)] | length')
     [ "$carried_before" -eq 1 ]
@@ -320,17 +325,7 @@ PY
 }
 
 @test "carry-forward-findings.sh: prune-safety still passes with a withdrawal marker present" {
-    python3 - "$TEST_DIR/review.md" << 'PY'
-import sys
-path = sys.argv[1]
-lines = open(path).read().splitlines()
-for i, line in enumerate(lines):
-    if line.startswith("#### `src/untouched.py"):
-        lines.insert(i + 1, "")
-        lines.insert(i + 2, "*Withdrawn 2026-08-25: not a real issue*")
-        break
-open(path, "w").write("\n".join(lines) + "\n")
-PY
+    withdraw_untouched_finding "not a real issue"
     run "$SCRIPT" --review-file "$TEST_DIR/review.md" --delta-diff "$TEST_DIR/delta.patch"
     [ "$status" -eq 0 ]
     echo "$output" | jq -e '.pruned == true' > /dev/null

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -845,3 +845,70 @@ EOF
     [[ "$output" == *"1 comments filtered out"* ]]
     [[ "$output" == *'"inline_count": 2'* ]]
 }
+
+# =============================================================================
+# Recording posted comment ids in the review file
+# =============================================================================
+
+# The whole amend flow rests on these ids existing. Nothing else drives
+# create-draft-review.sh with review_file, so without this the feature can go
+# inert without a single test noticing.
+@test "create-draft-review: records posted comment ids in the review file" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"/reviews/99999/comments"* ]]; then
+    echo '[{"id":777,"node_id":"PRRC_aaa","path":"src/auth.ts","line":42,"position":3,"body":"Validate the token first."}]'
+elif [[ "$*" == *"/reviews --paginate"* ]]; then
+    echo '[]'
+elif [[ "$*" == *"--method POST"* ]]; then
+    echo '{"id": 99999}'
+else
+    echo '[]'
+fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+
+    local review="$MOCK_DIR/pr-1.md"
+    cat > "$review" << 'EOF'
+<!-- review-metadata
+reviewed_at: 2026-08-25T00:00:00Z
+mode: pr
+-->
+
+## Suggested Comments
+
+### New Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*From: Security (85% confidence)*
+
+---
+EOF
+
+    local input
+    input=$(jq -n --arg rf "$review" '{owner:"org", repo:"test", pr_number:1,
+        reviewer_username:"user", summary:"T", review_file:$rf,
+        comments:[{path:"src/auth.ts", line:42, side:"RIGHT", body:"Validate the token first."}]}')
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"annotated_count": 1'* ]]
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:777 PRRC_aaa b:[0-9a-f]{8} -->$' "$review"
+    grep -q '^review_id: 99999$' "$review"
+}
+
+@test "create-draft-review: annotates nothing when no review_file is given" {
+    cat > "$MOCK_DIR/gh" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"--method POST"* ]]; then echo '{"id": 99999}'; else echo '[]'; fi
+EOF
+    chmod +x "$MOCK_DIR/gh"
+    local input='{"owner": "org", "repo": "test", "pr_number": 1, "reviewer_username": "user", "summary": "T", "comments": []}'
+    run bash -c "echo '$input' | '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"annotated_count": 0'* ]]
+}

--- a/tests/unit/test-create-draft-review.bats
+++ b/tests/unit/test-create-draft-review.bats
@@ -56,8 +56,8 @@ EOF
     [ "$status" -eq 0 ]
 }
 
-@test "create-draft-review: has get_existing_pending_review function" {
-    run bash -c "grep -q '^get_existing_pending_review()' '$SCRIPT'"
+@test "create-draft-review: has get_existing_pending_review function (via gh-review-helpers)" {
+    run bash -c "source '$SCRIPT' && declare -f get_existing_pending_review > /dev/null"
     [ "$status" -eq 0 ]
 }
 

--- a/tests/unit/test-get-review-diff.bats
+++ b/tests/unit/test-get-review-diff.bats
@@ -355,8 +355,8 @@ teardown_test_repo() {
 
     [ "$status" -eq 0 ]
     [[ "$output" == *"DIFF_TYPE: branch + uncommitted (main...feature + local)"* ]]
-    [[ "$output" == *"file2.txt"* ]]  # Branch changes
-    [[ "$output" == *"file3.txt"* ]]  # Uncommitted changes
+    [[ "$output" == *"file2.txt"* ]] # Branch changes
+    [[ "$output" == *"file3.txt"* ]] # Uncommitted changes
     [[ "$output" == *"Uncommitted Changes"* ]]
 
     teardown_test_repo

--- a/tests/unit/test-get-review-diff.bats
+++ b/tests/unit/test-get-review-diff.bats
@@ -565,3 +565,91 @@ teardown_test_repo() {
 
     teardown_test_repo
 }
+
+# =============================================================================
+# Refs that carry a slash
+# =============================================================================
+
+# A remote-tracking ref on the left of a range is the ordinary way to name the
+# base, and it used to be read as a pathspec and stripped, leaving the range
+# positional unset.
+@test "get-review-diff.sh: range mode accepts a remote-tracking ref" {
+    setup_test_repo
+
+    echo "one" > file.txt
+    git add file.txt
+    git commit -q -m "First"
+    git update-ref refs/remotes/origin/main HEAD
+    echo "two" > file.txt
+    git commit -q -am "Second"
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" range "origin/main..HEAD"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DIFF_TYPE: range (origin/main..HEAD)"* ]]
+    [[ "$output" == *"two"* ]]
+    teardown_test_repo
+}
+
+# Same shape, one argument earlier: a base branch whose name carries a dot after
+# the slash, such as a release line.
+@test "get-review-diff.sh: branch mode accepts a base ref with a dot in it" {
+    setup_test_repo
+
+    echo "one" > file.txt
+    git add file.txt
+    git commit -q -m "First"
+    git update-ref refs/remotes/origin/release-1.0 HEAD
+    git checkout -q -b feature
+    echo "two" > file.txt
+    git commit -q -am "Second"
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" branch feature "origin/release-1.0"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"origin/release-1.0...feature"* ]]
+    teardown_test_repo
+}
+
+@test "get-review-diff.sh: a pattern after a slashed range still filters" {
+    setup_test_repo
+
+    echo "one" > keep.py
+    echo "one" > skip.txt
+    git add keep.py skip.txt
+    git commit -q -m "First"
+    git update-ref refs/remotes/origin/main HEAD
+    echo "two" > keep.py
+    echo "two" > skip.txt
+    git commit -q -am "Second"
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" range "origin/main..HEAD" "*.py"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"filtered by: *.py"* ]]
+    [[ "$output" == *"keep.py"* ]]
+    [[ "$output" != *"skip.txt"* ]]
+    teardown_test_repo
+}
+
+# The old shape test only recognised a pattern with a glob or a dot after a
+# slash, so a plain filename was silently dropped and the diff came back
+# unfiltered rather than wrong, which is harder to notice.
+@test "get-review-diff.sh: a bare filename is treated as a pattern" {
+    setup_test_repo
+
+    echo "one" > keep.py
+    echo "one" > skip.txt
+    git add keep.py skip.txt
+    git commit -q -m "First"
+    echo "two" > keep.py
+    echo "two" > skip.txt
+    git commit -q -am "Second"
+
+    run "$PROJECT_ROOT/skills/review-code/scripts/get-review-diff.sh" range "HEAD~1..HEAD" "keep.py"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"filtered by: keep.py"* ]]
+    [[ "$output" != *"skip.txt"* ]]
+    teardown_test_repo
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -683,3 +683,100 @@ EOF
     echo "$output" | jq -e 'length == 1' > /dev/null
     echo "$output" | jq -e '.[0].end_line == 12' > /dev/null
 }
+
+# =============================================================================
+# Withdrawn findings
+# =============================================================================
+
+@test "parse-review-findings.sh: skips a finding withdrawn on its heading" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42` <!-- pc:777 PRRC_aaa withdrawn:2026-08-25 -->
+
+The token check is wrong.
+
+*Withdrawn 2026-08-25: author showed it was already handled*
+
+---
+
+#### `src/db.py:12` <!-- pc:888 PRRC_bbb -->
+
+N+1 query here.
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -eq 1 ]
+    [ "$(echo "$output" | jq -r '.[0].file')" = "src/db.py" ]
+}
+
+@test "parse-review-findings.sh: --include-withdrawn returns it with a flag" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42` <!-- pc:777 PRRC_aaa withdrawn:2026-08-25 -->
+
+The token check is wrong.
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --include-withdrawn "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -eq 1 ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn')" = "true" ]
+}
+
+@test "parse-review-findings.sh: skips a finding marked withdrawn by hand" {
+    # A review never posted as a draft has no heading annotation to stamp.
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42`
+
+The token check is wrong.
+
+*Withdrawn 2026-08-25: author showed it was already handled*
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -eq 0 ]
+}
+
+@test "parse-review-findings.sh: a quoted Withdrawn line does not retire a finding" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42`
+
+```text
+The docs show the marker as:
+
+*Withdrawn 2026-01-01: example*
+
+which is what to write.
+```
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -eq 1 ]
+}
+
+@test "parse-review-findings.sh: a live finding reports withdrawn false" {
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42`
+
+The token check is wrong.
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$(echo "$output" | jq -r '.[0].withdrawn')" = "false" ]
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -780,3 +780,20 @@ EOF
     run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
     [ "$(echo "$output" | jq -r '.[0].withdrawn')" = "false" ]
 }
+
+@test "parse-review-findings.sh: prose on a heading does not retire a finding" {
+    # Only the token inside the pc annotation retires a finding. An unanchored
+    # match would let this heading silently drop a live finding.
+    cat > "$TEST_DIR/review.md" << 'EOF'
+## Security Review
+
+#### `src/auth.ts:42` (withdrawn: still under discussion)
+
+The token check is wrong.
+
+---
+EOF
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$TEST_DIR/review.md"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq 'length')" -eq 1 ]
+}

--- a/tests/unit/test-parse-review-findings.bats
+++ b/tests/unit/test-parse-review-findings.bats
@@ -797,3 +797,100 @@ EOF
     [ "$status" -eq 0 ]
     [ "$(echo "$output" | jq 'length')" -eq 1 ]
 }
+
+# =============================================================================
+# The withdrawal reason travels as a field, not as description text
+# =============================================================================
+
+@test "parse-review-findings.sh: a withdrawn finding carries its reason as a field" {
+    review="$TEST_DIR/review.md"
+    cat > "$review" << 'DOC'
+# Review
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*Withdrawn 2026-08-25: author showed the guard is unreachable*
+
+---
+DOC
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --include-withdrawn "$review"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn_reason')" = "author showed the guard is unreachable" ]
+}
+
+# The marker describes the finding rather than being part of it. Left in the
+# description it reads as the tail of the finding text, and the learning pass
+# quotes descriptions back at the user.
+@test "parse-review-findings.sh: the withdrawal marker stays out of the description" {
+    review="$TEST_DIR/review.md"
+    cat > "$review" << 'DOC'
+# Review
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*Withdrawn 2026-08-25: author showed the guard is unreachable*
+
+---
+DOC
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --include-withdrawn "$review"
+    [ "$status" -eq 0 ]
+    [[ "$(echo "$output" | jq -r '.[0].description')" != *"Withdrawn"* ]]
+    [[ "$(echo "$output" | jq -r '.[0].description')" == *"Validate the token first."* ]]
+}
+
+@test "parse-review-findings.sh: a live finding reports an empty withdrawal reason" {
+    review="$TEST_DIR/review.md"
+    cat > "$review" << 'DOC'
+# Review
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+---
+DOC
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" "$review"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn')" = "false" ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn_reason')" = "" ]
+}
+
+# A marker with no reason after the date must not store the date as the reason.
+@test "parse-review-findings.sh: a reasonless withdrawal leaves the field empty" {
+    review="$TEST_DIR/review.md"
+    cat > "$review" << 'DOC'
+# Review
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*Withdrawn 2026-08-25*
+
+---
+DOC
+    run "$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh" --include-withdrawn "$review"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn')" = "true" ]
+    [ "$(echo "$output" | jq -r '.[0].withdrawn_reason')" = "" ]
+}

--- a/tests/unit/test-review-comment-blocks.bats
+++ b/tests/unit/test-review-comment-blocks.bats
@@ -71,6 +71,11 @@ posted_json() {
     ]'
 }
 
+# Same shape as tests/unit/test-lint-review-narrative.bats:24.
+checksum() {
+    md5 -q "$1" 2> /dev/null || md5sum "$1" | cut -d' ' -f1
+}
+
 annotate() {
     posted_json | python3 "$SCRIPT" annotate --review-file "$REVIEW" "$@"
 }
@@ -161,12 +166,12 @@ annotate() {
 # =============================================================================
 
 @test "annotate: invalid input reports an error and leaves the file untouched" {
-    checksum_before=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    checksum_before=$(checksum "$REVIEW")
     run bash -c "echo 'not json' | python3 '$SCRIPT' annotate --review-file '$REVIEW'"
     [ "$status" -eq 0 ]
     [[ "$output" == *'"error":'* ]]
     [[ "$output" != *'"error": null'* ]]
-    checksum_after=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    checksum_after=$(checksum "$REVIEW")
     [ "$checksum_before" = "$checksum_after" ]
 }
 
@@ -462,4 +467,45 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *'"updated": 0'* ]]
     grep -q "Validate the token first." "$REVIEW"
+}
+
+# A review never posted as a draft has no heading token, only the prose line.
+# Python has to honour it or annotate's filter lets the retired block be
+# claimed by a new finding at the same path and line.
+@test "withdraw: a hand-marked withdrawal is honoured without a heading token" {
+    cat > "$REVIEW" << 'EOF'
+#### `src/auth.ts:42`
+
+```text
+Retired by hand, never posted as a draft.
+```
+
+*Withdrawn 2026-08-25: author was right*
+
+---
+
+#### `src/auth.ts:42`
+
+```text
+A live finding at the same line.
+```
+
+---
+EOF
+    jq -n '[{id: 999, node_id: "PRRC_new", path: "src/auth.ts", line: 42,
+             body: "Matches neither body, forcing the path and line fallback."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW"
+
+    # The hand-marked block keeps no annotation; the live one gets it.
+    run grep -c 'pc:999' "$REVIEW"
+    [ "$output" -eq 1 ]
+    line_no=$(grep -n 'pc:999' "$REVIEW" | cut -d: -f1)
+    [ "$line_no" -gt 5 ]
+}
+
+@test "status: identical bodies read as in_sync even with a stale digest" {
+    annotate
+    # Corrupt the recorded digest, as a dropped refresh would.
+    sed -i.bak -E 's/ b:[0-9a-f]{8} / b:00000000 /' "$REVIEW"
+    [ "$(status_of '.')" = "in_sync" ]
 }

--- a/tests/unit/test-review-comment-blocks.bats
+++ b/tests/unit/test-review-comment-blocks.bats
@@ -1,0 +1,465 @@
+#!/usr/bin/env bats
+# Tests for review-comment-blocks.py
+
+setup() {
+    PROJECT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+    export PROJECT_ROOT
+    SCRIPT="$PROJECT_ROOT/skills/review-code/scripts/review-comment-blocks.py"
+    PARSER="$PROJECT_ROOT/skills/review-code/scripts/parse-review-findings.sh"
+
+    TEST_DIR=$(mktemp -d)
+    REVIEW="$TEST_DIR/pr-1.md"
+    write_review
+}
+
+teardown() {
+    rm -rf "$TEST_DIR"
+}
+
+# A review with two findings. The second body quotes a heading-shaped line, so
+# any annotator that does not walk fences will annotate the quote by mistake.
+write_review() {
+    cat > "$REVIEW" << 'EOF'
+<!-- review-metadata
+reviewed_at: 2026-08-25T00:00:00Z
+mode: pr
+pr_number: 1
+org: org
+repo: test
+scope:
+  exploration_depth: thorough
+-->
+
+# Pull Request Review: #1
+
+## Suggested Comments
+
+### New Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*From: Security (85% confidence)*
+
+---
+
+#### `src/db.py:12`
+
+```text
+N+1 query here. The docs show it as:
+
+#### `docs/perf.md:9`
+
+which is the pattern to follow.
+```
+
+*From: Performance (70% confidence)*
+
+---
+EOF
+}
+
+posted_json() {
+    jq -n '[
+        {id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 42,
+         body: "Validate the token first."},
+        {id: 888, node_id: "PRRC_bbb", path: "src/db.py", line: 12,
+         body: "N+1 query here. The docs show it as:\n\n#### `docs/perf.md:9`\n\nwhich is the pattern to follow."}
+    ]'
+}
+
+annotate() {
+    posted_json | python3 "$SCRIPT" annotate --review-file "$REVIEW" "$@"
+}
+
+# =============================================================================
+# Annotation
+# =============================================================================
+
+@test "annotate: records id and node_id on each finding heading" {
+    run annotate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"annotated": 2'* ]]
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:777 PRRC_aaa b:[0-9a-f]{8} -->$' "$REVIEW"
+    grep -Eq '^#### `src/db\.py:12` <!-- pc:888 PRRC_bbb b:[0-9a-f]{8} -->$' "$REVIEW"
+}
+
+@test "annotate: leaves a heading-shaped line inside a fenced body alone" {
+    annotate
+    grep -q '^#### `docs/perf.md:9`$' "$REVIEW"
+    [ "$(grep -c 'pc:' "$REVIEW")" -eq 2 ]
+}
+
+@test "annotate: replaces an existing annotation instead of stacking one" {
+    annotate
+    posted_json | jq '[.[] | .id = (.id + 1) | .node_id = (.node_id + "_v2")]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW"
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:778 PRRC_aaa_v2 b:[0-9a-f]{8} -->$' "$REVIEW"
+    run grep -c 'pc:.*pc:' "$REVIEW"
+    [ "$output" -eq 0 ]
+}
+
+@test "annotate: matches by body when the comment moved to a different line" {
+    # Drift remapping posts the comment at line 44 while the heading still says 42.
+    jq -n '[{id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 44,
+             body: "Validate the token first."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW"
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:777 PRRC_aaa b:[0-9a-f]{8} -->$' "$REVIEW"
+}
+
+@test "annotate: reports a comment it could not place" {
+    run bash -c "jq -n '[{id: 999, node_id: \"PRRC_x\", path: \"src/nope.ts\", line: 1, body: \"orphan\"}]' \
+        | python3 '$SCRIPT' annotate --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"annotated": 0'* ]]
+    [[ "$output" == *'999'* ]]
+}
+
+# =============================================================================
+# Metadata header
+# =============================================================================
+
+@test "annotate: records review_id and posted_at above the nested blocks" {
+    annotate --review-id 5023086234 --posted-at 2026-08-25T12:00:00Z
+    grep -q '^review_id: 5023086234$' "$REVIEW"
+    grep -q '^posted_at: 2026-08-25T12:00:00Z$' "$REVIEW"
+    # Both scalars must sit above scope:, not inside it.
+    review_line=$(grep -n '^review_id:' "$REVIEW" | cut -d: -f1)
+    scope_line=$(grep -n '^scope:' "$REVIEW" | cut -d: -f1)
+    [ "$review_line" -lt "$scope_line" ]
+}
+
+@test "annotate: rewrites review_id rather than adding a second one" {
+    annotate --review-id 111
+    annotate --review-id 222
+    [ "$(grep -c '^review_id:' "$REVIEW")" -eq 1 ]
+    grep -q '^review_id: 222$' "$REVIEW"
+}
+
+@test "annotate: only touches the first metadata block" {
+    printf '\n<!-- review-metadata\nreviewed_at: 2026-01-01T00:00:00Z\n-->\n' >> "$REVIEW"
+    annotate --review-id 111
+    [ "$(grep -c '^review_id:' "$REVIEW")" -eq 1 ]
+}
+
+# =============================================================================
+# The parser must not see any of this
+# =============================================================================
+
+@test "annotate: annotations are invisible to parse-review-findings.sh" {
+    before=$("$PARSER" "$REVIEW" | jq -S -c '[.[] | {agent, file, line, description}]')
+    annotate --review-id 111
+    after=$("$PARSER" "$REVIEW" | jq -S -c '[.[] | {agent, file, line, description}]')
+    [ "$before" = "$after" ]
+}
+
+# =============================================================================
+# Fail open
+# =============================================================================
+
+@test "annotate: invalid input reports an error and leaves the file untouched" {
+    checksum_before=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    run bash -c "echo 'not json' | python3 '$SCRIPT' annotate --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"error":'* ]]
+    [[ "$output" != *'"error": null'* ]]
+    checksum_after=$(md5 -q "$REVIEW" 2> /dev/null || md5sum "$REVIEW" | cut -d' ' -f1)
+    [ "$checksum_before" = "$checksum_after" ]
+}
+
+@test "annotate: a missing review file reports an error rather than failing" {
+    run bash -c "jq -n '[]' | python3 '$SCRIPT' annotate --review-file '$TEST_DIR/gone.md'"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'"error": null'* ]]
+}
+
+# =============================================================================
+# read
+# =============================================================================
+
+@test "read: returns each recorded block with its ids, path, line and body" {
+    annotate --review-id 5023086234
+    run bash -c "python3 '$SCRIPT' read --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.comments | length')" -eq 2 ]
+    [ "$(echo "$output" | jq -r '.comments[0].id')" = "777" ]
+    [ "$(echo "$output" | jq -r '.comments[0].node_id')" = "PRRC_aaa" ]
+    [ "$(echo "$output" | jq -r '.comments[0].path')" = "src/auth.ts" ]
+    [ "$(echo "$output" | jq -r '.comments[0].line')" = "42" ]
+    [ "$(echo "$output" | jq -r '.comments[0].body')" = "Validate the token first." ]
+    [ "$(echo "$output" | jq -r '.review_id')" = "5023086234" ]
+}
+
+@test "read: skips findings that were never posted" {
+    # Nothing annotated yet, so nothing is claimed to exist on GitHub.
+    run bash -c "python3 '$SCRIPT' read --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '.comments | length')" -eq 0 ]
+}
+
+@test "read: keeps a body that contains its own fenced block intact" {
+    annotate
+    run bash -c "python3 '$SCRIPT' read --review-file '$REVIEW'"
+    body=$(echo "$output" | jq -r '.comments[1].body')
+    [[ "$body" == *'#### `docs/perf.md:9`'* ]]
+    [[ "$body" == *"which is the pattern to follow."* ]]
+}
+
+@test "read: fails loud when the review file is missing" {
+    run bash -c "python3 '$SCRIPT' read --review-file '$TEST_DIR/gone.md'"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *'"error": null'* ]]
+}
+
+# =============================================================================
+# set-body
+# =============================================================================
+
+@test "set-body: replaces the named block's body and leaves the others alone" {
+    annotate
+    run bash -c "jq -n '[{id: 777, body: \"Reworded: check for null first.\"}]' \
+        | python3 '$SCRIPT' set-body --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"updated": 1'* ]]
+
+    read_out=$(python3 "$SCRIPT" read --review-file "$REVIEW")
+    [ "$(echo "$read_out" | jq -r '.comments[0].body')" = "Reworded: check for null first." ]
+    [[ "$(echo "$read_out" | jq -r '.comments[1].body')" == *"N+1 query here."* ]]
+}
+
+@test "set-body: keeps the heading and its annotation" {
+    annotate
+    jq -n '[{id: 777, body: "Reworded."}]' | python3 "$SCRIPT" set-body --review-file "$REVIEW"
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:777 PRRC_aaa b:[0-9a-f]{8} -->$' "$REVIEW"
+}
+
+@test "set-body: handles a multi-line replacement body" {
+    annotate
+    jq -n '[{id: 777, body: "First line.\n\nSecond line."}]' \
+        | python3 "$SCRIPT" set-body --review-file "$REVIEW"
+    body=$(python3 "$SCRIPT" read --review-file "$REVIEW" | jq -r '.comments[0].body')
+    [ "$body" = "First line.
+
+Second line." ]
+}
+
+@test "set-body: replacing one body leaves the review parseable and unchanged elsewhere" {
+    annotate
+    before=$("$PARSER" "$REVIEW" | jq -S -c '[.[] | {agent, file, line}]')
+    jq -n '[{id: 777, body: "Reworded."}]' | python3 "$SCRIPT" set-body --review-file "$REVIEW"
+    after=$("$PARSER" "$REVIEW" | jq -S -c '[.[] | {agent, file, line}]')
+    [ "$before" = "$after" ]
+}
+
+@test "set-body: reports ids it could not find" {
+    annotate
+    run bash -c "jq -n '[{id: 4242, body: \"nope\"}]' \
+        | python3 '$SCRIPT' set-body --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"updated": 0'* ]]
+    [[ "$output" == *'4242'* ]]
+}
+
+@test "set-body: fails loud on malformed input" {
+    run bash -c "echo 'not json' | python3 '$SCRIPT' set-body --review-file '$REVIEW'"
+    [ "$status" -eq 1 ]
+    [[ "$output" != *'"error": null'* ]]
+}
+
+# =============================================================================
+# status
+# =============================================================================
+
+# Live pending review matching the fixture as posted.
+live_json() {
+    jq -n '[
+        {id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", position: 3,
+         body: "Validate the token first."},
+        {id: 888, node_id: "PRRC_bbb", path: "src/db.py", position: 7,
+         body: "N+1 query here. The docs show it as:\n\n#### `docs/perf.md:9`\n\nwhich is the pattern to follow."}
+    ]'
+}
+
+status_of() {
+    live_json | jq "$1" | python3 "$SCRIPT" status --review-file "$REVIEW" \
+        | jq -r '.comments[] | select(.id == 777) | .state'
+}
+
+@test "status: reports in_sync when neither side moved" {
+    annotate
+    [ "$(status_of '.')" = "in_sync" ]
+}
+
+@test "status: names GitHub as the side that changed" {
+    annotate
+    [ "$(status_of '[.[] | if .id == 777 then .body = "Edited in the GitHub UI." else . end]')" = "changed_on_github" ]
+}
+
+@test "status: names the notes as the side that changed" {
+    annotate
+    jq -n '[{id: 777, body: "Reworded in the notes."}]' \
+        | python3 "$SCRIPT" set-body --review-file "$REVIEW"
+    [ "$(status_of '.')" = "changed_in_notes" ]
+}
+
+@test "status: reports diverged when both sides moved" {
+    annotate
+    jq -n '[{id: 777, body: "Reworded in the notes."}]' \
+        | python3 "$SCRIPT" set-body --review-file "$REVIEW"
+    [ "$(status_of '[.[] | if .id == 777 then .body = "Edited in the GitHub UI." else . end]')" = "diverged" ]
+}
+
+@test "status: reports a comment that is gone from GitHub" {
+    annotate
+    [ "$(status_of '[.[] | select(.id != 777)]')" = "missing_on_github" ]
+}
+
+@test "status: reports a live comment the notes never recorded" {
+    annotate
+    run bash -c "live_json_out=\$(jq -n '[{id: 999, path: \"src/other.ts\", body: \"hand written\"}]'); \
+        echo \"\$live_json_out\" | python3 '$SCRIPT' status --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"unrecorded"'* ]]
+    [[ "$output" == *'999'* ]]
+}
+
+@test "status: falls back to unknown_baseline without a recorded digest" {
+    # An annotation written before digests existed, or hand-edited.
+    annotate
+    sed -i.bak -E 's/ b:[0-9a-f]{8} -->/ -->/' "$REVIEW"
+    [ "$(status_of '[.[] | if .id == 777 then .body = "Edited somewhere." else . end]')" = "unknown_baseline" ]
+}
+
+@test "status: counts each state and reports the review id" {
+    annotate --review-id 5023086234
+    run bash -c "$(declare -f live_json); live_json | python3 '$SCRIPT' status --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq -r '.counts.in_sync')" = "2" ]
+    [ "$(echo "$output" | jq -r '.review_id')" = "5023086234" ]
+}
+
+@test "status: fails loud on a missing review file" {
+    run bash -c "jq -n '[]' | python3 '$SCRIPT' status --review-file '$TEST_DIR/gone.md'"
+    [ "$status" -eq 1 ]
+}
+
+# =============================================================================
+# withdraw
+# =============================================================================
+
+withdraw() {
+    jq -n --arg r "${1:-}" '[{id: 777, reason: $r}]' \
+        | python3 "$SCRIPT" withdraw --review-file "$REVIEW" --date 2026-08-25
+}
+
+@test "withdraw: stamps the heading and keeps the ids for the record" {
+    annotate
+    run withdraw "author showed it was already handled"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"withdrawn": 1'* ]]
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:777 PRRC_aaa b:[0-9a-f]{8} withdrawn:2026-08-25 -->$' "$REVIEW"
+}
+
+@test "withdraw: records the reason where a reader will see it" {
+    annotate
+    withdraw "environments are deprecated"
+    grep -q '^\*Withdrawn 2026-08-25: environments are deprecated\*$' "$REVIEW"
+}
+
+@test "withdraw: keeps the finding body, so the argument stays on the record" {
+    annotate
+    withdraw "not a real issue"
+    grep -q "Validate the token first." "$REVIEW"
+}
+
+@test "withdraw: leaves the other finding alone" {
+    annotate
+    withdraw "reason"
+    [ "$(grep -c 'withdrawn:' "$REVIEW")" -eq 1 ]
+    grep -q '^#### `src/db.py:12` <!-- pc:888' "$REVIEW"
+}
+
+@test "withdraw: works without a reason" {
+    annotate
+    withdraw ""
+    grep -q '^\*Withdrawn 2026-08-25\*$' "$REVIEW"
+}
+
+@test "withdraw: a withdrawn comment drops out of read and status" {
+    annotate
+    withdraw "reason"
+    [ "$(python3 "$SCRIPT" read --review-file "$REVIEW" | jq '.comments | length')" -eq 1 ]
+    run bash -c "jq -n '[]' | python3 '$SCRIPT' status --review-file '$REVIEW'"
+    [ "$(echo "$output" | jq '.comments | length')" -eq 1 ]
+}
+
+@test "withdraw: withdrawing twice does not stack markers" {
+    annotate
+    withdraw "first"
+    run withdraw "second"
+    [[ "$output" == *'"withdrawn": 0'* ]]
+    [ "$(grep -c 'withdrawn:' "$REVIEW")" -eq 1 ]
+    [ "$(grep -c '^\*Withdrawn' "$REVIEW")" -eq 1 ]
+}
+
+@test "withdraw: reports an id it could not find" {
+    annotate
+    run bash -c "jq -n '[{id: 4242, reason: \"x\"}]' \
+        | python3 '$SCRIPT' withdraw --review-file '$REVIEW' --date 2026-08-25"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'4242'* ]]
+}
+
+# A withdrawn finding must stay withdrawn through every later write. The
+# path-and-line fallback in annotate is the way it could come back: a new
+# finding at the same location would claim the retired block's annotation.
+@test "withdraw: annotate leaves a withdrawn block alone and takes the live one" {
+    cat > "$REVIEW" << 'EOF'
+#### `src/auth.ts:42` <!-- pc:777 PRRC_aaa b:deadbeef withdrawn:2026-08-25 -->
+
+```text
+Old retired finding.
+```
+
+*Withdrawn 2026-08-25: author was right*
+
+---
+
+#### `src/auth.ts:42`
+
+```text
+A brand new finding at the same line.
+```
+
+---
+EOF
+    # A body matching neither block, which forces the path-and-line fallback.
+    jq -n '[{id: 999, node_id: "PRRC_new", path: "src/auth.ts", line: 42,
+             body: "Reworded on GitHub, matching nothing in the notes."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW"
+
+    grep -q '^#### `src/auth.ts:42` <!-- pc:777 PRRC_aaa b:deadbeef withdrawn:2026-08-25 -->$' "$REVIEW"
+    grep -Eq '^#### `src/auth\.ts:42` <!-- pc:999 PRRC_new b:[0-9a-f]{8} -->$' "$REVIEW"
+}
+
+@test "withdraw: annotate never revives a withdrawn finding" {
+    annotate
+    withdraw "author was right"
+    # Re-annotating, as a later --draft repost or refresh would.
+    posted_json | python3 "$SCRIPT" annotate --review-file "$REVIEW" > /dev/null
+    grep -q 'withdrawn:2026-08-25' "$REVIEW"
+    [ "$("$PARSER" "$REVIEW" | jq '[.[] | select(.file == "src/auth.ts")] | length')" -eq 0 ]
+}
+
+@test "withdraw: set-body refuses to rewrite a retired finding" {
+    annotate
+    withdraw "author was right"
+    run bash -c "jq -n '[{id: 777, body: \"should not land\"}]' \
+        | python3 '$SCRIPT' set-body --review-file '$REVIEW'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"updated": 0'* ]]
+    grep -q "Validate the token first." "$REVIEW"
+}

--- a/tests/unit/test-review-comment-blocks.bats
+++ b/tests/unit/test-review-comment-blocks.bats
@@ -509,3 +509,57 @@ EOF
     sed -i.bak -E 's/ b:[0-9a-f]{8} / b:00000000 /' "$REVIEW"
     [ "$(status_of '.')" = "in_sync" ]
 }
+
+# A finding whose body was never fenced. annotate still reaches it, because
+# match_comments falls back to path and line when no body matches, so withdraw
+# has to put the reason somewhere even with no fence to sit under.
+@test "withdraw: records the reason on a finding that has no fenced body" {
+    cat > "$REVIEW" << 'DOC'
+<!-- review-metadata
+mode: pr
+pr_number: 1
+-->
+
+# Pull Request Review: #1
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+Validate the token first.
+
+---
+DOC
+    jq -n '[{id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 42, body: "Validate the token first."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW" --review-id 99 > /dev/null
+
+    run withdraw "author showed the guard is unreachable"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"withdrawn": 1'* ]]
+    grep -q '^\*Withdrawn 2026-08-25: author showed the guard is unreachable\*$' "$REVIEW"
+}
+
+@test "withdraw: a body-less finding still reads as withdrawn afterwards" {
+    cat > "$REVIEW" << 'DOC'
+<!-- review-metadata
+mode: pr
+pr_number: 1
+-->
+
+# Pull Request Review: #1
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+Validate the token first.
+
+---
+DOC
+    jq -n '[{id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 42, body: "Validate the token first."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW" --review-id 99 > /dev/null
+    withdraw "not a real issue"
+
+    [ "$("$PARSER" --include-withdrawn "$REVIEW" | jq -r '.[0].withdrawn')" = "true" ]
+    [ "$("$PARSER" "$REVIEW" | jq 'length')" -eq 0 ]
+}

--- a/tests/unit/test-review-comment-blocks.bats
+++ b/tests/unit/test-review-comment-blocks.bats
@@ -563,3 +563,119 @@ DOC
     [ "$("$PARSER" --include-withdrawn "$REVIEW" | jq -r '.[0].withdrawn')" = "true" ]
     [ "$("$PARSER" "$REVIEW" | jq 'length')" -eq 0 ]
 }
+
+# =============================================================================
+# A finding written twice: agent section and Suggested Comments
+# =============================================================================
+
+# What a composed review actually looks like. Only the copy under Suggested
+# Comments was posted, but the agent-section copy comes first in the document.
+write_duplicated_review() {
+    cat > "$REVIEW" << 'DOC'
+<!-- review-metadata
+mode: pr
+pr_number: 1
+-->
+
+# Pull Request Review: #1
+
+## Security Review
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+## Suggested Comments
+
+### New Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+*From: Security (85% confidence)*
+
+---
+DOC
+}
+
+dup_annotate() {
+    jq -n '[{id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 42, body: "Validate the token first."}]' \
+        | python3 "$SCRIPT" annotate --review-file "$REVIEW" --review-id 99
+}
+
+@test "annotate: records the id on every copy of a repeated finding" {
+    write_duplicated_review
+    run dup_annotate
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"annotated": 2'* ]]
+    [ "$(grep -c 'pc:777 PRRC_aaa' "$REVIEW")" -eq 2 ]
+}
+
+# The point of the whole exercise: a dropped comment must stop being a live
+# finding, or the next --append re-review offers it again.
+@test "withdraw: retires every copy, so nothing is left to re-propose" {
+    write_duplicated_review
+    dup_annotate > /dev/null
+    [ "$("$PARSER" "$REVIEW" | jq 'length')" -eq 2 ]
+    withdraw "author disagreed"
+    [ "$("$PARSER" "$REVIEW" | jq 'length')" -eq 0 ]
+}
+
+# Both copies carry the id. Reporting each separately would pair the live
+# comment with one and call the other missing_on_github, which is enough on its
+# own to make --push refuse.
+@test "status: a repeated finding is one comment, not two" {
+    write_duplicated_review
+    dup_annotate > /dev/null
+    run bash -c 'jq -n "[{id: 777, node_id: \"PRRC_aaa\", path: \"src/auth.ts\", position: 3, body: \"Validate the token first.\"}]" | python3 "'"$SCRIPT"'" status --review-file "'"$REVIEW"'"'
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '[.comments[] | select(.id == 777)] | length')" -eq 1 ]
+    [ "$(echo "$output" | jq -r '.comments[] | select(.id == 777) | .state')" = "in_sync" ]
+    [ "$(echo "$output" | jq '.unrecorded | length')" -eq 0 ]
+}
+
+@test "set-body: rewrites every copy, so the two do not drift apart" {
+    write_duplicated_review
+    dup_annotate > /dev/null
+    jq -n '[{id: 777, body: "Reworded once."}]' | python3 "$SCRIPT" set-body --review-file "$REVIEW" > /dev/null
+    [ "$(grep -c 'Reworded once.' "$REVIEW")" -eq 2 ]
+    ! grep -q "Validate the token first." "$REVIEW"
+}
+
+# Two different findings that happen to share a line are not copies of one
+# another, so the second must not be claimed by the first comment.
+@test "annotate: two findings on the same line keep their own ids" {
+    cat > "$REVIEW" << 'DOC'
+<!-- review-metadata
+mode: pr
+pr_number: 1
+-->
+
+## Suggested Comments
+
+#### `src/auth.ts:42`
+
+```text
+Validate the token first.
+```
+
+#### `src/auth.ts:42`
+
+```text
+This allocation is avoidable.
+```
+
+---
+DOC
+    jq -n '[
+      {id: 777, node_id: "PRRC_aaa", path: "src/auth.ts", line: 42, body: "Validate the token first."},
+      {id: 888, node_id: "PRRC_bbb", path: "src/auth.ts", line: 42, body: "This allocation is avoidable."}
+    ]' | python3 "$SCRIPT" annotate --review-file "$REVIEW" --review-id 99 > /dev/null
+    [ "$(grep -c 'pc:777' "$REVIEW")" -eq 1 ]
+    [ "$(grep -c 'pc:888' "$REVIEW")" -eq 1 ]
+}

--- a/tests/unit/test-review-safety-hook.bats
+++ b/tests/unit/test-review-safety-hook.bats
@@ -134,3 +134,84 @@ make_input() {
     make_input "gh pr review 123" | bash "$SCRIPT"
     [ $? -eq 0 ]
 }
+
+# =============================================================================
+# Single review comment endpoints (REST)
+# =============================================================================
+
+@test "blocks gh api DELETE on a single review comment" {
+    result=$(make_input "gh api --method DELETE repos/org/repo/pulls/comments/123" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks the -X DELETE spelling too" {
+    result=$(make_input "gh api -X DELETE repos/org/repo/pulls/comments/123" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks gh api PATCH on a single review comment" {
+    result=$(make_input "gh api --method PATCH repos/org/repo/pulls/comments/123 -f body=x" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks a review comment endpoint built from a shell variable" {
+    result=$(make_input 'gh api --method DELETE repos/$OWNER/$REPO/pulls/comments/$id' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "block reason for a review comment endpoint names amend-pending-review.sh" {
+    result=$(make_input "gh api --method DELETE repos/org/repo/pulls/comments/123" | bash "$SCRIPT")
+    reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    [[ "$reason" == *"amend-pending-review.sh"* ]]
+}
+
+@test "still allows the PR comments collection" {
+    result=$(make_input "gh api repos/org/repo/pulls/123/comments" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "still allows replying to a review comment" {
+    result=$(make_input "gh api --method POST repos/org/repo/pulls/123/comments/456/replies -f body=ok" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "allows amend-pending-review.sh" {
+    result=$(make_input "~/.agents/skills/review-code/scripts/amend-pending-review.sh 123 --drop --comment-id 456" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+# =============================================================================
+# Review comment mutations (GraphQL)
+# =============================================================================
+
+@test "blocks a raw GraphQL comment reword" {
+    result=$(make_input "gh api graphql -f query='mutation { updatePullRequestReviewComment(input: {}) { x } }'" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks a raw GraphQL addPullRequestReviewThread" {
+    result=$(make_input "gh api graphql -f query='mutation { addPullRequestReviewThread(input: {}) { x } }'" | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "block reason for a GraphQL mutation names amend-pending-review.sh" {
+    result=$(make_input "gh api graphql -f query='mutation { updatePullRequestReviewComment(input: {}) { x } }'" | bash "$SCRIPT")
+    reason=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    [[ "$reason" == *"amend-pending-review.sh"* ]]
+}
+
+@test "still allows the GraphQL thread resolution the append flow uses" {
+    result=$(make_input "gh api graphql -f query='mutation { resolveReviewThread(input: {}) { x } }'" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+@test "still allows an ordinary GraphQL query" {
+    result=$(make_input "gh api graphql -f query='query { viewer { login } }'" | bash "$SCRIPT")
+    [ -z "$result" ]
+}

--- a/tests/unit/test-review-safety-hook.bats
+++ b/tests/unit/test-review-safety-hook.bats
@@ -13,6 +13,13 @@ make_input() {
     printf '{"tool_input":{"command":"%s"}}' "$cmd"
 }
 
+# Same, for a command carrying newlines or double quotes. make_input pastes its
+# argument straight between two quote characters, so either one produces JSON
+# that jq rejects before the hook ever sees the command.
+make_input_raw() {
+    jq -nc --arg cmd "$1" '{tool_input: {command: $cmd}}'
+}
+
 # =============================================================================
 # Blocked commands
 # =============================================================================
@@ -213,5 +220,58 @@ make_input() {
 
 @test "still allows an ordinary GraphQL query" {
     result=$(make_input "gh api graphql -f query='query { viewer { login } }'" | bash "$SCRIPT")
+    [ -z "$result" ]
+}
+
+# Every spelling above is a single line. A mutation written across lines used to
+# reach GitHub, because grep tests one line at a time and "gh api" then landed on
+# a different line from the mutation name. The multi-line form is the one written
+# by hand: reword_comment in amend-pending-review.sh spells its query this way.
+@test "blocks a GraphQL comment reword written across lines" {
+    result=$(make_input_raw 'gh api graphql -f query='"'"'
+mutation {
+  updatePullRequestReviewComment(input: {pullRequestReviewCommentId: "x", body: "y"}) { clientMutationId }
+}'"'"'' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks a GraphQL comment delete written across lines" {
+    result=$(make_input_raw 'gh api graphql -f query='"'"'
+mutation {
+  deletePullRequestReviewComment(input: {id: "PRRC_x"}) { clientMutationId }
+}'"'"'' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks a review comment DELETE continued with a backslash" {
+    result=$(make_input_raw 'gh api --method DELETE \
+  repos/org/repo/pulls/comments/123' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+# Submitting publishes every pending comment at once and cannot be undone. The
+# REST spelling is already denied by the /pulls/<n>/reviews pattern, so leaving
+# these two out of the mutation list enforced "never submit a review on the
+# user's behalf" on one transport and not the other.
+@test "blocks submitting a review over GraphQL" {
+    result=$(make_input_raw 'gh api graphql -f query='"'"'mutation { submitPullRequestReview(input: {pullRequestReviewId: "x", event: APPROVE}) { clientMutationId } }'"'"'' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "blocks creating and submitting a review over GraphQL" {
+    result=$(make_input_raw 'gh api graphql -f query='"'"'mutation { addPullRequestReview(input: {pullRequestId: "x", event: APPROVE}) { clientMutationId } }'"'"'' | bash "$SCRIPT")
+    decision=$(echo "$result" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "still allows a multi-line GraphQL query that mutates nothing" {
+    result=$(make_input_raw 'gh api graphql -f query='"'"'
+query {
+  viewer { login }
+}'"'"'' | bash "$SCRIPT")
     [ -z "$result" ]
 }


### PR DESCRIPTION
Correcting one comment in a pending review used to cost a full re-review. `create-draft-review.sh` replaces a pending review wholesale and `--draft` only runs at the end of a review, so changing a sentence re-ran every agent, renumbered every comment, and discarded anything edited by hand on GitHub.

- `amend-pending-review.sh` reports each recorded comment as in sync, changed on GitHub, changed in the notes, diverged, or missing. `--pull` copies GitHub's wording into the notes, `--push` sends reworded bodies back, and `--drop` removes one comment. Posting a draft now records each comment's id and a digest of its body on the finding heading, inside an HTML comment the parser cannot see. The digest is what lets `--push` refuse a comment someone edited in the UI instead of overwriting it.
- Dropping a comment marks its finding withdrawn rather than deleting it. The block stays with the reason and stops counting as live, so carry-forward does not re-propose it and a later `--draft` does not repost it. `parse-review-findings.sh --include-withdrawn` returns them for the learning pass, where a finding the author rebutted is the clearest false positive there is.
- The safety hook blocks the review-comment endpoints on both REST and GraphQL. It matches the whole command rather than one line at a time, so a mutation written across lines no longer slips past, and it covers the two GraphQL mutations that submit a review, which REST already denied.
- `carry-forward-findings.sh` parses both sides of its prune-safety check the same way. It compared a `--with-spans` parse against a plain one, and only the plain mode truncates a description at 500 bytes, so any review with a finding body past that length failed the check every time and kept its stale findings beside the new ones.
- `get-review-diff.sh` takes its optional file pattern by argument count instead of by shape. A ref carrying a dot after a slash looked exactly like a path glob, so `origin/main..HEAD` was stripped as a pattern and the mode read a positional that was no longer there.

**Test plan:** `bin/test` passes at 1908 tests. Coverage was added for each behavior above: the withdrawal contract and the cases that must not trigger it, the fence walk over a finding body that quotes a heading, the digest three-way comparison including a stale digest, the multi-line and backslash-continued hook spellings, a `--drop` where one delete fails and one succeeds, and slashed refs in range and branch mode. Each fix has a test that fails without it.