### PR TITLE
Symlink AGENTS.md to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
Codex reads `AGENTS.md` and Claude reads `CLAUDE.md`. `AGENTS.md` is now a symlink to `CLAUDE.md`, so both harnesses load the same guidance from one file.

An untracked `AGENTS.md` had been sitting in the working tree: a copy of `CLAUDE.md` with "Claude" string-replaced by "Codex". The replacement also hit words that were not the harness name, so `~/.claude/skills/review-code/` became `~/.Codex/skills/review-code/`, a path that does not exist, and the two sentences describing both harnesses read "Codex + Codex". Nothing in the repo writes `AGENTS.md`, so `bin/setup` will not clobber the symlink.

## Test plan

- [ ] `git ls-files -s AGENTS.md` reports mode `120000`
- [ ] `cat AGENTS.md` prints the contents of `CLAUDE.md`
- [ ] `bin/test` passes