### PR TITLE
Prioritize narrow review scopes

### DIFF
--- a/skills/review-code/scripts/classify-review-scope.sh
+++ b/skills/review-code/scripts/classify-review-scope.sh
@@ -67,8 +67,19 @@ if [[ "${infra_config_count}" -gt 0 ]] && [[ "${infra_config_count}" -eq "${file
     agents=("infra-config")
     exploration_depth="minimal"
     reasoning="Infra-config-only change (${diff_tokens} diff tokens, ${infra_config_count} infra config files): infra-config agent"
-# For medium+ diffs, or when file metadata is absent (e.g., deletions-only PRs where
-# pre-review-context.sh only parses added files), always run all agents
+elif [[ "${config_count}" -gt 0 ]] && [[ "${config_count}" -eq "${file_count}" ]] && { [[ "${deleted_count}" -eq 0 ]] || [[ "${diff_tokens}" -lt 2000 ]]; }; then
+    # Config-only (note: .md/docs files are classified as source, so this branch only matches
+    # changes where all modified files are config files)
+    agents=("correctness" "compatibility")
+    reasoning="Config-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
+elif [[ "${test_count}" -gt 0 ]] && [[ "${test_count}" -eq "${file_count}" ]] && { [[ "${deleted_count}" -eq 0 ]] || [[ "${diff_tokens}" -lt 2000 ]]; }; then
+    # Test-only changes
+    agents=("testing" "correctness" "maintainability")
+    reasoning="Test-only change (${diff_tokens} diff tokens, ${test_count} test files): testing + correctness + maintainability"
+elif [[ "${migration_count}" -gt 0 ]] && [[ "${migration_count}" -eq "${file_count}" ]] && { [[ "${deleted_count}" -eq 0 ]] || [[ "${diff_tokens}" -lt 2000 ]]; }; then
+    # Migration-only
+    agents=("correctness" "compatibility" "security")
+    reasoning="Migration-only change (${diff_tokens} diff tokens, ${migration_count} migration files): correctness + compatibility + security"
 elif [[ "${diff_tokens}" -ge 2000 ]]; then
     agents=("${all_agents[@]}")
     reasoning="Medium or large diff (${diff_tokens} diff tokens, ${file_count} files): running all agents"
@@ -76,20 +87,6 @@ elif [[ "${file_count}" -eq 0 ]] && [[ "${diff_tokens}" -gt 0 ]]; then
     # No file metadata (likely a deletions-only PR) - run all core agents to avoid under-reviewing
     agents=("${all_agents[@]}")
     reasoning="No file metadata (${diff_tokens} diff tokens, possible deletions-only change): running all agents"
-# For tiny/small diffs, select agents based on file composition
-elif [[ "${config_count}" -gt 0 ]] && [[ "${config_count}" -eq "${file_count}" ]]; then
-    # Config-only (note: .md/docs files are classified as source, so this branch only matches
-    # changes where all modified files are config files)
-    agents=("correctness" "compatibility")
-    reasoning="Config-only change (${diff_tokens} diff tokens, ${config_count} config, ${file_count} total files): correctness + compatibility"
-elif [[ "${test_count}" -gt 0 ]] && [[ "${test_count}" -eq "${file_count}" ]]; then
-    # Test-only changes
-    agents=("testing" "correctness" "maintainability")
-    reasoning="Test-only change (${diff_tokens} diff tokens, ${test_count} test files): testing + correctness + maintainability"
-elif [[ "${migration_count}" -gt 0 ]] && [[ "${migration_count}" -eq "${file_count}" ]]; then
-    # Migration-only
-    agents=("correctness" "compatibility" "security")
-    reasoning="Migration-only change (${diff_tokens} diff tokens, ${migration_count} migration files): correctness + compatibility + security"
 elif [[ "${diff_tokens}" -lt 500 ]]; then
     # Tiny source change: core agents only
     agents=("correctness" "security" "testing" "architecture")

--- a/tests/unit/test-classify-review-scope.bats
+++ b/tests/unit/test-classify-review-scope.bats
@@ -17,13 +17,15 @@ create_session() {
     local diff_tokens="${1:-100}"
     local files_json="${2:-[]}"
     local has_frontend="${3:-false}"
+    local deleted_count="${4:-0}"
 
     cat > "$TMPDIR/session.json" <<ENDJSON
 {
     "diff_tokens": $diff_tokens,
     "file_metadata": {
         "modified_files": $files_json,
-        "file_count": $(echo "$files_json" | jq 'length')
+        "file_count": $(echo "$files_json" | jq 'length'),
+        "deleted_file_count": $deleted_count
     },
     "languages": {
         "has_frontend": $has_frontend
@@ -61,6 +63,36 @@ ENDJSON
     echo "$result" | jq -e '.agents | contains(["infra-config"]) | not'
 }
 
+@test "config-only selects correctness + compatibility above 2000 diff tokens" {
+    session=$(create_session 3000 '[
+        {"path":"package.json","type":"config","is_infra_config":false,"is_test":false},
+        {"path":"tsconfig.json","type":"config","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents == ["correctness", "compatibility"]'
+}
+
+@test "test-only selects testing + correctness + maintainability above 2000 diff tokens" {
+    session=$(create_session 3000 '[
+        {"path":"tests/test_api.py","type":"test","is_infra_config":false,"is_test":true},
+        {"path":"tests/test_web.py","type":"test","is_infra_config":false,"is_test":true}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents == ["testing", "correctness", "maintainability"]'
+}
+
+@test "migration-only selects correctness + compatibility + security above 2000 diff tokens" {
+    session=$(create_session 3000 '[
+        {"path":"migrations/001_add_index.py","type":"migration","is_infra_config":false,"is_test":false},
+        {"path":"migrations/002_backfill.py","type":"migration","is_infra_config":false,"is_test":false}
+    ]')
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents == ["correctness", "compatibility", "security"]'
+}
+
 @test "mixed infra + source includes infra-config agent" {
     session=$(create_session 800 '[
         {"path":"argocd/service/values/values.yaml","type":"config","is_infra_config":true,"is_test":false},
@@ -83,6 +115,17 @@ ENDJSON
     echo "$result" | jq -e '.agents | contains(["infra-config"])'
     echo "$result" | jq -e '.agents | contains(["correctness", "security"])'
     echo "$result" | jq -e '.exploration_depth == "thorough"'
+}
+
+@test "large infra-config change with a deleted source file uses all core agents plus infra-config" {
+    session=$(create_session 3000 '[
+        {"path":"argocd/service/values/values.prod-us.yaml","type":"config","is_infra_config":true,"is_test":false},
+        {"path":"argocd/service/values/values.prod-eu.yaml","type":"config","is_infra_config":true,"is_test":false}
+    ]' false 1)
+
+    result=$("$SCRIPT" "$session")
+    echo "$result" | jq -e '.agents == ["security", "performance", "correctness", "maintainability", "testing", "compatibility", "architecture", "infra-config"]'
+    echo "$result" | jq -e '.reasoning | contains("running all agents")'
 }
 
 @test "infra-config-only forces minimal exploration even for larger diffs (standard range)" {


### PR DESCRIPTION
- Config-only, test-only, and migration-only changes select their narrow reviewer sets before the 2,000-token fallback.
- Large diffs with deleted files still use the full reviewer set, while infra-config and frontend behavior remain unchanged.

## Test plan

- `bin/fmt`
- `bats tests/unit/test-classify-review-scope.bats` (15 tests)
- `bin/test` (1,911 unit tests and 12 integration tests)